### PR TITLE
fix: OllamaEmbeddingModel ignores base_url from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.19.6] - 2026-03-11
+
+### Fixed
+
+- **OllamaEmbeddingModel ignores `base_url` from config** - Fixed `OllamaEmbeddingModel.__post_init__` reading `base_url` from `kwargs` instead of `self.base_url`, causing config-provided and factory-provided base URLs to be silently overwritten by the environment variable fallback or localhost default.
+
 ## [2.19.5] - 2026-03-10
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esperanto"
-version = "2.19.5"
+version = "2.19.6"
 description = "A light-weight, production-ready, unified interface for various AI model providers"
 authors = [
     { name = "LUIS NOVO", email = "lfnovo@gmail.com" }

--- a/src/esperanto/providers/embedding/ollama.py
+++ b/src/esperanto/providers/embedding/ollama.py
@@ -16,7 +16,7 @@ class OllamaEmbeddingModel(EmbeddingModel):
 
         # Set default base URL if not provided
         self.base_url = (
-            kwargs.get("base_url")
+            self.base_url
             or os.getenv("OLLAMA_BASE_URL") or os.getenv("OLLAMA_API_BASE")
             or "http://localhost:11434"
         )


### PR DESCRIPTION
## Summary

- Fix `OllamaEmbeddingModel` reading `base_url` from `kwargs` instead of `self.base_url`, which caused config/factory-provided base URLs to be silently ignored
- Bump version to 2.19.6 and update CHANGELOG

Closes #90