### PR TITLE
add GEMINI_API_BASE_URL support for configurable Gemini API endpoint

### DIFF
--- a/src/esperanto/providers/embedding/google.py
+++ b/src/esperanto/providers/embedding/google.py
@@ -41,7 +41,8 @@ class GoogleEmbeddingModel(EmbeddingModel):
             raise ValueError("Google API key not found")
 
         # Set base URL
-        self.base_url = "https://generativelanguage.googleapis.com/v1beta"
+        base_host = os.getenv("GEMINI_API_BASE_URL") or "https://generativelanguage.googleapis.com"
+        self.base_url = f"{base_host}/v1beta"
 
         # Initialize HTTP clients
         self.client = httpx.Client(timeout=30.0)

--- a/src/esperanto/providers/llm/google.py
+++ b/src/esperanto/providers/llm/google.py
@@ -50,7 +50,8 @@ class GoogleLanguageModel(LanguageModel):
             )
 
         # Set base URL
-        self.base_url = "https://generativelanguage.googleapis.com/v1beta"
+        base_host = os.getenv("GEMINI_API_BASE_URL") or "https://generativelanguage.googleapis.com"
+        self.base_url = f"{base_host}/v1beta"
 
         # Initialize HTTP clients
         self.client = httpx.Client(timeout=30.0)

--- a/src/esperanto/providers/tts/google.py
+++ b/src/esperanto/providers/tts/google.py
@@ -47,7 +47,8 @@ class GoogleTextToSpeechModel(TextToSpeechModel):
             )
 
         # Set base URL
-        self.base_url = "https://generativelanguage.googleapis.com/v1beta"
+        base_host = os.getenv("GEMINI_API_BASE_URL") or "https://generativelanguage.googleapis.com"
+        self.base_url = f"{base_host}/v1beta"
 
         # Initialize HTTP clients
         self.client = httpx.Client(timeout=30.0)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

No

#### What does this implement/fix? Explain your changes.

This PR introduces support for configuring the base URL of the Gemini API via the `GEMINI_API_BASE_URL` environment variable.

By default, the code uses `https://generativelanguage.googleapis.com` as the API endpoint. However, in some networks this endpoint may not be accessible. Allowing users to override the base URL enables broader usage and flexibility for different deployment environments.

#### Any other comments?

- Maintains backward compatibility: if `GEMINI_API_BASE_URL` is not set, the default endpoint is still used.

<!--
Thanks for contributing!
-->