### PR TITLE
fix: honor embedding api_key from config dict across providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.19.1] - 2026-02-12
+
+### Fixed
+
+- **Config Dict API Key Resolution in Embedding Providers** - Fixed embedding providers ignoring `api_key` passed via config dict
+  - Affected providers: OpenAI, Google, Jina, Voyage (embedding)
+  - Providers now correctly honor API keys resolved from config before env fallback
+  - Added regression tests to ensure `config={"api_key": "..."}` works consistently
+
 ## [2.19.0] - 2026-02-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esperanto"
-version = "2.19.0"
+version = "2.19.1"
 description = "A light-weight, production-ready, unified interface for various AI model providers"
 authors = [
     { name = "LUIS NOVO", email = "lfnovo@gmail.com" }

--- a/src/esperanto/providers/embedding/google.py
+++ b/src/esperanto/providers/embedding/google.py
@@ -33,7 +33,9 @@ class GoogleEmbeddingModel(EmbeddingModel):
 
         # Get API key
         self.api_key = (
-            kwargs.get("api_key")
+            self.api_key
+            or kwargs.get("api_key")
+            or (self.config or {}).get("api_key")
             or os.getenv("GOOGLE_API_KEY")
             or os.getenv("GEMINI_API_KEY")
         )

--- a/src/esperanto/providers/embedding/jina.py
+++ b/src/esperanto/providers/embedding/jina.py
@@ -39,13 +39,23 @@ class JinaEmbeddingModel(EmbeddingModel):
                 - config: Dict with task_type, late_chunking, output_dimensions, etc.
         """
         super().__init__(**kwargs)
-        self.api_key = kwargs.get("api_key") or os.getenv("JINA_API_KEY")
+        self.api_key = (
+            self.api_key
+            or kwargs.get("api_key")
+            or (self.config or {}).get("api_key")
+            or os.getenv("JINA_API_KEY")
+        )
         if not self.api_key:
             raise ValueError(
                 "Jina API key not found. Please set the JINA_API_KEY environment "
                 "variable or pass it as 'api_key' parameter."
             )
-        self.base_url = kwargs.get("base_url", "https://api.jina.ai/v1/embeddings")
+        self.base_url = (
+            self.base_url
+            or kwargs.get("base_url")
+            or (self.config or {}).get("base_url")
+            or "https://api.jina.ai/v1/embeddings"
+        )
 
         # Initialize HTTP clients with configurable timeout
         self._create_http_clients()

--- a/src/esperanto/providers/embedding/openai.py
+++ b/src/esperanto/providers/embedding/openai.py
@@ -12,19 +12,24 @@ class OpenAIEmbeddingModel(EmbeddingModel):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        
+
         # Get API key
-        self.api_key = kwargs.get("api_key") or os.getenv("OPENAI_API_KEY")
+        self.api_key = (
+            self.api_key
+            or kwargs.get("api_key")
+            or (self.config or {}).get("api_key")
+            or os.getenv("OPENAI_API_KEY")
+        )
         if not self.api_key:
             raise ValueError("OpenAI API key not found")
-        
+
         # Set base URL
         self.base_url = self.base_url or "https://api.openai.com/v1"
-        
+
         # Update config with model_name if provided
         if "model_name" in kwargs:
             self._config["model_name"] = kwargs["model_name"]
-        
+
         # Initialize HTTP clients with configurable timeout
         self._create_http_clients()
 

--- a/src/esperanto/providers/embedding/voyage.py
+++ b/src/esperanto/providers/embedding/voyage.py
@@ -20,12 +20,17 @@ class VoyageEmbeddingModel(EmbeddingModel):
         super().__init__(**kwargs)
 
         # Get API key
-        self.api_key = kwargs.get("api_key") or os.getenv("VOYAGE_API_KEY")
+        self.api_key = (
+            self.api_key
+            or kwargs.get("api_key")
+            or (self.config or {}).get("api_key")
+            or os.getenv("VOYAGE_API_KEY")
+        )
         if not self.api_key:
             raise ValueError("Voyage API key not found")
 
         # Set base URL
-        self.base_url = "https://api.voyageai.com/v1"
+        self.base_url = self.base_url or "https://api.voyageai.com/v1"
 
         # Initialize HTTP clients with configurable timeout
         self._create_http_clients()

--- a/tests/providers/embedding/test_embedding_providers.py
+++ b/tests/providers/embedding/test_embedding_providers.py
@@ -323,6 +323,11 @@ def test_openai_initialization_with_api_key():
     assert model.api_key == "test-key"
 
 
+def test_openai_initialization_with_config_api_key():
+    model = OpenAIEmbeddingModel(config={"api_key": "config-test-key"})
+    assert model.api_key == "config-test-key"
+
+
 def test_openai_initialization_with_env_var():
     with patch.dict(os.environ, {"OPENAI_API_KEY": "env-test-key"}):
         model = OpenAIEmbeddingModel()
@@ -538,6 +543,11 @@ def test_google_provider_name():
 def test_google_initialization_with_api_key():
     model = GoogleEmbeddingModel(api_key="test-key")
     assert model.api_key == "test-key"
+
+
+def test_google_initialization_with_config_api_key():
+    model = GoogleEmbeddingModel(config={"api_key": "config-test-key"})
+    assert model.api_key == "config-test-key"
 
 
 def test_google_initialization_with_env_var():

--- a/tests/providers/embedding/test_jina.py
+++ b/tests/providers/embedding/test_jina.py
@@ -26,6 +26,11 @@ class TestJinaEmbeddingModel:
             model = JinaEmbeddingModel()
             assert model.api_key == "env-key"
 
+    def test_init_with_config_api_key(self):
+        """Test initialization with API key from config."""
+        model = JinaEmbeddingModel(config={"api_key": "config-key"})
+        assert model.api_key == "config-key"
+
     def test_init_without_api_key(self):
         """Test initialization without API key raises error."""
         with patch.dict(os.environ, {}, clear=True):

--- a/tests/providers/embedding/test_voyage_provider.py
+++ b/tests/providers/embedding/test_voyage_provider.py
@@ -65,6 +65,11 @@ def test_init_with_env_api_key():
         model = VoyageEmbeddingModel()
         assert model.api_key == "test-key"
 
+def test_init_with_config_api_key():
+    """Test initialization with API key from config."""
+    model = VoyageEmbeddingModel(config={"api_key": "config-test-key"})
+    assert model.api_key == "config-test-key"
+
 
 def test_init_without_api_key():
     """Test initialization without API key raises error."""


### PR DESCRIPTION
## Summary
- fix API key resolution in embedding providers to honor config-resolved values before env fallback
- apply the fix to OpenAI, Google, Jina, and Voyage embedding providers
- bump package version to 2.19.1
- add changelog entry for the fix
- add regression tests for config={"api_key": "..."} initialization paths

## Why
Some users passed API keys via config (e.g. through factory methods) and still got API key not found in embedding providers due to provider-specific __init__ overriding resolved credentials.

## Validation
- uv run pytest -q tests/providers/embedding/test_embedding_providers.py -k "openai_initialization_with_config_api_key or google_initialization_with_config_api_key"
- uv run pytest -q tests/providers/embedding/test_jina.py -k "config_api_key or init_with_api_key or init_with_env_var or init_without_api_key"
- uv run pytest -q tests/providers/embedding/test_voyage_provider.py -k "config_api_key or init_with_api_key or init_with_env_api_key or init_without_api_key"
