### PR TITLE
docs: remove hardcoded OpenRouter base URL from config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -134,7 +134,6 @@ XAI_API_KEY=...
 #### OpenRouter
 ```bash
 OPENROUTER_API_KEY=...
-OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 ```
 
 → **[Full OpenRouter Setup Guide](./providers/openrouter.md)**


### PR DESCRIPTION
## Summary

- Remove `OPENROUTER_BASE_URL=https://openrouter.ai/api/v1` from the OpenRouter env vars section — it's a default, not something users need to set.