### PR TITLE
fix: add encoding_format to openai-compatible embeddings and update Azure docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.19.5] - 2026-03-10
+
+### Fixed
+
+- **OpenAI-compatible embeddings return base64 instead of float** - Added `encoding_format: "float"` to OpenAI-compatible embedding payloads (both sync and async). Some providers (e.g., OpenRouter) return base64-encoded embeddings when `encoding_format` is not explicitly set, causing `"could not convert string to float"` errors at parse time.
+
+### Changed
+
+- **Azure documentation: recommend latest API version** - Updated all Azure provider documentation examples to recommend `2024-10-21` (latest stable) instead of the outdated `2024-02-01`.
+
 ## [2.19.4] - 2026-02-17
 
 ### Fixed

--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -43,7 +43,7 @@ model = AIFactory.create_language("azure", "my-gpt4-deployment")
 # Generic (works for all modalities)
 AZURE_OPENAI_API_KEY="your-azure-api-key"
 AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com/"
-AZURE_OPENAI_API_VERSION="2024-02-01"
+AZURE_OPENAI_API_VERSION="2024-10-21"
 
 # Modality-specific (takes precedence over generic)
 # Use these when you want different deployments for different AI capabilities
@@ -51,7 +51,7 @@ AZURE_OPENAI_API_VERSION="2024-02-01"
 # Language Models
 # AZURE_OPENAI_API_KEY_LLM="your-llm-key"
 # AZURE_OPENAI_ENDPOINT_LLM="https://your-llm-resource.openai.azure.com/"
-# AZURE_OPENAI_API_VERSION_LLM="2024-02-01"
+# AZURE_OPENAI_API_VERSION_LLM="2024-10-21"
 
 # Embeddings
 # AZURE_OPENAI_API_KEY_EMBEDDING="your-embedding-key"
@@ -61,12 +61,12 @@ AZURE_OPENAI_API_VERSION="2024-02-01"
 # Speech-to-Text
 # AZURE_OPENAI_API_KEY_STT="your-stt-key"
 # AZURE_OPENAI_ENDPOINT_STT="https://your-stt-resource.openai.azure.com/"
-# AZURE_OPENAI_API_VERSION_STT="2024-02-01"
+# AZURE_OPENAI_API_VERSION_STT="2024-10-21"
 
 # Text-to-Speech
 # AZURE_OPENAI_API_KEY_TTS="your-tts-key"
 # AZURE_OPENAI_ENDPOINT_TTS="https://your-tts-resource.openai.azure.com/"
-# AZURE_OPENAI_API_VERSION_TTS="2024-02-01"
+# AZURE_OPENAI_API_VERSION_TTS="2024-10-21"
 ```
 
 **Variable Priority:**
@@ -106,7 +106,7 @@ from esperanto.providers.text_to_speech.azure import AzureTextToSpeech
 llm = AzureLanguageModel(
     api_key="your-azure-key",
     azure_endpoint="https://your-resource.openai.azure.com/",
-    api_version="2024-02-01",
+    api_version="2024-10-21",
     model_name="your-deployment-name"
 )
 
@@ -122,7 +122,7 @@ embedder = AzureEmbeddingModel(
 stt = AzureSpeechToText(
     api_key="your-azure-key",
     azure_endpoint="https://your-resource.openai.azure.com/",
-    api_version="2024-02-01",
+    api_version="2024-10-21",
     model_name="your-whisper-deployment"
 )
 
@@ -130,7 +130,7 @@ stt = AzureSpeechToText(
 tts = AzureTextToSpeech(
     api_key="your-azure-key",
     azure_endpoint="https://your-resource.openai.azure.com/",
-    api_version="2024-02-01",
+    api_version="2024-10-21",
     model_name="your-tts-deployment"
 )
 ```
@@ -193,7 +193,7 @@ model = AIFactory.create_language(
     config={
         "api_key": "your-azure-key",
         "azure_endpoint": "https://your-resource.openai.azure.com/",
-        "api_version": "2024-02-01",
+        "api_version": "2024-10-21",
         "temperature": 0.7,
         "structured": {"type": "json"}  # Azure supports JSON mode
     }
@@ -512,9 +512,9 @@ Error: Failed to connect
 ```
 Error: Invalid API version
 ```
-**Solution:** Use a valid API version. Common versions:
-- `2024-02-01` - General use
-- `2024-12-01-preview` - Embeddings with custom dimensions
+**Solution:** Use a valid API version. Recommended:
+- `2024-10-21` - Latest stable version (recommended for all modalities)
+- `2024-12-01-preview` - Preview features (e.g., embeddings with custom dimensions)
 
 **Rate Limit Error:**
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esperanto"
-version = "2.19.4"
+version = "2.19.5"
 description = "A light-weight, production-ready, unified interface for various AI model providers"
 authors = [
     { name = "LUIS NOVO", email = "lfnovo@gmail.com" }

--- a/src/esperanto/providers/embedding/openai_compatible.py
+++ b/src/esperanto/providers/embedding/openai_compatible.py
@@ -202,6 +202,7 @@ class OpenAICompatibleEmbeddingModel(EmbeddingModel):
             payload = {
                 "input": texts,
                 "model": self.get_model_name(),
+                "encoding_format": "float",
                 **{**self._get_api_kwargs(), **kwargs},
             }
 
@@ -242,6 +243,7 @@ class OpenAICompatibleEmbeddingModel(EmbeddingModel):
             payload = {
                 "input": texts,
                 "model": self.get_model_name(),
+                "encoding_format": "float",
                 **{**self._get_api_kwargs(), **kwargs},
             }
 

--- a/uv.lock
+++ b/uv.lock
@@ -497,7 +497,7 @@ wheels = [
 
 [[package]]
 name = "esperanto"
-version = "2.19.3"
+version = "2.19.5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Add `encoding_format: "float"` to `openai_compatible.py` embedding payloads (both sync and async) to prevent base64-encoded responses from providers that require explicit format specification (fixes Open Notebook #610)
- Update Azure provider documentation to recommend API version `2024-10-21` across all modalities instead of outdated `2024-02-01` (addresses Open Notebook #637)

## Test plan

- [x] Existing test suite passes (21 tests, all green)
- [x] `encoding_format` already validated in `test_embed_with_additional_kwargs`