### PR TITLE
fix: use self.* instead of kwargs.get() in embedding providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.19.7] - 2026-03-11
+
+### Fixed
+
+- **Azure embedding provider ignores `api_key` and `base_url` from config** - Fixed `AzureEmbeddingModel` reading `api_key` and `base_url` from `kwargs` instead of `self.*`, causing config-provided values to be silently ignored.
+- **Embedding providers have redundant `kwargs.get()` fallbacks** - Cleaned up dead code in OpenAI, Voyage, Google, and Jina embedding providers that redundantly read `api_key`/`base_url` from `kwargs` after the base class already set them on `self.*`.
+
 ## [2.19.6] - 2026-03-11
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esperanto"
-version = "2.19.6"
+version = "2.19.7"
 description = "A light-weight, production-ready, unified interface for various AI model providers"
 authors = [
     { name = "LUIS NOVO", email = "lfnovo@gmail.com" }

--- a/src/esperanto/providers/embedding/azure.py
+++ b/src/esperanto/providers/embedding/azure.py
@@ -23,16 +23,16 @@ class AzureEmbeddingModel(EmbeddingModel):
 
         super().__init__(**kwargs)
 
-        # Resolve configuration with priority: kwargs → config dict → modality env var → generic env var
+        # Resolve configuration with priority: self (set by super) → config dict → modality env var → generic env var
         self.api_key = (
-            kwargs.get("api_key") or
+            self.api_key or
             self._config.get("api_key") or
             os.getenv("AZURE_OPENAI_API_KEY_EMBEDDING") or
             os.getenv("AZURE_OPENAI_API_KEY")
         )
 
         self.azure_endpoint = (
-            kwargs.get("base_url") or
+            self.base_url or
             azure_endpoint or
             self._config.get("azure_endpoint") or
             os.getenv("AZURE_OPENAI_ENDPOINT_EMBEDDING") or

--- a/src/esperanto/providers/embedding/azure.py
+++ b/src/esperanto/providers/embedding/azure.py
@@ -32,8 +32,8 @@ class AzureEmbeddingModel(EmbeddingModel):
         )
 
         self.azure_endpoint = (
-            self.base_url or
             azure_endpoint or
+            self.base_url or
             self._config.get("azure_endpoint") or
             os.getenv("AZURE_OPENAI_ENDPOINT_EMBEDDING") or
             os.getenv("AZURE_OPENAI_ENDPOINT")

--- a/src/esperanto/providers/embedding/google.py
+++ b/src/esperanto/providers/embedding/google.py
@@ -34,8 +34,6 @@ class GoogleEmbeddingModel(EmbeddingModel):
         # Get API key
         self.api_key = (
             self.api_key
-            or kwargs.get("api_key")
-            or (self.config or {}).get("api_key")
             or os.getenv("GOOGLE_API_KEY")
             or os.getenv("GEMINI_API_KEY")
         )

--- a/src/esperanto/providers/embedding/jina.py
+++ b/src/esperanto/providers/embedding/jina.py
@@ -41,8 +41,6 @@ class JinaEmbeddingModel(EmbeddingModel):
         super().__init__(**kwargs)
         self.api_key = (
             self.api_key
-            or kwargs.get("api_key")
-            or (self.config or {}).get("api_key")
             or os.getenv("JINA_API_KEY")
         )
         if not self.api_key:
@@ -52,8 +50,6 @@ class JinaEmbeddingModel(EmbeddingModel):
             )
         self.base_url = (
             self.base_url
-            or kwargs.get("base_url")
-            or (self.config or {}).get("base_url")
             or "https://api.jina.ai/v1/embeddings"
         )
 

--- a/src/esperanto/providers/embedding/openai.py
+++ b/src/esperanto/providers/embedding/openai.py
@@ -16,8 +16,6 @@ class OpenAIEmbeddingModel(EmbeddingModel):
         # Get API key
         self.api_key = (
             self.api_key
-            or kwargs.get("api_key")
-            or (self.config or {}).get("api_key")
             or os.getenv("OPENAI_API_KEY")
         )
         if not self.api_key:

--- a/src/esperanto/providers/embedding/voyage.py
+++ b/src/esperanto/providers/embedding/voyage.py
@@ -22,8 +22,6 @@ class VoyageEmbeddingModel(EmbeddingModel):
         # Get API key
         self.api_key = (
             self.api_key
-            or kwargs.get("api_key")
-            or (self.config or {}).get("api_key")
             or os.getenv("VOYAGE_API_KEY")
         )
         if not self.api_key:


### PR DESCRIPTION
## Summary

- Fix Azure embedding provider ignoring `api_key` and `base_url` from config dict (same bug pattern as #90)
- Clean up redundant `kwargs.get()` fallbacks in OpenAI, Voyage, Google, and Jina embedding providers — the base class `__post_init__()` already sets `self.api_key`/`self.base_url` from both top-level kwargs and config dict
- Bump version to 2.19.7 and update CHANGELOG

## Affected providers

| Provider | Issue |
|----------|-------|
| Azure | Bug: `kwargs.get()` used first, ignoring config values |
| OpenAI | Cleanup: redundant `kwargs.get()` after `self.*` |
| Voyage | Cleanup: redundant `kwargs.get()` after `self.*` |
| Google | Cleanup: redundant `kwargs.get()` after `self.*` |
| Jina | Cleanup: redundant `kwargs.get()` after `self.*` |

## Test plan

- [x] All embedding provider tests pass (141 passed)