### PR TITLE
fix: pass response_format in TTS API requests and map to correct content_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.19.4] - 2026-02-17
+
+### Fixed
+
+- **TTS `response_format` and `content_type` support** - OpenAI-compatible TTS providers now correctly pass `response_format` in the API request and map it to the appropriate MIME type in `AudioResponse.content_type`. Previously, `response_format` was never sent and `content_type` was always hardcoded to `"audio/mp3"`, causing failures when providers return non-MP3 audio (e.g., WAV from mlx-audio/Kokoro).
+  - Affected providers: OpenAI, OpenAI-compatible, Azure TTS
+  - Default behavior unchanged: omitting `response_format` still defaults to `"mp3"`
+
 ## [2.19.2] - 2026-02-14
 
 ### Fixed

--- a/docs/providers/openai-compatible.md
+++ b/docs/providers/openai-compatible.md
@@ -489,9 +489,9 @@ async def generate_speech_async():
 response = tts.generate_speech(
     text="Custom speech generation",
     voice="en_US-amy-medium",
-    speed=1.2,      # Custom parameter
-    format="wav",   # Custom parameter
-    quality="high"  # Custom parameter
+    speed=1.2,              # Custom parameter
+    response_format="wav",  # Audio format: mp3, opus, aac, flac, wav, pcm
+    quality="high"          # Custom parameter
 )
 ```
 

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -517,6 +517,7 @@ Error: Request timed out
 
 **TTS Output Format:**
 - MP3 format by default
+- Configurable via `response_format` kwarg: `"mp3"`, `"opus"`, `"aac"`, `"flac"`, `"wav"`, `"pcm"`
 - Stereo output
 - 24kHz sample rate (tts-1) or 44.1kHz (tts-1-hd)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esperanto"
-version = "2.19.3"
+version = "2.19.4"
 description = "A light-weight, production-ready, unified interface for various AI model providers"
 authors = [
     { name = "LUIS NOVO", email = "lfnovo@gmail.com" }

--- a/src/esperanto/providers/tts/azure.py
+++ b/src/esperanto/providers/tts/azure.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Union
 import httpx
 
 from .base import AudioResponse, Model, TextToSpeechModel, Voice
+from .openai import RESPONSE_FORMAT_TO_CONTENT_TYPE
 
 
 class AzureTextToSpeechModel(TextToSpeechModel):
@@ -203,6 +204,7 @@ class AzureTextToSpeechModel(TextToSpeechModel):
             RuntimeError: If speech generation fails
         """
         try:
+            response_format = kwargs.pop("response_format", "mp3")
             url = self._build_url("audio/speech")
 
             # Prepare request payload
@@ -210,6 +212,7 @@ class AzureTextToSpeechModel(TextToSpeechModel):
                 "model": self.deployment_name,
                 "voice": voice,
                 "input": text,
+                "response_format": response_format,
                 **kwargs
             }
 
@@ -230,9 +233,12 @@ class AzureTextToSpeechModel(TextToSpeechModel):
                 output_file.parent.mkdir(parents=True, exist_ok=True)
                 output_file.write_bytes(audio_data)
 
+            content_type = RESPONSE_FORMAT_TO_CONTENT_TYPE.get(
+                response_format, f"audio/{response_format}"
+            )
             return AudioResponse(
                 audio_data=audio_data,
-                content_type="audio/mp3",
+                content_type=content_type,
                 model=self.deployment_name,
                 voice=voice,
                 provider=self.PROVIDER,
@@ -264,6 +270,7 @@ class AzureTextToSpeechModel(TextToSpeechModel):
             RuntimeError: If speech generation fails
         """
         try:
+            response_format = kwargs.pop("response_format", "mp3")
             url = self._build_url("audio/speech")
 
             # Prepare request payload
@@ -271,6 +278,7 @@ class AzureTextToSpeechModel(TextToSpeechModel):
                 "model": self.deployment_name,
                 "voice": voice,
                 "input": text,
+                "response_format": response_format,
                 **kwargs
             }
 
@@ -291,9 +299,12 @@ class AzureTextToSpeechModel(TextToSpeechModel):
                 output_file.parent.mkdir(parents=True, exist_ok=True)
                 output_file.write_bytes(audio_data)
 
+            content_type = RESPONSE_FORMAT_TO_CONTENT_TYPE.get(
+                response_format, f"audio/{response_format}"
+            )
             return AudioResponse(
                 audio_data=audio_data,
-                content_type="audio/mp3",
+                content_type=content_type,
                 model=self.deployment_name,
                 voice=voice,
                 provider=self.PROVIDER,

--- a/src/esperanto/providers/tts/openai.py
+++ b/src/esperanto/providers/tts/openai.py
@@ -8,6 +8,15 @@ import httpx
 
 from .base import TextToSpeechModel, AudioResponse, Voice, Model
 
+RESPONSE_FORMAT_TO_CONTENT_TYPE = {
+    "mp3": "audio/mp3",
+    "opus": "audio/opus",
+    "aac": "audio/aac",
+    "flac": "audio/flac",
+    "wav": "audio/wav",
+    "pcm": "audio/pcm",
+}
+
 
 class OpenAITextToSpeechModel(TextToSpeechModel):
     """OpenAI Text-to-Speech provider implementation.
@@ -173,11 +182,14 @@ class OpenAITextToSpeechModel(TextToSpeechModel):
             RuntimeError: If speech generation fails
         """
         try:
+            response_format = kwargs.pop("response_format", "mp3")
+
             # Prepare request payload
             payload = {
                 "model": self.model_name,
                 "voice": voice,
                 "input": text,
+                "response_format": response_format,
                 **kwargs
             }
 
@@ -191,16 +203,19 @@ class OpenAITextToSpeechModel(TextToSpeechModel):
 
             # Get audio data (binary content)
             audio_data = response.content
-            
+
             # Save to file if specified
             if output_file:
                 output_file = Path(output_file)
                 output_file.parent.mkdir(parents=True, exist_ok=True)
                 output_file.write_bytes(audio_data)
 
+            content_type = RESPONSE_FORMAT_TO_CONTENT_TYPE.get(
+                response_format, f"audio/{response_format}"
+            )
             return AudioResponse(
                 audio_data=audio_data,
-                content_type="audio/mp3",
+                content_type=content_type,
                 model=self.model_name,
                 voice=voice,
                 provider=self.PROVIDER,
@@ -232,11 +247,14 @@ class OpenAITextToSpeechModel(TextToSpeechModel):
             RuntimeError: If speech generation fails
         """
         try:
+            response_format = kwargs.pop("response_format", "mp3")
+
             # Prepare request payload
             payload = {
                 "model": self.model_name,
                 "voice": voice,
                 "input": text,
+                "response_format": response_format,
                 **kwargs
             }
 
@@ -250,16 +268,19 @@ class OpenAITextToSpeechModel(TextToSpeechModel):
 
             # Get audio data (binary content)
             audio_data = response.content
-            
+
             # Save to file if specified
             if output_file:
                 output_file = Path(output_file)
                 output_file.parent.mkdir(parents=True, exist_ok=True)
                 output_file.write_bytes(audio_data)
 
+            content_type = RESPONSE_FORMAT_TO_CONTENT_TYPE.get(
+                response_format, f"audio/{response_format}"
+            )
             return AudioResponse(
                 audio_data=audio_data,
-                content_type="audio/mp3",
+                content_type=content_type,
                 model=self.model_name,
                 voice=voice,
                 provider=self.PROVIDER,

--- a/src/esperanto/providers/tts/openai_compatible.py
+++ b/src/esperanto/providers/tts/openai_compatible.py
@@ -8,7 +8,7 @@ from esperanto.common_types import Model
 from esperanto.utils.logging import logger
 
 from .base import AudioResponse, Voice
-from .openai import OpenAITextToSpeechModel
+from .openai import OpenAITextToSpeechModel, RESPONSE_FORMAT_TO_CONTENT_TYPE
 
 
 class OpenAICompatibleTextToSpeechModel(OpenAITextToSpeechModel):
@@ -225,11 +225,14 @@ class OpenAICompatibleTextToSpeechModel(OpenAITextToSpeechModel):
             RuntimeError: If speech generation fails
         """
         try:
+            response_format = kwargs.pop("response_format", "mp3")
+
             # Prepare request payload using OpenAI standard format
             payload = {
                 "model": self.model_name,
                 "voice": voice,
                 "input": text,  # OpenAI standard uses "input", not "text"
+                "response_format": response_format,
                 **kwargs
             }
 
@@ -250,9 +253,12 @@ class OpenAICompatibleTextToSpeechModel(OpenAITextToSpeechModel):
                 output_file.parent.mkdir(parents=True, exist_ok=True)
                 output_file.write_bytes(audio_data)
 
+            content_type = RESPONSE_FORMAT_TO_CONTENT_TYPE.get(
+                response_format, f"audio/{response_format}"
+            )
             return AudioResponse(
                 audio_data=audio_data,
-                content_type="audio/mp3",
+                content_type=content_type,
                 model=self.model_name,
                 voice=voice,
                 provider=self.provider,
@@ -284,11 +290,14 @@ class OpenAICompatibleTextToSpeechModel(OpenAITextToSpeechModel):
             RuntimeError: If speech generation fails
         """
         try:
+            response_format = kwargs.pop("response_format", "mp3")
+
             # Prepare request payload using OpenAI standard format
             payload = {
                 "model": self.model_name,
                 "voice": voice,
                 "input": text,  # OpenAI standard uses "input", not "text"
+                "response_format": response_format,
                 **kwargs
             }
 
@@ -309,9 +318,12 @@ class OpenAICompatibleTextToSpeechModel(OpenAITextToSpeechModel):
                 output_file.parent.mkdir(parents=True, exist_ok=True)
                 output_file.write_bytes(audio_data)
 
+            content_type = RESPONSE_FORMAT_TO_CONTENT_TYPE.get(
+                response_format, f"audio/{response_format}"
+            )
             return AudioResponse(
                 audio_data=audio_data,
-                content_type="audio/mp3",
+                content_type=content_type,
                 model=self.model_name,
                 voice=voice,
                 provider=self.provider,

--- a/tests/providers/tts/test_openai.py
+++ b/tests/providers/tts/test_openai.py
@@ -178,6 +178,57 @@ async def test_agenerate_speech(tts_model):
     assert response.provider == "openai"
 
 
+def test_generate_speech_with_response_format(tts_model):
+    """Test speech generation with explicit response_format."""
+    response = tts_model.generate_speech(
+        text="Hello world",
+        voice="alloy",
+        response_format="wav"
+    )
+
+    # Check payload includes response_format
+    call_args = tts_model.client.post.call_args
+    json_payload = call_args[1]["json"]
+    assert json_payload["response_format"] == "wav"
+
+    # Check content_type is mapped correctly
+    assert response.content_type == "audio/wav"
+
+
+def test_generate_speech_default_response_format(tts_model):
+    """Test that default response_format is mp3."""
+    response = tts_model.generate_speech(
+        text="Hello world",
+        voice="alloy"
+    )
+
+    # Check payload defaults to mp3
+    call_args = tts_model.client.post.call_args
+    json_payload = call_args[1]["json"]
+    assert json_payload["response_format"] == "mp3"
+
+    # Check content_type is audio/mp3
+    assert response.content_type == "audio/mp3"
+
+
+@pytest.mark.asyncio
+async def test_agenerate_speech_with_response_format(tts_model):
+    """Test async speech generation with explicit response_format."""
+    response = await tts_model.agenerate_speech(
+        text="Hello world",
+        voice="nova",
+        response_format="flac"
+    )
+
+    # Check payload includes response_format
+    call_args = tts_model.async_client.post.call_args
+    json_payload = call_args[1]["json"]
+    assert json_payload["response_format"] == "flac"
+
+    # Check content_type is mapped correctly
+    assert response.content_type == "audio/flac"
+
+
 def test_available_voices(tts_model):
     """Test getting available voices."""
     voices = tts_model.available_voices

--- a/tests/providers/tts/test_openai_compatible.py
+++ b/tests/providers/tts/test_openai_compatible.py
@@ -237,6 +237,57 @@ async def test_agenerate_speech(tts_model):
     assert response.provider == "openai-compatible"
 
 
+def test_generate_speech_with_response_format(tts_model):
+    """Test speech generation with explicit response_format."""
+    response = tts_model.generate_speech(
+        text="Hello world",
+        voice="default",
+        response_format="wav"
+    )
+
+    # Check payload includes response_format
+    call_args = tts_model.client.post.call_args
+    json_payload = call_args[1]["json"]
+    assert json_payload["response_format"] == "wav"
+
+    # Check content_type is mapped correctly
+    assert response.content_type == "audio/wav"
+
+
+def test_generate_speech_default_response_format(tts_model):
+    """Test that default response_format is mp3."""
+    response = tts_model.generate_speech(
+        text="Hello world",
+        voice="default"
+    )
+
+    # Check payload defaults to mp3
+    call_args = tts_model.client.post.call_args
+    json_payload = call_args[1]["json"]
+    assert json_payload["response_format"] == "mp3"
+
+    # Check content_type is audio/mp3
+    assert response.content_type == "audio/mp3"
+
+
+@pytest.mark.asyncio
+async def test_agenerate_speech_with_response_format(tts_model):
+    """Test async speech generation with explicit response_format."""
+    response = await tts_model.agenerate_speech(
+        text="Hello world",
+        voice="default",
+        response_format="opus"
+    )
+
+    # Check payload includes response_format
+    call_args = tts_model.async_client.post.call_args
+    json_payload = call_args[1]["json"]
+    assert json_payload["response_format"] == "opus"
+
+    # Check content_type is mapped correctly
+    assert response.content_type == "audio/opus"
+
+
 def test_available_voices(tts_model):
     """Test getting available voices."""
     voices = tts_model.available_voices


### PR DESCRIPTION
## Summary

- TTS providers now extract `response_format` from kwargs (defaulting to `"mp3"`), include it in the API payload, and map it to the correct MIME type for `AudioResponse.content_type`
- Previously `response_format` was never sent and `content_type` was always hardcoded to `"audio/mp3"`, causing failures when providers return non-MP3 audio (e.g. WAV from mlx-audio/Kokoro)
- Affected providers: OpenAI, OpenAI-compatible, Azure TTS

Closes #86

## Test plan

- [x] Existing TTS tests pass unchanged (default behavior preserved)
- [x] New tests verify `response_format` is included in payload and `content_type` is mapped correctly (OpenAI + OpenAI-compatible)
- [ ] Manual test with mlx-audio/Kokoro endpoint using `response_format="wav"`