### PR TITLE
fix: assertion for 'model' attribute in test_google_langchain_conversion

### DIFF
--- a/tests/integration/test_langchain_integration.py
+++ b/tests/integration/test_langchain_integration.py
@@ -114,7 +114,9 @@ def test_xai_langchain_conversion(xai_model):
 def test_google_langchain_conversion(google_model):
     langchain_model = google_model.to_langchain()
     assert isinstance(langchain_model, ChatGoogleGenerativeAI)
-    assert langchain_model.model == "gemini-1.5-pro"
+
+    # Specific design for Google SDK: 'model' attribute is the full model name with "models/" prefix
+    assert langchain_model.model == "models/gemini-1.5-pro"
     assert langchain_model.temperature == 0.7
     assert langchain_model.max_output_tokens == 100
     assert langchain_model.top_p == 0.9


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #58 


#### What does this implement/fix? Explain your changes.
Fix the wrong assertion for `model` attribute from langchain model`ChatGoogleGenerativeAI`. In google langchain integration, **the model name will have prefix of "models/"**. Thus add this prefix to assertion:
```python
assert langchain_model.model == "models/gemini-1.5-pro"
```
for the conversion from `GoogleLanguageModel` with `model_name` of "gemini-1.5-pro".


<!--
Thanks for contributing!
-->