### PR TITLE
fix: resolve config dict api_key not being unpacked in OpenAI-based providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.17.1] - 2026-01-24
+
+### Fixed
+
+- **Config Dict API Key Not Unpacked** - Fixed providers ignoring `api_key` passed via config dict (#68)
+  - Affected providers: OpenRouter, DeepSeek, xAI (LLM), Groq (STT)
+  - These providers inherit from OpenAI-compatible parent classes and were checking for `api_key` before the config dict was unpacked
+  - Now correctly extracts `api_key` and `base_url` from config dict before setting provider defaults
+  - Example that now works:
+    ```python
+    model = AIFactory.create_language(
+        "openrouter",
+        "anthropic/claude-3.5-sonnet",
+        config={"api_key": "sk-or-v1-xxxxx"}
+    )
+    ```
+
 ## [2.17.0] - 2026-01-23
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esperanto"
-version = "2.17.0"
+version = "2.17.1"
 description = "A light-weight, production-ready, unified interface for various AI model providers"
 authors = [
     { name = "LUIS NOVO", email = "lfnovo@gmail.com" }

--- a/src/esperanto/providers/llm/deepseek.py
+++ b/src/esperanto/providers/llm/deepseek.py
@@ -25,6 +25,13 @@ class DeepSeekLanguageModel(OpenAILanguageModel):
         return "deepseek"
 
     def __post_init__(self):
+        # Extract api_key and base_url from config dict first (before parent sets OpenAI defaults)
+        if hasattr(self, "config") and self.config:
+            if "api_key" in self.config:
+                self.api_key = self.config["api_key"]
+            if "base_url" in self.config:
+                self.base_url = self.config["base_url"]
+
         # Initialize DeepSeek-specific configuration
         self.base_url = self.base_url or os.getenv(
             "DEEPSEEK_BASE_URL", "https://api.deepseek.com/v1"
@@ -37,7 +44,7 @@ class DeepSeekLanguageModel(OpenAILanguageModel):
                 "DeepSeek API key not found. Set the DEEPSEEK_API_KEY environment variable."
             )
 
-        # Call parent's post_init to set up normalized response handling
+        # Call parent's post_init (won't overwrite since values are already set)
         super().__post_init__()
 
         # DeepSeek supports JSON mode like OpenAI (handled by parent)

--- a/src/esperanto/providers/llm/openrouter.py
+++ b/src/esperanto/providers/llm/openrouter.py
@@ -37,6 +37,13 @@ class OpenRouterLanguageModel(OpenAILanguageModel):
     api_key: Optional[str] = None  # Changed type hint
 
     def __post_init__(self):
+        # Extract api_key and base_url from config dict first (before parent sets OpenAI defaults)
+        if hasattr(self, "config") and self.config:
+            if "api_key" in self.config:
+                self.api_key = self.config["api_key"]
+            if "base_url" in self.config:
+                self.base_url = self.config["base_url"]
+
         # Initialize OpenRouter-specific configuration
         self.base_url = self.base_url or os.getenv(
             "OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1"
@@ -48,7 +55,7 @@ class OpenRouterLanguageModel(OpenAILanguageModel):
                 "OpenRouter API key not found. Set the OPENROUTER_API_KEY environment variable."
             )
 
-        # Call parent's post_init to set up HTTP clients
+        # Call parent's post_init (won't overwrite since values are already set)
         super().__post_init__()
 
     def _get_headers(self) -> Dict[str, str]:

--- a/src/esperanto/providers/llm/xai.py
+++ b/src/esperanto/providers/llm/xai.py
@@ -20,6 +20,13 @@ class XAILanguageModel(OpenAILanguageModel):
     api_key: Optional[str] = None  # Changed type hint
 
     def __post_init__(self):
+        # Extract api_key and base_url from config dict first (before parent sets OpenAI defaults)
+        if hasattr(self, "config") and self.config:
+            if "api_key" in self.config:
+                self.api_key = self.config["api_key"]
+            if "base_url" in self.config:
+                self.base_url = self.config["base_url"]
+
         # Initialize XAI-specific configuration
         self.base_url = self.base_url or os.getenv(
             "XAI_BASE_URL", "https://api.x.ai/v1"
@@ -31,7 +38,7 @@ class XAILanguageModel(OpenAILanguageModel):
                 "XAI API key not found. Set the XAI_API_KEY environment variable."
             )
 
-        # Call parent's post_init to set up HTTP clients
+        # Call parent's post_init (won't overwrite since values are already set)
         super().__post_init__()
 
 

--- a/src/esperanto/providers/stt/groq.py
+++ b/src/esperanto/providers/stt/groq.py
@@ -14,15 +14,22 @@ class GroqSpeechToTextModel(OpenAISpeechToTextModel):
 
     def __post_init__(self):
         """Initialize HTTP clients with Groq configuration."""
-        # Set Groq-specific API key and base URL before calling parent
+        # Extract api_key and base_url from config dict first (before parent sets OpenAI defaults)
+        if hasattr(self, "config") and self.config:
+            if "api_key" in self.config:
+                self.api_key = self.config["api_key"]
+            if "base_url" in self.config:
+                self.base_url = self.config["base_url"]
+
+        # Set Groq-specific API key and base URL
         self.api_key = self.api_key or os.getenv("GROQ_API_KEY")
         if not self.api_key:
             raise ValueError("Groq API key not found")
-        
+
         # Set Groq's OpenAI-compatible base URL
         self.base_url = self.base_url or "https://api.groq.com/openai/v1"
-        
-        # Call parent's post_init which will initialize HTTP clients
+
+        # Call parent's post_init (won't overwrite since values are already set)
         super().__post_init__()
 
     def _get_default_model(self) -> str:

--- a/tests/providers/llm/test_deepseek_provider.py
+++ b/tests/providers/llm/test_deepseek_provider.py
@@ -52,6 +52,34 @@ def test_to_langchain():
     assert lc is not None
 
 
+def test_initialization_with_api_key_in_config():
+    """Test that api_key can be passed via config dict (GitHub issue #68)."""
+    model = DeepSeekLanguageModel(config={"api_key": "config-test-key"})
+    assert model.api_key == "config-test-key"
+    assert model.base_url == "https://api.deepseek.com/v1"
+
+
+def test_initialization_with_base_url_in_config():
+    """Test that base_url can be passed via config dict."""
+    model = DeepSeekLanguageModel(
+        api_key="test-key",
+        config={"base_url": "https://custom.deepseek.com/v1"}
+    )
+    assert model.base_url == "https://custom.deepseek.com/v1"
+
+
+def test_initialization_with_api_key_and_base_url_in_config():
+    """Test that both api_key and base_url can be passed via config dict."""
+    model = DeepSeekLanguageModel(
+        config={
+            "api_key": "config-test-key",
+            "base_url": "https://custom.deepseek.com/v1"
+        }
+    )
+    assert model.api_key == "config-test-key"
+    assert model.base_url == "https://custom.deepseek.com/v1"
+
+
 # =============================================================================
 # Tool Calling Tests
 # =============================================================================

--- a/tests/providers/llm/test_openrouter_provider.py
+++ b/tests/providers/llm/test_openrouter_provider.py
@@ -39,6 +39,34 @@ def test_custom_base_url():
     assert model.base_url == "https://custom.openrouter.ai/v1"
 
 
+def test_initialization_with_api_key_in_config():
+    """Test that api_key can be passed via config dict (GitHub issue #68)."""
+    model = OpenRouterLanguageModel(config={"api_key": "config-test-key"})
+    assert model.api_key == "config-test-key"
+    assert model.base_url == "https://openrouter.ai/api/v1"
+
+
+def test_initialization_with_base_url_in_config():
+    """Test that base_url can be passed via config dict."""
+    model = OpenRouterLanguageModel(
+        api_key="test-key",
+        config={"base_url": "https://custom.openrouter.ai/v1"}
+    )
+    assert model.base_url == "https://custom.openrouter.ai/v1"
+
+
+def test_initialization_with_api_key_and_base_url_in_config():
+    """Test that both api_key and base_url can be passed via config dict."""
+    model = OpenRouterLanguageModel(
+        config={
+            "api_key": "config-test-key",
+            "base_url": "https://custom.openrouter.ai/v1"
+        }
+    )
+    assert model.api_key == "config-test-key"
+    assert model.base_url == "https://custom.openrouter.ai/v1"
+
+
 # =============================================================================
 # Tool Calling Tests
 # =============================================================================

--- a/tests/providers/llm/test_xai_provider.py
+++ b/tests/providers/llm/test_xai_provider.py
@@ -38,6 +38,34 @@ def test_custom_base_url():
     assert model.base_url == "https://custom.x.ai/v1"
 
 
+def test_initialization_with_api_key_in_config():
+    """Test that api_key can be passed via config dict (GitHub issue #68)."""
+    model = XAILanguageModel(config={"api_key": "config-test-key"})
+    assert model.api_key == "config-test-key"
+    assert model.base_url == "https://api.x.ai/v1"
+
+
+def test_initialization_with_base_url_in_config():
+    """Test that base_url can be passed via config dict."""
+    model = XAILanguageModel(
+        api_key="test-key",
+        config={"base_url": "https://custom.x.ai/v1"}
+    )
+    assert model.base_url == "https://custom.x.ai/v1"
+
+
+def test_initialization_with_api_key_and_base_url_in_config():
+    """Test that both api_key and base_url can be passed via config dict."""
+    model = XAILanguageModel(
+        config={
+            "api_key": "config-test-key",
+            "base_url": "https://custom.x.ai/v1"
+        }
+    )
+    assert model.api_key == "config-test-key"
+    assert model.base_url == "https://custom.x.ai/v1"
+
+
 # =============================================================================
 # Tool Calling Tests
 # =============================================================================

--- a/tests/providers/stt/test_groq.py
+++ b/tests/providers/stt/test_groq.py
@@ -23,11 +23,46 @@ def test_factory_creates_groq_stt():
     """Test that AIFactory creates Groq STT model."""
     from unittest.mock import patch
     import os
-    
+
     # Mock the environment variable to provide an API key
     with patch.dict(os.environ, {'GROQ_API_KEY': 'test-key'}):
         model = AIFactory.create_speech_to_text("groq")
         assert isinstance(model, GroqSpeechToTextModel)
+
+
+def test_initialization_with_api_key():
+    """Test initialization with api_key parameter."""
+    model = GroqSpeechToTextModel(api_key="test-key")
+    assert model.api_key == "test-key"
+    assert model.base_url == "https://api.groq.com/openai/v1"
+
+
+def test_initialization_with_api_key_in_config():
+    """Test that api_key can be passed via config dict (GitHub issue #68)."""
+    model = GroqSpeechToTextModel(config={"api_key": "config-test-key"})
+    assert model.api_key == "config-test-key"
+    assert model.base_url == "https://api.groq.com/openai/v1"
+
+
+def test_initialization_with_base_url_in_config():
+    """Test that base_url can be passed via config dict."""
+    model = GroqSpeechToTextModel(
+        api_key="test-key",
+        config={"base_url": "https://custom.groq.com/v1"}
+    )
+    assert model.base_url == "https://custom.groq.com/v1"
+
+
+def test_initialization_with_api_key_and_base_url_in_config():
+    """Test that both api_key and base_url can be passed via config dict."""
+    model = GroqSpeechToTextModel(
+        config={
+            "api_key": "config-test-key",
+            "base_url": "https://custom.groq.com/v1"
+        }
+    )
+    assert model.api_key == "config-test-key"
+    assert model.base_url == "https://custom.groq.com/v1"
 
 
 def test_groq_transcribe(audio_file):


### PR DESCRIPTION
## Summary

- Fixes #68: OpenRouter (and other OpenAI-based providers) were ignoring `api_key` passed via the config dict
- Fixed providers: LLM openrouter, deepseek, xai and STT groq
- Added regression tests for config dict initialization

## Root Cause

Providers that inherit from OpenAI-compatible parent classes were checking for `api_key` before the config dict was unpacked by the base class's `__post_init__`. Additionally, when calling `super().__post_init__()` first, the parent OpenAI class would set its own defaults before the child provider could set its own.

## Fix

For providers that inherit from OpenAI-compatible parent classes, manually extract `api_key` and `base_url` from the config dict before setting provider-specific defaults:

```python
def __post_init__(self):
    # Extract api_key and base_url from config dict first
    if hasattr(self, "config") and self.config:
        if "api_key" in self.config:
            self.api_key = self.config["api_key"]
        if "base_url" in self.config:
            self.base_url = self.config["base_url"]

    # Set provider-specific defaults
    self.api_key = self.api_key or os.getenv("PROVIDER_API_KEY")
    # ...
    
    super().__post_init__()
```

## Test plan

- [x] All existing tests pass (390 LLM provider tests)
- [x] Added tests for config dict initialization:
  - `test_initialization_with_api_key_in_config`
  - `test_initialization_with_base_url_in_config`
  - `test_initialization_with_api_key_and_base_url_in_config`