### PR TITLE
fix: unused import 'openai' (may cause error in test)

### DIFF
--- a/src/esperanto/providers/llm/deepseek.py
+++ b/src/esperanto/providers/llm/deepseek.py
@@ -4,8 +4,6 @@ import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from openai import AsyncOpenAI, OpenAI
-
 from esperanto.common_types import Model
 from esperanto.providers.llm.openai import OpenAILanguageModel
 from esperanto.utils.logging import logger

--- a/src/esperanto/providers/llm/xai.py
+++ b/src/esperanto/providers/llm/xai.py
@@ -4,8 +4,6 @@ import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional  # Added Optional
 
-from openai import AsyncOpenAI, OpenAI
-
 from esperanto.common_types import Model
 from esperanto.providers.llm.openai import OpenAILanguageModel
 from esperanto.utils.logging import logger


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #51 : package import for `openai` in `providers.llm.deepseek` and `providers.llm.xai` not used and will cause an `ModuleNotFoundError` for `openai` which is not in `dev` group or any other dependencies for this project.


#### Changes
Delete import for `openai` in `providers.llm.deepseek` and `providers.llm.xai` in `src/`.

<!--
Thanks for contributing!
-->