### PR TITLE
feat: add Zaps.ai as a first-class provider

### DIFF
--- a/src/esperanto/factory.py
+++ b/src/esperanto/factory.py
@@ -31,6 +31,7 @@ class AIFactory:
             "mistral": "esperanto.providers.llm.mistral:MistralLanguageModel",
             "deepseek": "esperanto.providers.llm.deepseek:DeepSeekLanguageModel",
             "vertex": "esperanto.providers.llm.vertex:VertexLanguageModel",
+            "zaps": "esperanto.providers.llm.zaps:ZapsLanguageModel",
         },
         "embedding": {
             "openai": "esperanto.providers.embedding.openai:OpenAIEmbeddingModel",
@@ -44,6 +45,7 @@ class AIFactory:
             "azure": "esperanto.providers.embedding.azure:AzureEmbeddingModel",
             "jina": "esperanto.providers.embedding.jina:JinaEmbeddingModel",
             "openrouter": "esperanto.providers.embedding.openrouter:OpenRouterEmbeddingModel",
+            "zaps": "esperanto.providers.embedding.zaps:ZapsEmbeddingModel",
         },
         "speech_to_text": {
             "openai": "esperanto.providers.stt.openai:OpenAISpeechToTextModel",

--- a/src/esperanto/providers/embedding/zaps.py
+++ b/src/esperanto/providers/embedding/zaps.py
@@ -1,0 +1,67 @@
+"""Zaps.ai embedding model provider."""
+
+import os
+from typing import Dict, List, Optional
+
+from esperanto.common_types import Model
+from esperanto.providers.embedding.openai import OpenAIEmbeddingModel
+
+
+class ZapsEmbeddingModel(OpenAIEmbeddingModel):
+    """Zaps.ai embedding model implementation using OpenAI-compatible API.
+
+    Zaps.ai acts as a privacy gateway — requests pass through Zaps for PII
+    redaction before being forwarded to the upstream provider.
+    """
+
+    def __init__(self, **kwargs):
+        # Extract api_key and base_url from config dict first
+        config = kwargs.get("config", {})
+        if config:
+            if "api_key" in config:
+                kwargs["api_key"] = config["api_key"]
+            if "base_url" in config:
+                kwargs["base_url"] = config["base_url"]
+
+        # Set Zaps-specific defaults before parent init
+        if not kwargs.get("api_key"):
+            kwargs["api_key"] = os.getenv("ZAPS_API_KEY")
+        if not kwargs.get("base_url"):
+            kwargs["base_url"] = os.getenv(
+                "ZAPS_BASE_URL", "https://api.zaps.ai/v1"
+            )
+
+        if not kwargs.get("api_key"):
+            raise ValueError(
+                "Zaps API key not found. Set the ZAPS_API_KEY environment variable."
+            )
+
+        super().__init__(**kwargs)
+
+    def _get_default_model(self) -> str:
+        """Get the default model name."""
+        return "text-embedding-3-small"
+
+    @property
+    def provider(self) -> str:
+        """Get the provider name."""
+        return "zaps"
+
+    def _get_models(self) -> List[Model]:
+        """List all available models for this provider."""
+        response = self.client.get(
+            f"{self.base_url}/models",
+            headers=self._get_headers(),
+        )
+        self._handle_error(response)
+
+        models_data = response.json()
+        return [
+            Model(
+                id=model["id"],
+                owned_by=model.get("owned_by", "zaps"),
+                context_window=model.get("context_window", None),
+            )
+            for model in models_data["data"]
+            if "embedding" in model["id"]
+        ]

--- a/src/esperanto/providers/llm/zaps.py
+++ b/src/esperanto/providers/llm/zaps.py
@@ -1,0 +1,89 @@
+"""Zaps.ai language model implementation."""
+
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from esperanto.common_types import Model
+from esperanto.providers.llm.openai import OpenAILanguageModel
+from esperanto.utils.logging import logger
+
+if TYPE_CHECKING:
+    from langchain_openai import ChatOpenAI
+
+
+@dataclass
+class ZapsLanguageModel(OpenAILanguageModel):
+    """Zaps.ai language model implementation using OpenAI-compatible API.
+
+    Zaps.ai acts as a privacy gateway — requests pass through Zaps for PII
+    redaction before being forwarded to the upstream provider.
+    """
+
+    base_url: Optional[str] = None
+    api_key: Optional[str] = None
+    model_name: str = "gpt-4o"
+
+    @property
+    def provider(self) -> str:
+        return "zaps"
+
+    def __post_init__(self):
+        # Extract api_key and base_url from config dict first (before parent sets OpenAI defaults)
+        if hasattr(self, "config") and self.config:
+            if "api_key" in self.config:
+                self.api_key = self.config["api_key"]
+            if "base_url" in self.config:
+                self.base_url = self.config["base_url"]
+
+        # Initialize Zaps-specific configuration
+        self.base_url = self.base_url or os.getenv(
+            "ZAPS_BASE_URL", "https://api.zaps.ai/v1"
+        )
+        self.api_key = self.api_key or os.getenv("ZAPS_API_KEY")
+        self.model_name = self.model_name or "gpt-4o"
+
+        if not self.api_key:
+            raise ValueError(
+                "Zaps API key not found. Set the ZAPS_API_KEY environment variable."
+            )
+
+        # Call parent's post_init (won't overwrite since values are already set)
+        super().__post_init__()
+
+    def _get_default_model(self) -> str:
+        """Get the default model name."""
+        return "gpt-4o"
+
+    def to_langchain(self) -> "ChatOpenAI":
+        """Convert to a LangChain chat model.
+
+        Raises:
+            ImportError: If langchain_openai is not installed.
+        """
+        try:
+            from langchain_openai import ChatOpenAI
+        except ImportError as e:
+            raise ImportError(
+                "Langchain integration requires langchain_openai. "
+                "Install with: uv add langchain_openai or pip install langchain_openai"
+            ) from e
+
+        langchain_kwargs = {
+            "max_tokens": self.max_tokens,
+            "temperature": self.temperature,
+            "top_p": self.top_p,
+            "streaming": self.streaming,
+            "api_key": self.api_key,
+            "base_url": self.base_url,
+            "organization": self.organization,
+            "model": self.get_model_name(),
+            "model_kwargs": {},
+        }
+
+        model_name = self.get_model_name()
+        if not model_name:
+            raise ValueError("Model name is required for Langchain integration.")
+        langchain_kwargs["model"] = model_name
+
+        return ChatOpenAI(**self._clean_config(langchain_kwargs))


### PR DESCRIPTION
## Summary

Adds [Zaps.ai](https://zaps.ai) as a first-class provider in Esperanto, covering **Language Models** and **Embeddings**.

Zaps.ai is a **privacy gateway** — requests are routed through Zaps for automatic PII redaction before being forwarded to the upstream provider (OpenAI, Anthropic, etc.). It exposes an OpenAI-compatible API.

## Changes

### New Files
- `src/esperanto/providers/llm/zaps.py` — `ZapsLanguageModel` (extends `OpenAILanguageModel`)
- `src/esperanto/providers/embedding/zaps.py` — `ZapsEmbeddingModel` (extends `OpenAIEmbeddingModel`)

### Modified Files
- `src/esperanto/factory.py` — Registered `zaps` in `language` and `embedding` provider modules
- `src/esperanto/model_discovery.py` — Added `get_zaps_models()` discovery function + registry entry

## Configuration

| Env Variable | Description | Default |
|---|---|---|
| `ZAPS_API_KEY` | API key for Zaps.ai | (required) |
| `ZAPS_BASE_URL` | Base URL | `https://api.zaps.ai/v1` |

## Usage

```python
from esperanto.factory import AIFactory

# Language Model
model = AIFactory.create_language('zaps', 'gpt-4o')
response = model.chat_complete([{'role': 'user', 'content': 'Hello!'}])

# Embeddings
embedder = AIFactory.create_embedding('zaps', 'text-embedding-3-small')
vectors = embedder.embed(['Privacy is important'])
```

## Testing
All factory registration and provider instantiation tests pass locally.