### PR TITLE
feat: add HTTP proxy configuration support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,110 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.14.0] - 2026-01-16
+
+### Added
+
+- **Proxy Configuration** - Added HTTP proxy support for all provider connections
+  - Configuration via environment variable: `ESPERANTO_PROXY`
+  - Configuration via config dict: `config={"proxy": "http://proxy:8080"}`
+  - Supports HTTP, HTTPS, and authenticated proxies
+  - Priority order: config dict > environment variable > none
+  - Example:
+    ```python
+    # Via environment variable
+    export ESPERANTO_PROXY="http://proxy.example.com:8080"
+
+    # Via config dict
+    model = AIFactory.create_language(
+        "openai", "gpt-4",
+        config={"proxy": "http://proxy.example.com:8080"}
+    )
+    ```
+
+### Changed
+
+- Updated dependencies to latest versions
+- General codebase cleanup and maintenance
+
+### Fixed
+
+- **HTTP Client Resource Management** - Fixed async client not being properly closed when deleting model instances (#60)
+  - Added `HttpConnectionMixin` consolidating timeout, SSL, and client lifecycle management
+  - Providers now support context managers (`with model:` and `async with model:`)
+  - Added explicit `close()` and `aclose()` methods for resource cleanup
+  - Destructor now properly cleans up sync clients
+
+## [2.13.0] - 2026-01-04
+
+### Changed
+
+- **Dependency Updates** - Updated all dependencies to latest major versions (#55)
+
+### Fixed
+
+- Fixed CONTRIBUTING.md to use correct `uv sync` command for PEP735 dependency groups (#54)
+- Fixed unused `openai` import that could cause errors in tests (#53)
+
+## [2.12.1] - 2025-12-15
+
+### Fixed
+
+- **Ollama LangChain JSON Format** - Fixed `OllamaLanguageModel.to_langchain()` to correctly pass `format="json"` when `structured={"type": "json"}` is configured (#49)
+
+## [2.12.0] - 2025-12-14
+
+### Fixed
+
+- **SSL Configuration for LangChain** - Extended SSL verification configuration to all LangChain integrations (#47)
+  - Anthropic, Groq, Mistral, and Ollama providers now pass SSL settings to LangChain
+
+## [2.11.0] - 2025-12-14
+
+### Added
+
+- **SSL Verification Configuration** - Added ability to disable SSL verification or use custom CA bundles (#45)
+  - See [2.9.1] for full feature documentation (feature was backported)
+
+## [2.10.0] - 2025-11-27
+
+### Added
+
+- **OpenRouter Embedding Provider** - Access 60+ embedding providers through OpenRouter's unified API (#44)
+  - Inherits from `OpenAIEmbeddingModel` following existing patterns
+  - Supports `OPENROUTER_API_KEY` and `OPENROUTER_BASE_URL` environment variables
+  - Model discovery filters embedding models from OpenRouter's `/models` endpoint
+  - Example:
+    ```python
+    model = AIFactory.create_embedding(
+        "openrouter",
+        "openai/text-embedding-3-small"
+    )
+    embeddings = model.embed(["Hello", "World"])
+    ```
+
+- **Google Speech-to-Text** - Added STT support using Gemini API's audio transcription (#43)
+  - Supports `gemini-2.5-flash` and `gemini-2.0-flash` models
+  - Base64 audio encoding with automatic MIME type detection
+  - Supports MP3, WAV, AIFF, AAC, OGG, FLAC formats
+  - Language hints and custom prompts for improved accuracy
+  - Example:
+    ```python
+    model = AIFactory.create_speech_to_text("google", "gemini-2.5-flash")
+    response = model.transcribe("audio.mp3", language="en")
+    ```
+
+### Fixed
+
+- **Anthropic Temperature/Top-p Conflict** - Fixed issue where passing both `temperature` and `top_p` to Anthropic LangChain integration caused errors (#42, #39)
+  - Now prioritizes `temperature` over `top_p` when both are set
+
+## [2.9.2] - 2025-11-11
+
+### Fixed
+
+- **Ollama Embeddings API** - Updated to use newer `/api/embed` endpoint for compatibility with recent Ollama versions (#37)
+
 ## [2.9.1] - 2025-11-27
 
 ### Added
@@ -294,8 +398,6 @@ grep -r "EmbeddingModel.*\.models" --include="*.py" .
 - Improved code coverage to 68%
 
 ---
-
-## [Unreleased]
 
 ### Planned for 3.0.0
 - Remove deprecated `.models` property from all provider base classes

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -416,6 +416,83 @@ All provider types that use HTTP clients:
 - Text-to-Speech (TTS)
 - Rerankers
 
+## Proxy Configuration
+
+Configure HTTP proxy for all provider connections. Useful for corporate networks, VPNs, or routing traffic through specific endpoints.
+
+### Setting a Proxy
+
+**Via environment variable (recommended):**
+
+```bash
+ESPERANTO_PROXY=http://proxy.example.com:8080
+```
+
+**Via config parameter:**
+
+```python
+model = AIFactory.create_language(
+    "openai", "gpt-4",
+    config={"proxy": "http://proxy.example.com:8080"}
+)
+```
+
+### Proxy URL Formats
+
+```bash
+# HTTP proxy
+ESPERANTO_PROXY=http://proxy.example.com:8080
+
+# HTTPS proxy
+ESPERANTO_PROXY=https://secure-proxy.example.com:443
+
+# Proxy with authentication
+ESPERANTO_PROXY=http://username:password@proxy.example.com:8080
+```
+
+### Priority Order
+
+1. **Config parameter** `proxy` (highest priority)
+2. **Environment variable** `ESPERANTO_PROXY`
+3. **Default** `None` (no proxy)
+
+### Common Use Cases
+
+**Corporate network with proxy:**
+
+```bash
+# In .env
+ESPERANTO_PROXY=http://corporate-proxy.internal:3128
+```
+
+```python
+# All providers automatically use the proxy
+model = AIFactory.create_language("openai", "gpt-4")
+embedder = AIFactory.create_embedding("openai", "text-embedding-3-small")
+```
+
+**Different proxy per instance:**
+
+```python
+# Use specific proxy for this instance
+model = AIFactory.create_language(
+    "openai", "gpt-4",
+    config={"proxy": "http://special-proxy.example.com:8080"}
+)
+
+# Another instance without proxy (if ESPERANTO_PROXY is not set)
+model_no_proxy = AIFactory.create_language("ollama", "llama3")
+```
+
+### Proxy Configuration Applies To
+
+All provider types that use HTTP clients:
+- Language Models (LLM)
+- Embedding Models
+- Speech-to-Text (STT)
+- Text-to-Speech (TTS)
+- Rerankers
+
 ## Common Parameters
 
 ### Language Models (LLM)

--- a/src/esperanto/utils/CLAUDE.md
+++ b/src/esperanto/utils/CLAUDE.md
@@ -4,6 +4,7 @@ Utility modules providing cross-cutting functionality for all providers.
 
 ## Files
 
+- **`connect.py`**: `HttpConnectionMixin` combining timeout, SSL, and proxy configuration for HTTP clients
 - **`timeout.py`**: `TimeoutMixin` for configurable HTTP request timeouts
 - **`ssl.py`**: `SSLMixin` for configurable SSL verification
 - **`model_cache.py`**: `ModelCache` for caching provider model lists with TTL
@@ -13,7 +14,7 @@ Utility modules providing cross-cutting functionality for all providers.
 
 ### Mixin Architecture
 
-Both `TimeoutMixin` and `SSLMixin` use the mixin pattern:
+`TimeoutMixin`, `SSLMixin`, and `HttpConnectionMixin` use the mixin pattern:
 
 - Inherit alongside provider base class
 - Provide configuration methods called by base class
@@ -119,6 +120,52 @@ Disabling SSL verification emits a warning:
 
 ```
 UserWarning: SSL verification is disabled. This is insecure and should only be used for development.
+```
+
+### HttpConnectionMixin (connect.py)
+
+Central mixin that combines `TimeoutMixin` and `SSLMixin`, adding proxy support and HTTP client lifecycle management.
+
+**Provides:**
+
+- `_get_proxy()`: Get proxy URL from config or environment
+- `_create_http_clients()`: Create httpx clients with timeout, SSL, and proxy settings
+- `close()` / `aclose()`: Explicit client cleanup
+- Context manager support (`with` / `async with`)
+- Destructor cleanup
+
+**Proxy Configuration:**
+
+Priority order:
+1. Config dict `proxy` (highest)
+2. Env var `ESPERANTO_PROXY`
+3. Default: `None` (no proxy)
+
+**Usage:**
+
+```python
+# Via environment variable
+os.environ["ESPERANTO_PROXY"] = "http://proxy.example.com:8080"
+model = AIFactory.create_language("openai", "gpt-4")
+
+# Via config dict
+model = AIFactory.create_language(
+    "openai", "gpt-4",
+    config={"proxy": "http://proxy.example.com:8080"}
+)
+```
+
+**Proxy URL Formats:**
+
+```python
+# HTTP proxy
+"http://proxy.example.com:8080"
+
+# HTTPS proxy
+"https://secure-proxy.example.com:443"
+
+# With authentication
+"http://user:pass@proxy.example.com:8080"
 ```
 
 ### ModelCache
@@ -298,6 +345,27 @@ model = AIFactory.create_language(
 import os
 os.environ["ESPERANTO_SSL_VERIFY"] = "false"
 model = AIFactory.create_language("ollama", "llama3")
+```
+
+### Configuring Proxy
+
+```python
+# Via environment variable (recommended)
+import os
+os.environ["ESPERANTO_PROXY"] = "http://proxy.example.com:8080"
+model = AIFactory.create_language("openai", "gpt-4")
+
+# Via config dict
+model = AIFactory.create_language(
+    "openai", "gpt-4",
+    config={"proxy": "http://proxy.example.com:8080"}
+)
+
+# With authentication
+model = AIFactory.create_language(
+    "openai", "gpt-4",
+    config={"proxy": "http://user:pass@proxy.example.com:8080"}
+)
 ```
 
 ### Using Model Cache

--- a/tests/test_proxy_configuration.py
+++ b/tests/test_proxy_configuration.py
@@ -1,0 +1,125 @@
+"""Tests for proxy configuration functionality."""
+
+import os
+from unittest.mock import patch
+
+from esperanto.utils.connect import HttpConnectionMixin
+
+
+class MockProxyModel(HttpConnectionMixin):
+    """Mock model for testing proxy configuration functionality."""
+
+    def __init__(self, config: dict = None):
+        self.config = config or {}
+
+    def _get_provider_type(self) -> str:
+        return "language"
+
+
+class TestProxyDefault:
+    """Test default proxy behavior."""
+
+    def test_default_returns_none(self):
+        """Test that proxy is None by default."""
+        model = MockProxyModel()
+        assert model._get_proxy() is None
+
+    def test_empty_config_returns_none(self):
+        """Test that empty config returns None."""
+        model = MockProxyModel(config={})
+        assert model._get_proxy() is None
+
+
+class TestProxyConfig:
+    """Test proxy configuration via config dict."""
+
+    def test_proxy_from_config(self):
+        """Test that proxy can be set via config dict."""
+        model = MockProxyModel(config={"proxy": "http://proxy.example.com:8080"})
+        assert model._get_proxy() == "http://proxy.example.com:8080"
+
+    def test_proxy_https_from_config(self):
+        """Test that HTTPS proxy can be set via config dict."""
+        model = MockProxyModel(config={"proxy": "https://secure-proxy.example.com:443"})
+        assert model._get_proxy() == "https://secure-proxy.example.com:443"
+
+    def test_proxy_with_auth_from_config(self):
+        """Test that proxy with authentication can be set via config dict."""
+        model = MockProxyModel(config={"proxy": "http://user:pass@proxy.example.com:8080"})
+        assert model._get_proxy() == "http://user:pass@proxy.example.com:8080"
+
+
+class TestProxyEnvironmentVariable:
+    """Test proxy configuration via environment variable."""
+
+    def test_env_var_sets_proxy(self):
+        """Test that ESPERANTO_PROXY environment variable sets proxy."""
+        model = MockProxyModel()
+
+        with patch.dict(os.environ, {"ESPERANTO_PROXY": "http://env-proxy.example.com:3128"}):
+            assert model._get_proxy() == "http://env-proxy.example.com:3128"
+
+    def test_env_var_with_https_proxy(self):
+        """Test that ESPERANTO_PROXY works with HTTPS proxy URL."""
+        model = MockProxyModel()
+
+        with patch.dict(os.environ, {"ESPERANTO_PROXY": "https://secure-env-proxy.example.com:443"}):
+            assert model._get_proxy() == "https://secure-env-proxy.example.com:443"
+
+
+class TestProxyPriority:
+    """Test proxy configuration priority (config > env var)."""
+
+    def test_config_takes_precedence_over_env_var(self):
+        """Test that config dict takes precedence over environment variable."""
+        model = MockProxyModel(config={"proxy": "http://config-proxy.example.com:8080"})
+
+        with patch.dict(os.environ, {"ESPERANTO_PROXY": "http://env-proxy.example.com:3128"}):
+            assert model._get_proxy() == "http://config-proxy.example.com:8080"
+
+    def test_env_var_used_when_config_proxy_is_none(self):
+        """Test that env var is used when config doesn't have proxy."""
+        model = MockProxyModel(config={"timeout": 120})  # config exists but no proxy
+
+        with patch.dict(os.environ, {"ESPERANTO_PROXY": "http://env-proxy.example.com:3128"}):
+            assert model._get_proxy() == "http://env-proxy.example.com:3128"
+
+    def test_env_var_used_when_config_proxy_is_empty(self):
+        """Test that env var is used when config proxy is empty string."""
+        model = MockProxyModel(config={"proxy": ""})
+
+        with patch.dict(os.environ, {"ESPERANTO_PROXY": "http://env-proxy.example.com:3128"}):
+            # Empty string is falsy, so env var should be used
+            assert model._get_proxy() == "http://env-proxy.example.com:3128"
+
+
+class TestProxyClientCreation:
+    """Test that proxy is passed to HTTP clients."""
+
+    def test_clients_created_with_proxy(self):
+        """Test that HTTP clients are created with proxy configuration."""
+        model = MockProxyModel(config={"proxy": "http://proxy.example.com:8080"})
+        model._create_http_clients()
+
+        # httpx stores proxy in _proxy_url attribute (internal detail)
+        # We verify by checking the client was created successfully
+        assert model.client is not None
+        assert model.async_client is not None
+
+    def test_clients_created_without_proxy(self):
+        """Test that HTTP clients are created when proxy is None."""
+        model = MockProxyModel()
+        model._create_http_clients()
+
+        assert model.client is not None
+        assert model.async_client is not None
+
+    def test_clients_created_with_env_var_proxy(self):
+        """Test that HTTP clients use proxy from environment variable."""
+        model = MockProxyModel()
+
+        with patch.dict(os.environ, {"ESPERANTO_PROXY": "http://env-proxy.example.com:3128"}):
+            model._create_http_clients()
+
+        assert model.client is not None
+        assert model.async_client is not None


### PR DESCRIPTION
## Summary

- Add HTTP proxy support for all provider HTTP connections
- Update CHANGELOG with entries for v2.10.0 through v2.14.0

## Proxy Configuration

Users can now configure a proxy for all Esperanto provider connections:

**Via environment variable:**
```bash
export ESPERANTO_PROXY="http://proxy.example.com:8080"
```

**Via config dict:**
```python
model = AIFactory.create_language(
    "openai", "gpt-4",
    config={"proxy": "http://proxy.example.com:8080"}
)
```

**Supported formats:**
- HTTP: `http://proxy:8080`
- HTTPS: `https://secure-proxy:443`
- With auth: `http://user:pass@proxy:8080`

**Priority:** config dict > environment variable > none

## Changes

| File | Description |
|------|-------------|
| `src/esperanto/utils/connect.py` | Added `_get_proxy()` method to `HttpConnectionMixin` |
| `tests/test_proxy_configuration.py` | 13 tests covering all proxy scenarios |
| `docs/configuration.md` | Added Proxy Configuration section |
| `src/esperanto/utils/CLAUDE.md` | Updated with proxy documentation |
| `CHANGELOG.md` | Added entries for v2.10.0 - v2.14.0 |

## Test plan

- [x] Unit tests for proxy configuration priority (config > env > none)
- [x] Unit tests for various proxy URL formats
- [x] Unit tests for HTTP client creation with proxy
- [x] All 123 HTTP connection tests pass