### PR TITLE
feat: OpenAI-compatible provider profiles

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,184 @@
+# Architecture & Design Principles
+
+This document defines the core design principles that guide Esperanto's development. **Please read this before contributing** — it will save you time and help us review your work faster.
+
+## Core Principle: Provider Parity
+
+Esperanto's entire value proposition is a **consistent, provider-agnostic interface**. Users can switch providers by changing one parameter, with identical code otherwise:
+
+```python
+# Same code, different provider — this is the promise
+model = AIFactory.create_language("openai", "gpt-4o")
+model = AIFactory.create_language("anthropic", "claude-sonnet-4-20250514")
+model = AIFactory.create_language("google", "gemini-2.0-flash")
+
+response = model.chat_complete(messages)  # identical API for all
+```
+
+This means:
+
+1. **New features must work across all (or most) providers.** If a feature only makes sense for one provider, it probably doesn't belong in the public interface. Open an issue to discuss the cross-provider design before implementing.
+
+2. **Interface consistency > feature count.** We'd rather ship a feature later with full provider support than ship it early for one provider. Partial implementations create an inconsistent API surface that breaks the core promise.
+
+3. **Graceful degradation when needed.** Some providers genuinely can't support certain features. In those rare cases, raise a clear error — never silently ignore or return unexpected results. The user should always know what to expect.
+
+## Provider Tiers
+
+Not all providers require the same level of implementation effort. We classify them into tiers:
+
+### First-class Providers
+
+Providers with a fundamentally different API or SDK that requires unique implementation logic:
+
+- **OpenAI** — the reference implementation
+- **Anthropic** — different message format, tool format, content blocks
+- **Google / Vertex AI** — parts-based format, GCP authentication
+- **Azure** — deployment-based naming, Azure-specific auth
+- **Ollama** — local execution, no auth, options dict
+- **Mistral** — different tool format
+
+These justify their own provider class with custom logic.
+
+### Extended Providers
+
+Providers that are OpenAI-compatible but add meaningful unique capabilities that require code:
+
+- **Perplexity** — web search options, custom streaming behavior
+
+### Profile-based Providers (OpenAI-Compatible)
+
+Providers that are OpenAI-compatible with a different `base_url` and API key. These are implemented as **profiles** — declarative config objects — not Python classes:
+
+- **DeepSeek** — just changes `base_url` and API key
+- **xAI** — changes `base_url`, disables `response_format`, filters models to `grok-*`
+- **DashScope (Qwen)** — Alibaba Cloud's OpenAI-compatible endpoint
+- **MiniMax** — OpenAI-compatible endpoint
+
+Profiles are defined in `src/esperanto/providers/llm/profiles.py` and resolved by the factory at runtime. Adding a new OpenAI-compatible provider is a **6-line config change**, not a new class:
+
+```python
+"minimax": OpenAICompatibleProfile(
+    name="minimax",
+    base_url="https://api.minimax.io/v1",
+    api_key_env="MINIMAX_API_KEY",
+    default_model="MiniMax-M2.5",
+    owned_by="MiniMax",
+    display_name="MiniMax",
+),
+```
+
+Users can also register their own profiles at runtime:
+
+```python
+from esperanto import AIFactory, OpenAICompatibleProfile
+
+AIFactory.register_openai_compatible_profile(
+    OpenAICompatibleProfile(
+        name="together",
+        base_url="https://api.together.xyz/v1",
+        api_key_env="TOGETHER_API_KEY",
+        default_model="meta-llama/Llama-3-70b-chat-hf",
+    )
+)
+model = AIFactory.create_language("together", "meta-llama/Llama-3-70b-chat-hf")
+```
+
+### Extended Providers (OpenAI-Compatible with Custom Code)
+
+Providers that are OpenAI-compatible but add unique behavior that can't be expressed as config:
+
+- **OpenRouter** — custom HTTP headers, selective `response_format` by model, custom HTTP request format
+- **Perplexity** — web search parameters, custom streaming behavior
+
+These keep their own Python classes because their customizations go beyond what a profile can express.
+
+### When to Add a New Provider
+
+Before implementing a new provider, ask yourself:
+
+1. **Is it OpenAI-compatible?** If yes, add a profile in `profiles.py` — don't create a new class. This covers the vast majority of new provider requests.
+2. **Does it need custom behavior beyond base_url/api_key/model filtering?** Custom headers, unique parameters, special error handling? If yes, it may need a class that extends `OpenAICompatibleLanguageModel`.
+3. **Does it have a fundamentally different API?** Different message format, auth mechanism, or response structure? Then it needs a first-class provider class.
+4. **Can it support the full interface?** A provider that can only do `chat_complete` but not streaming, tools, or structured output may not be ready for first-class support.
+
+When in doubt, open an issue. We'd rather discuss the design upfront than review a PR that doesn't align with these principles.
+
+## Architecture Overview
+
+### Provider Pattern
+
+All provider types follow the same structure:
+
+```
+Base class (abstract interface)
+  -> Provider implementation (API integration)
+    -> Factory registration (discoverability)
+      -> Common response types (consistency)
+```
+
+### Configuration Priority
+
+Three-tier configuration system (highest to lowest priority):
+
+1. **Constructor args / config dict**: `config={"timeout": 120}`
+2. **Environment variables**: `ESPERANTO_LLM_TIMEOUT=90`
+3. **Provider defaults**
+
+### Provider Composition
+
+Providers inherit functionality via mixins:
+
+- `TimeoutMixin` — configurable HTTP timeouts
+- `SSLMixin` — configurable SSL verification
+- Base class (e.g., `LanguageModel`) — provider-specific interface
+- Provider implementation — actual API integration
+
+### Response Types
+
+All providers convert API-specific responses into Esperanto's common types:
+
+| Type | Response |
+|------|----------|
+| Language | `ChatCompletion` / `ChatCompletionChunk` |
+| Embedding | `List[List[float]]` |
+| Reranker | `RerankResponse` |
+| Speech-to-Text | `TranscriptionResponse` |
+| Text-to-Speech | `AudioResponse` |
+
+This normalization is what enables the provider-agnostic interface.
+
+## Testing Philosophy
+
+With 40+ provider implementations across 5 provider types, manual testing is impractical. We rely heavily on automated tests:
+
+- **Every provider must have unit tests** that mock API responses and verify the Esperanto response format.
+- **Every feature must be tested across all providers that support it.** A feature that works for OpenAI but breaks on Anthropic is a bug, not a partial implementation.
+- **Test the interface, not the internals.** Tests should verify that `chat_complete()` returns the right `ChatCompletion` regardless of provider — not test provider-specific parsing logic in isolation.
+
+Run the full test suite before submitting:
+
+```bash
+uv run pytest -v
+```
+
+## Key Design Decisions
+
+### Why Not Just Wrap LangChain/LiteLLM?
+
+Esperanto is a lightweight, focused library. We control the interface, the response types, and the provider implementations. This gives us:
+
+- Predictable behavior across providers
+- Minimal dependencies (only install SDKs for providers you use)
+- First-class async support without adapter layers
+- Direct control over streaming, tool calling, and structured output formats
+
+### Why Optional Dependencies?
+
+Each provider SDK is an optional dependency. Users only install what they need:
+
+```bash
+pip install esperanto[openai,anthropic]  # only these two
+```
+
+This keeps the base install small and avoids dependency conflicts between provider SDKs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.20.0] - 2026-03-21
+
+### Added
+
+- **OpenAI-compatible provider profiles** — config-driven virtual providers that eliminate the need for separate Python classes for each OpenAI-compatible endpoint. Add a new provider with 6 lines of config instead of a new file. Users can also register custom profiles at runtime via `AIFactory.register_openai_compatible_profile()`.
+- **DashScope (Qwen) provider** — Alibaba Cloud's Qwen models via OpenAI-compatible profile (`qwen-turbo`, `qwen-plus`, `qwen-max`).
+- **MiniMax provider** — MiniMax models via OpenAI-compatible profile (`MiniMax-M2.5`, `MiniMax-M2.5-highspeed` with 204K context).
+- **`OpenAICompatibleProfile`** exported from `esperanto` for custom provider registration.
+- **`ARCHITECTURE.md`** — design principles and contributor guide for the project.
+- **`CONTRIBUTING.md`** — rewritten with practical guidance, provider addition checklist, and link to ARCHITECTURE.md.
+
+### Changed
+
+- **DeepSeek and xAI providers migrated to profiles** — both now use `OpenAICompatibleLanguageModel` configured by profile data instead of dedicated provider classes. The factory API is unchanged: `AIFactory.create_language("deepseek", ...)` works exactly as before.
+- **`OpenAICompatibleLanguageModel._normalize_response` now extracts tool calls** — previously tool_calls in API responses were silently dropped. This was a pre-existing bug that surfaced during the migration.
+
+### Deprecated
+
+- **`DeepSeekLanguageModel` direct instantiation** — use `AIFactory.create_language("deepseek", ...)` instead. Direct import still works but emits `DeprecationWarning`.
+- **`XAILanguageModel` direct instantiation** — use `AIFactory.create_language("xai", ...)` instead. Direct import still works but emits `DeprecationWarning`.
+
 ## [2.19.7] - 2026-03-11
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,8 +247,11 @@ All providers use utility mixins:
 
 ## Critical Principles
 
-1. **Consistency > Features**: If a feature can't be consistent across providers, reconsider
-2. **Interface First**: Design interfaces before implementing providers
-3. **Test Driven**: Write tests as you implement, run frequently
-4. **Documentation**: Keep both human and AI docs in sync with code
-5. **Provider Parity**: New features should work across multiple providers when possible
+See @ARCHITECTURE.md for the full design principles. The key rules:
+
+1. **Provider Parity**: New features MUST work across all (or most) providers. Partial implementations are not acceptable — they break the core promise of a provider-agnostic interface.
+2. **Consistency > Features**: If a feature can't be consistent across providers, reconsider. We'd rather ship later with full support than early with partial support.
+3. **Interface First**: Design interfaces before implementing providers.
+4. **Provider Tiers**: Not every provider needs its own class. OpenAI-compatible providers should use `OpenAICompatibleLanguageModel` unless they have fundamentally different APIs. See ARCHITECTURE.md for tier definitions.
+5. **Test Driven**: Write tests as you implement, run frequently. Every feature must be tested across all affected providers.
+6. **Documentation**: Keep both human and AI docs in sync with code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,54 +1,67 @@
 # Contributing to Esperanto
 
-First off, thank you for considering contributing to Esperanto! It's people like you that make Esperanto such a great tool.
+Thank you for considering contributing to Esperanto! Before you start, please read our [Architecture & Design Principles](ARCHITECTURE.md) — it explains the core decisions behind the project and will help you write contributions that align with the project's direction.
 
 ## Code of Conduct
 
 This project and everyone participating in it is governed by our Code of Conduct. By participating, you are expected to uphold this code.
 
-## How Can I Contribute?
+## Before You Start
+
+### Read the Architecture Guide
+
+The most common reason PRs need significant rework is a mismatch with our design principles. The [ARCHITECTURE.md](ARCHITECTURE.md) covers:
+
+- **Provider parity**: New features must work across all (or most) providers
+- **Provider tiers**: When a new provider class is justified vs. using OpenAI-Compatible
+- **Testing philosophy**: What we expect in terms of test coverage
+
+### Open an Issue First
+
+For non-trivial changes (new features, new providers, architectural changes), **open an issue before writing code**. This lets us discuss the design and avoid wasted effort. Bug fixes and documentation improvements can go straight to a PR.
+
+## How to Contribute
 
 ### Reporting Bugs
 
-Before creating bug reports, please check the issue list as you might find out that you don't need to create one. When you are creating a bug report, please include as many details as possible:
-
-* Use a clear and descriptive title
-* Describe the exact steps which reproduce the problem
-* Provide specific examples to demonstrate the steps
-* Describe the behavior you observed after following the steps
-* Explain which behavior you expected to see instead and why
-* Include any error messages
-
-### Suggesting Enhancements
-
-If you have a suggestion for a new feature or enhancement, first check the issue list to see if it's already been proposed. If it hasn't, you can create a new issue. Please provide:
+Before creating bug reports, check the issue list. When creating a bug report, include:
 
 * A clear and descriptive title
-* A detailed description of the proposed feature
-* An explanation of why this enhancement would be useful
-* Examples of how the feature would be used
+* Steps to reproduce the problem
+* Expected vs. actual behavior
+* Error messages and stack traces
+* Provider and model being used
+
+### Suggesting Features
+
+Open an issue with:
+
+* A description of the feature
+* Which providers it would apply to (ideally all of them)
+* Example usage code showing the desired API
 
 ### Pull Requests
 
 1. Fork the repository
-2. Create a new branch for your feature (`git checkout -b feature/amazing-feature`)
+2. Create a feature branch (`git checkout -b feature/amazing-feature`)
 3. Make your changes
-4. Run the tests (`pytest`)
-5. Commit your changes (`git commit -m 'Add some amazing feature'`)
-6. Push to the branch (`git push origin feature/amazing-feature`)
-7. Open a Pull Request
+4. Run the tests (`uv run pytest -v`)
+5. Run the linter (`uv run ruff check .`)
+6. Commit your changes using [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, etc.)
+7. Push and open a Pull Request
 
-#### Pull Request Guidelines
+#### PR Guidelines
 
-* Follow the existing code style
-* Write tests for new features
-* Update documentation for any changes
+* **Read [ARCHITECTURE.md](ARCHITECTURE.md)** before implementing
+* Follow existing code style and patterns
+* Write tests for new features — test across all affected providers
+* Update documentation for any user-facing changes
 * Keep commits focused and atomic
-* Use clear commit messages
+* One feature/fix per PR
 
 ## Development Setup
 
-1. Clone the repository
+1. Clone the repository:
 ```bash
 git clone https://github.com/lfnovo/esperanto.git
 cd esperanto
@@ -61,34 +74,24 @@ source .venv/bin/activate
 uv sync --group dev
 ```
 
-Note: If you need the `transformers` extra (for local model support), use:
+If you need the `transformers` extra (for local model support):
 ```bash
 uv sync --group dev --extra transformers
 ```
 
 3. Run tests:
 ```bash
-pytest
+uv run pytest -v
 ```
 
 4. Run linting:
 ```bash
-ruff check .
-mypy .
+uv run ruff check .
 ```
 
-## Code Style and Linting
-
-We use `ruff` for code linting and formatting. Before submitting a PR, make sure to:
-
-1. Run the linter to check for issues:
+Fix auto-fixable issues:
 ```bash
-ruff check .
-```
-
-2. Fix auto-fixable issues:
-```bash
-ruff check . --fix
+uv run ruff check . --fix
 ```
 
 The project's ruff configuration is in `pyproject.toml` and enforces:
@@ -96,17 +99,58 @@ The project's ruff configuration is in `pyproject.toml` and enforces:
 - Standard Python style rules (E, F)
 - Import sorting (I)
 
-## Testing
+## Adding a New Provider
 
-* Write tests for any new features
-* Ensure all tests pass before submitting a PR
-* Run the full test suite with `pytest`
+This is the most common type of contribution. To keep Esperanto maintainable, we have clear criteria for what we accept.
 
-## Documentation
+### Acceptance Criteria
 
-* Update the README.md if needed
-* Add docstrings for new functions and classes
-* Keep documentation clear and concise
+| Scenario | What to do |
+|----------|------------|
+| **OpenAI-compatible, no extra dependency** (just a different base_url and API key) | Add a profile in `src/esperanto/providers/llm/profiles.py`. We accept these for providers with demonstrated adoption (public docs, active pricing page, presence in LLM benchmarks/rankings). Profiles are ~6 lines of config, so the maintenance cost is minimal. |
+| **Requires a new SDK dependency** (e.g., a provider-specific Python package) | The SDK must have **>500k monthly downloads on PyPI** consistently over 3+ months. This ensures we're not taking on maintenance burden for niche dependencies. |
+| **OpenAI-compatible but needs custom behavior** (custom headers, special error handling, unique parameters) | Open an issue first. May justify a class extending `OpenAICompatibleLanguageModel`, but we'll evaluate case by case. |
+| **Fundamentally different API** (non-OpenAI message format, unique auth) | Open an issue first. Needs a first-class provider class. Must meet the SDK download threshold if it adds a dependency. |
+| **Doesn't meet the above criteria** | Register it yourself at runtime using `AIFactory.register_openai_compatible_profile()` in your own code. No PR needed — this is a feature, not a limitation. |
+
+### Adding a Profile (OpenAI-compatible providers)
+
+Most new provider requests are OpenAI-compatible endpoints. These are handled by adding a profile — no new Python class needed:
+
+1. Add the profile to `BUILTIN_PROFILES` in `src/esperanto/providers/llm/profiles.py`
+2. Add tests in `tests/providers/llm/test_profiles.py`
+3. Add docs in `docs/providers/{provider}.md`
+4. Update provider matrices in `README.md`, `docs/providers/README.md`, `docs/configuration.md`
+5. Run the full test suite: `uv run pytest -v`
+
+### Adding a First-class Provider (unique API)
+
+For providers that need their own class:
+
+1. **Open an issue** describing the provider and why a profile isn't sufficient.
+2. **Read the base class** for your provider type (e.g., `LanguageModel`, `EmbeddingModel`).
+3. **Study 2-3 existing providers** to understand the patterns.
+
+If approved, follow this checklist:
+
+- [ ] Create provider class in `src/esperanto/providers/{type}/{provider}.py`
+- [ ] Implement all abstract methods from the base class
+- [ ] Follow the `__post_init__()` pattern: `super().__post_init__()` first, `_create_http_clients()` last
+- [ ] Register in `factory.py` under `_provider_modules["{type}"]`
+- [ ] Add optional import in `src/esperanto/__init__.py` with try/except
+- [ ] Write tests in `tests/providers/{type}/test_{provider}.py`
+- [ ] Add docs in `docs/providers/{provider}.md`
+- [ ] Run the full test suite: `uv run pytest -v`
+
+## Adding a New Feature
+
+Features that touch the public interface (new parameters, new response fields, new methods) **must work across all relevant providers**. This is our most important design principle.
+
+Before implementing:
+
+1. **Open an issue** with your proposed API design
+2. **Show how it works across at least 3 providers** (e.g., OpenAI, Anthropic, Google)
+3. **Discuss edge cases** — what happens with providers that don't support this feature?
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -172,10 +172,10 @@ providers = AIFactory.get_available_providers()
 print(providers)
 # Output:
 # {
-#     'language': ['openai', 'openai-compatible', 'anthropic', 'google', 'groq', 'ollama', 'openrouter', 'xai', 'perplexity', 'azure', 'mistral', 'deepseek'],
-#     'embedding': ['openai', 'openai-compatible', 'google', 'ollama', 'vertex', 'transformers', 'voyage', 'mistral', 'azure', 'jina'],
+#     'language': ['anthropic', 'azure', 'dashscope', 'deepseek', 'google', 'groq', 'minimax', 'mistral', 'ollama', 'openai', 'openai-compatible', 'openrouter', 'perplexity', 'vertex', 'xai'],
+#     'embedding': ['openai', 'openai-compatible', 'google', 'ollama', 'vertex', 'transformers', 'voyage', 'mistral', 'azure', 'jina', 'openrouter'],
 #     'reranker': ['jina', 'voyage', 'transformers'],
-#     'speech_to_text': ['openai', 'openai-compatible', 'groq', 'elevenlabs', 'azure'],
+#     'speech_to_text': ['openai', 'openai-compatible', 'groq', 'elevenlabs', 'azure', 'google'],
 #     'text_to_speech': ['openai', 'openai-compatible', 'elevenlabs', 'google', 'vertex', 'azure']
 # }
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Whether you're building a quick prototype or a production application serving mi
   - Azure OpenAI (Chat, Embedding, Whisper, TTS)
   - Mistral (Mistral Large, Small, Embedding, etc.)
   - DeepSeek (deepseek-chat)
+  - DashScope / Qwen (qwen-turbo, qwen-plus, qwen-max)
+  - MiniMax (MiniMax-M2.5)
   - Voyage (Embeddings, Reranking)
   - Jina (Advanced embedding models with task optimization, Reranking)
 - **Embedding Support**: Multiple embedding providers for vector representations
@@ -147,7 +149,9 @@ pip install "langchain_deepseek>=0.1.3"
 | DeepSeek     | ✅          | ❌               | ❌                | ❌             | ❌             | ✅        |
 | Voyage       | ❌          | ✅               | ✅                | ❌             | ❌             | ❌        |
 | Jina         | ❌          | ✅               | ✅                | ❌             | ❌             | ❌        |
-| xAI          | ✅          | ❌               | ❌                | ❌             | ❌             | ✅        |
+| xAI          | ✅          | ❌               | ❌                | ❌             | ❌             | ❌        |
+| DashScope    | ✅          | ❌               | ❌                | ❌             | ❌             | ✅        |
+| MiniMax      | ✅          | ❌               | ❌                | ❌             | ❌             | ✅        |
 | OpenRouter   | ✅          | ❌               | ❌                | ❌             | ❌             | ✅        |
 
 *⚠️ OpenAI-Compatible: JSON mode support depends on the specific endpoint implementation

--- a/docs/capabilities/llm.md
+++ b/docs/capabilities/llm.md
@@ -171,7 +171,7 @@ response = model.chat_complete(messages)
 # Response content will be valid JSON
 ```
 
-**Supported Providers**: OpenAI, Anthropic, Google, Groq, OpenAI-Compatible (varies), Mistral, DeepSeek, xAI, OpenRouter, Azure, Perplexity
+**Supported Providers**: OpenAI, Anthropic, Google, Groq, OpenAI-Compatible (varies), Mistral, DeepSeek, xAI, DashScope, MiniMax, OpenRouter, Azure, Perplexity
 
 ## Provider Selection
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,6 +131,20 @@ XAI_API_KEY=...
 
 → **[Full xAI Setup Guide](./providers/xai.md)**
 
+#### DashScope (Qwen)
+```bash
+DASHSCOPE_API_KEY=...
+```
+
+→ **[Full DashScope Setup Guide](./providers/dashscope.md)**
+
+#### MiniMax
+```bash
+MINIMAX_API_KEY=...
+```
+
+→ **[Full MiniMax Setup Guide](./providers/minimax.md)**
+
 #### OpenRouter
 ```bash
 OPENROUTER_API_KEY=...

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -17,7 +17,9 @@ Welcome to the Esperanto provider guide. This page helps you choose the right AI
 | [Mistral](./mistral.md) | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
 | [DeepSeek](./deepseek.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | [Perplexity](./perplexity.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| [xAI](./xai.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| [xAI](./xai.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| [DashScope (Qwen)](./dashscope.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| [MiniMax](./minimax.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | [OpenRouter](./openrouter.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | [Transformers](./transformers.md) | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
 | [Jina](./jina.md) | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
@@ -197,7 +199,9 @@ Welcome to the Esperanto provider guide. This page helps you choose the right AI
 | [Mistral](./mistral.md) | ✅ | ✅ | ✅ | 128K |
 | [DeepSeek](./deepseek.md) | ✅ | ✅ | ✅ | 64K |
 | [Perplexity](./perplexity.md) | ✅ | ✅ | ❌ | 32K |
-| [xAI](./xai.md) | ✅ | ✅ | ✅ | 128K |
+| [xAI](./xai.md) | ✅ | ❌ | ✅ | 128K |
+| [DashScope](./dashscope.md) | ✅ | ✅ | ✅ | 1M (qwen-max-longcontext) |
+| [MiniMax](./minimax.md) | ✅ | ✅ | ✅ | 204K |
 | [OpenRouter](./openrouter.md) | ✅ | ✅ | ✅ | Varies |
 | [Ollama](./ollama.md) | ✅ | ❌ | ✅ | Model-dependent |
 | [OpenAI-Compatible](./openai-compatible.md) | ✅ | ⚠️ | ⚠️ | Endpoint-dependent |
@@ -304,6 +308,8 @@ Require API keys, pay-per-use:
 - [Groq](./groq.md)
 - [Mistral](./mistral.md)
 - [DeepSeek](./deepseek.md)
+- [DashScope (Qwen)](./dashscope.md)
+- [MiniMax](./minimax.md)
 - [Perplexity](./perplexity.md)
 - [xAI](./xai.md)
 - [OpenRouter](./openrouter.md)

--- a/docs/providers/dashscope.md
+++ b/docs/providers/dashscope.md
@@ -1,0 +1,127 @@
+# DashScope (Alibaba Cloud Qwen)
+
+## Overview
+
+DashScope is Alibaba Cloud's AI model service platform, providing access to the Qwen family of models through an OpenAI-compatible API. Qwen models offer strong multilingual performance, especially for Chinese and English tasks.
+
+**Supported Capabilities:**
+
+| Capability | Supported | Notes |
+|------------|-----------|-------|
+| Language Models (LLM) | ✅ | Qwen series (qwen-turbo, qwen-plus, qwen-max) |
+| Embeddings | ❌ | Not available via profile (use OpenAI-Compatible) |
+| Reranking | ❌ | Not available |
+| Speech-to-Text | ❌ | Not available |
+| Text-to-Speech | ❌ | Not available |
+
+**Official Documentation:** https://help.aliyun.com/zh/model-studio/
+
+## Prerequisites
+
+### Account Requirements
+- Alibaba Cloud account with DashScope access
+- API key from the DashScope console
+
+### Getting API Keys
+1. Visit https://dashscope.console.aliyun.com/
+2. Navigate to API Keys management
+3. Create and copy your API key
+
+## Environment Variables
+
+```bash
+# DashScope API key (required)
+DASHSCOPE_API_KEY="sk-..."
+
+# Custom base URL (optional, for international endpoint)
+DASHSCOPE_BASE_URL="https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+```
+
+**Default base URL:** `https://dashscope.aliyuncs.com/compatible-mode/v1`
+
+## Quick Start
+
+```python
+from esperanto.factory import AIFactory
+
+# Create DashScope model
+model = AIFactory.create_language("dashscope", "qwen-plus")
+
+# Chat completion
+messages = [{"role": "user", "content": "Explain quantum computing"}]
+response = model.chat_complete(messages)
+print(response.choices[0].message.content)
+```
+
+## Available Models
+
+| Model | Context Window | Best For |
+|-------|---------------|----------|
+| `qwen-turbo` | 128K | Fast, cost-effective tasks |
+| `qwen-plus` | 128K | Balanced performance and cost |
+| `qwen-max` | 32K | Most capable, complex reasoning |
+| `qwen-max-longcontext` | 1M | Very long document processing |
+
+## Features
+
+### Streaming
+
+```python
+model = AIFactory.create_language("dashscope", "qwen-plus")
+
+for chunk in model.chat_complete(messages, stream=True):
+    print(chunk.choices[0].delta.content, end="")
+```
+
+### JSON Mode
+
+```python
+model = AIFactory.create_language(
+    "dashscope", "qwen-plus",
+    config={"structured": {"type": "json_object"}}
+)
+```
+
+### Tool Calling
+
+```python
+from esperanto.common_types import Tool, ToolFunction
+
+tools = [
+    Tool(function=ToolFunction(
+        name="get_weather",
+        description="Get weather for a city",
+        parameters={"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}
+    ))
+]
+
+response = model.chat_complete(messages, tools=tools)
+```
+
+### Async Support
+
+```python
+response = await model.achat_complete(messages)
+```
+
+## Configuration
+
+```python
+# With explicit API key
+model = AIFactory.create_language(
+    "dashscope", "qwen-plus",
+    config={"api_key": "your-key"}
+)
+
+# With custom base URL (e.g., international endpoint)
+model = AIFactory.create_language(
+    "dashscope", "qwen-plus",
+    config={"base_url": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"}
+)
+```
+
+## Notes
+
+- DashScope uses Alibaba Cloud's OpenAI-compatible endpoint, so all standard Esperanto LLM features (streaming, tool calling, JSON mode) are supported.
+- Some OpenAI-specific parameters like `logit_bias` may not be supported on all models.
+- The `enable_search` DashScope-specific parameter is not exposed through Esperanto's interface. For advanced DashScope features, consider using their native SDK.

--- a/docs/providers/deepseek.md
+++ b/docs/providers/deepseek.md
@@ -54,21 +54,14 @@ response = model.chat_complete(messages)
 print(response.choices[0].message.content)
 ```
 
-### Direct Instantiation
+### Direct Instantiation (Deprecated)
+
+> **Note:** Direct instantiation via `DeepSeekLanguageModel` is deprecated. Use `AIFactory.create_language("deepseek", ...)` instead. DeepSeek is now implemented as an OpenAI-compatible provider profile.
 
 ```python
+# Deprecated — will emit a DeprecationWarning
 from esperanto.providers.llm.deepseek import DeepSeekLanguageModel
-
-# Create model instance
-model = DeepSeekLanguageModel(
-    api_key="your-api-key",
-    model_name="deepseek-chat"
-)
-
-# Use the model
-messages = [{"role": "user", "content": "Hello!"}]
-response = model.chat_complete(messages)
-print(response.choices[0].message.content)
+model = DeepSeekLanguageModel(api_key="your-api-key", model_name="deepseek-chat")
 ```
 
 ## Capabilities

--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -1,0 +1,94 @@
+# MiniMax
+
+## Overview
+
+MiniMax provides high-performance language models with large context windows (204K tokens) at competitive pricing through an OpenAI-compatible API.
+
+**Supported Capabilities:**
+
+| Capability | Supported | Notes |
+|------------|-----------|-------|
+| Language Models (LLM) | ✅ | MiniMax-M2.5 series |
+| Embeddings | ❌ | Not available |
+| Reranking | ❌ | Not available |
+| Speech-to-Text | ❌ | Not available |
+| Text-to-Speech | ❌ | Not available |
+
+**Official Documentation:** https://platform.minimaxi.com/
+
+## Prerequisites
+
+### Account Requirements
+- MiniMax account at https://platform.minimaxi.com/
+- API key with credits
+
+### Getting API Keys
+1. Visit https://platform.minimaxi.com/
+2. Navigate to API Keys
+3. Create and copy your API key
+
+## Environment Variables
+
+```bash
+# MiniMax API key (required)
+MINIMAX_API_KEY="your-api-key"
+```
+
+**Default base URL:** `https://api.minimax.io/v1`
+
+## Quick Start
+
+```python
+from esperanto.factory import AIFactory
+
+# Create MiniMax model
+model = AIFactory.create_language("minimax", "MiniMax-M2.5")
+
+# Chat completion
+messages = [{"role": "user", "content": "Explain quantum computing"}]
+response = model.chat_complete(messages)
+print(response.choices[0].message.content)
+```
+
+## Available Models
+
+| Model | Context Window | Best For |
+|-------|---------------|----------|
+| `MiniMax-M2.5` | 204K | Flagship model, complex tasks |
+| `MiniMax-M2.5-highspeed` | 204K | Faster variant, latency-sensitive tasks |
+
+## Features
+
+### Streaming
+
+```python
+model = AIFactory.create_language("minimax", "MiniMax-M2.5")
+
+for chunk in model.chat_complete(messages, stream=True):
+    print(chunk.choices[0].delta.content, end="")
+```
+
+### JSON Mode
+
+```python
+model = AIFactory.create_language(
+    "minimax", "MiniMax-M2.5",
+    config={"structured": {"type": "json_object"}}
+)
+```
+
+### Async Support
+
+```python
+response = await model.achat_complete(messages)
+```
+
+## Configuration
+
+```python
+# With explicit API key
+model = AIFactory.create_language(
+    "minimax", "MiniMax-M2.5",
+    config={"api_key": "your-key"}
+)
+```

--- a/docs/providers/openai-compatible.md
+++ b/docs/providers/openai-compatible.md
@@ -73,6 +73,30 @@ OPENAI_COMPATIBLE_API_KEY_TTS="your-key"
 
 This allows you to use different OpenAI-compatible endpoints for different AI capabilities (LLM, Embedding, STT, TTS) without code changes.
 
+## Custom Provider Profiles
+
+If you frequently use an OpenAI-compatible endpoint, you can register it as a named provider profile instead of specifying `base_url` every time:
+
+```python
+from esperanto import AIFactory, OpenAICompatibleProfile
+
+# Register your endpoint once
+AIFactory.register_openai_compatible_profile(
+    OpenAICompatibleProfile(
+        name="my-company",
+        base_url="https://llm.internal.company.com/v1",
+        api_key_env="MY_COMPANY_LLM_KEY",
+        default_model="llama-3-70b",
+    )
+)
+
+# Then use it like any built-in provider
+model = AIFactory.create_language("my-company", "llama-3-70b")
+response = model.chat_complete(messages)
+```
+
+Several OpenAI-compatible providers are already registered as built-in profiles: **DeepSeek**, **xAI**, **DashScope** (Qwen), and **MiniMax**. See their individual provider docs for details.
+
 ## Quick Start
 
 ### Via Factory (Recommended)

--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -55,21 +55,14 @@ response = model.chat_complete(messages)
 print(response.choices[0].message.content)
 ```
 
-### Direct Instantiation
+### Direct Instantiation (Deprecated)
+
+> **Note:** Direct instantiation via `XAILanguageModel` is deprecated. Use `AIFactory.create_language("xai", ...)` instead. xAI is now implemented as an OpenAI-compatible provider profile.
 
 ```python
+# Deprecated — will emit a DeprecationWarning
 from esperanto.providers.llm.xai import XAILanguageModel
-
-# Create model instance
-model = XAILanguageModel(
-    api_key="your-api-key",
-    model_name="grok-beta"
-)
-
-# Use the model
-messages = [{"role": "user", "content": "Hello!"}]
-response = model.chat_complete(messages)
-print(response.choices[0].message.content)
+model = XAILanguageModel(api_key="your-api-key", model_name="grok-beta")
 ```
 
 ## Capabilities

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esperanto"
-version = "2.19.7"
+version = "2.20.0"
 description = "A light-weight, production-ready, unified interface for various AI model providers"
 authors = [
     { name = "LUIS NOVO", email = "lfnovo@gmail.com" }

--- a/src/esperanto/__init__.py
+++ b/src/esperanto/__init__.py
@@ -15,6 +15,7 @@ from esperanto.common_types import (
 )
 from esperanto.providers.embedding.base import EmbeddingModel
 from esperanto.providers.llm.base import LanguageModel
+from esperanto.providers.llm.profiles import OpenAICompatibleProfile
 from esperanto.providers.stt.base import SpeechToTextModel
 from esperanto.providers.tts.base import TextToSpeechModel
 
@@ -155,6 +156,8 @@ __all__ = [
     "validate_tool_call",
     "validate_tool_calls",
     "find_tool_by_name",
+    # Profiles
+    "OpenAICompatibleProfile",
 ] + provider_classes
 
 # Make provider classes available at module level

--- a/src/esperanto/factory.py
+++ b/src/esperanto/factory.py
@@ -25,11 +25,11 @@ class AIFactory:
             "groq": "esperanto.providers.llm.groq:GroqLanguageModel",
             "ollama": "esperanto.providers.llm.ollama:OllamaLanguageModel",
             "openrouter": "esperanto.providers.llm.openrouter:OpenRouterLanguageModel",
-            "xai": "esperanto.providers.llm.xai:XAILanguageModel",
+            # xai: handled via OpenAICompatibleProfile (see profiles.py)
             "perplexity": "esperanto.providers.llm.perplexity:PerplexityLanguageModel",
             "azure": "esperanto.providers.llm.azure:AzureLanguageModel",
             "mistral": "esperanto.providers.llm.mistral:MistralLanguageModel",
-            "deepseek": "esperanto.providers.llm.deepseek:DeepSeekLanguageModel",
+            # deepseek: handled via OpenAICompatibleProfile (see profiles.py)
             "vertex": "esperanto.providers.llm.vertex:VertexLanguageModel",
         },
         "embedding": {
@@ -88,9 +88,15 @@ class AIFactory:
 
         provider = provider.lower().replace("_", "-")
         if provider not in cls._provider_modules[service_type]:
+            # Include profile names in the error for language providers
+            supported = list(cls._provider_modules[service_type].keys())
+            if service_type == "language":
+                from esperanto.providers.llm.profiles import get_all_profile_names
+
+                supported = sorted(set(supported) | get_all_profile_names())
             raise ValueError(
                 f"Provider '{provider}' not supported for {service_type}. "
-                f"Supported providers: {list(cls._provider_modules[service_type].keys())}"
+                f"Supported providers: {supported}"
             )
 
         module_path = cls._provider_modules[service_type][provider]
@@ -120,10 +126,43 @@ class AIFactory:
             Dict[str, List[str]]: A dictionary where keys are model types (language, embedding, speech_to_text, text_to_speech)
                 and values are lists of available provider names.
         """
-        return {
+        from esperanto.providers.llm.profiles import get_all_profile_names
+
+        result = {
             model_type: list(providers.keys())
             for model_type, providers in cls._provider_modules.items()
         }
+        # Merge OpenAI-compatible profile names into language providers
+        result["language"] = sorted(
+            set(result.get("language", [])) | get_all_profile_names()
+        )
+        return result
+
+    @classmethod
+    def register_openai_compatible_profile(cls, profile) -> None:
+        """Register an OpenAI-compatible provider profile.
+
+        Once registered, the profile's name can be used as the provider argument
+        in create_language().
+
+        Args:
+            profile: An OpenAICompatibleProfile instance.
+
+        Example:
+            >>> from esperanto.providers.llm.profiles import OpenAICompatibleProfile
+            >>> AIFactory.register_openai_compatible_profile(
+            ...     OpenAICompatibleProfile(
+            ...         name="together",
+            ...         base_url="https://api.together.xyz/v1",
+            ...         api_key_env="TOGETHER_API_KEY",
+            ...         default_model="meta-llama/Llama-3-70b-chat-hf",
+            ...     )
+            ... )
+            >>> model = AIFactory.create_language("together", "meta-llama/Llama-3-70b-chat-hf")
+        """
+        from esperanto.providers.llm.profiles import register_profile
+
+        register_profile(profile)
 
     @classmethod
     def get_provider_models(
@@ -229,13 +268,29 @@ class AIFactory:
         """Create a language model instance.
 
         Args:
-            provider: Provider name
+            provider: Provider name (supports class-based providers and
+                OpenAI-compatible profiles registered via register_openai_compatible_profile)
             model_name: Name of the model to use
             config: Optional configuration for the model
 
         Returns:
             Language model instance
         """
+        from esperanto.providers.llm.profiles import get_profile
+
+        normalized = provider.lower().replace("_", "-")
+        profile = get_profile(normalized)
+        if profile:
+            from esperanto.providers.llm.openai_compatible import (
+                OpenAICompatibleLanguageModel,
+            )
+
+            merged_config = dict(config or {})
+            merged_config["_profile_name"] = normalized
+            return OpenAICompatibleLanguageModel(
+                model_name=model_name, config=merged_config
+            )
+
         provider_class = cls._import_provider_class("language", provider)
         return provider_class(model_name=model_name, config=config or {})
 

--- a/src/esperanto/providers/llm/deepseek.py
+++ b/src/esperanto/providers/llm/deepseek.py
@@ -1,51 +1,34 @@
-"""DeepSeek language model implementation."""
+"""DeepSeek language model implementation.
 
-import os
+Deprecated: Use AIFactory.create_language('deepseek', ...) instead.
+DeepSeek is now handled as an OpenAI-compatible provider profile.
+"""
+
+import warnings
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from esperanto.common_types import Model
-from esperanto.providers.llm.openai import OpenAILanguageModel
-from esperanto.utils.logging import logger
-
-if TYPE_CHECKING:
-    from langchain_deepseek import ChatDeepSeek
+from esperanto.providers.llm.openai_compatible import OpenAICompatibleLanguageModel
 
 
 @dataclass
-class DeepSeekLanguageModel(OpenAILanguageModel):
-    """DeepSeek language model implementation using OpenAI-compatible API."""
+class DeepSeekLanguageModel(OpenAICompatibleLanguageModel):
+    """DeepSeek language model.
 
-    base_url: Optional[str] = None
-    api_key: Optional[str] = None
+    .. deprecated::
+        Use ``AIFactory.create_language('deepseek', ...)`` instead.
+        This class is kept for backwards compatibility.
+    """
+
     model_name: str = "deepseek-chat"
 
-    @property
-    def provider(self) -> str:
-        return "deepseek"
-
     def __post_init__(self):
-        # Extract api_key and base_url from config dict first (before parent sets OpenAI defaults)
-        if hasattr(self, "config") and self.config:
-            if "api_key" in self.config:
-                self.api_key = self.config["api_key"]
-            if "base_url" in self.config:
-                self.base_url = self.config["base_url"]
-
-        # Initialize DeepSeek-specific configuration
-        self.base_url = self.base_url or os.getenv(
-            "DEEPSEEK_BASE_URL", "https://api.deepseek.com/v1"
+        warnings.warn(
+            "DeepSeekLanguageModel is deprecated. "
+            "Use AIFactory.create_language('deepseek', ...) instead.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-        self.api_key = self.api_key or os.getenv("DEEPSEEK_API_KEY")
-        self.model_name = self.model_name or "deepseek-chat"
-
-        if not self.api_key:
-            raise ValueError(
-                "DeepSeek API key not found. Set the DEEPSEEK_API_KEY environment variable."
-            )
-
-        # Call parent's post_init (won't overwrite since values are already set)
+        if not self.config:
+            self.config = {}
+        self.config.setdefault("_profile_name", "deepseek")
         super().__post_init__()
-
-        # DeepSeek supports JSON mode like OpenAI (handled by parent)
-        # If any DeepSeek-specific warnings or configs are needed, add here

--- a/src/esperanto/providers/llm/deepseek.py
+++ b/src/esperanto/providers/llm/deepseek.py
@@ -30,5 +30,5 @@ class DeepSeekLanguageModel(OpenAICompatibleLanguageModel):
         )
         if not self.config:
             self.config = {}
-        self.config.setdefault("_profile_name", "deepseek")
+        self.config["_profile_name"] = "deepseek"
         super().__post_init__()

--- a/src/esperanto/providers/llm/openai_compatible.py
+++ b/src/esperanto/providers/llm/openai_compatible.py
@@ -64,8 +64,13 @@ class OpenAICompatibleLanguageModel(OpenAILanguageModel):
                 self._config.get("api_key") or
                 os.getenv(self._profile.api_key_env)
             )
+            display = self._profile.display_name or self._profile.name.title()
+            if not self.base_url:
+                raise ValueError(
+                    f"{display} base URL is not configured. "
+                    f"Provide base_url in config or check the profile configuration."
+                )
             if not self.api_key:
-                display = self._profile.display_name or self._profile.name.title()
                 raise ValueError(
                     f"{display} API key not found. "
                     f"Set {self._profile.api_key_env} environment variable "

--- a/src/esperanto/providers/llm/openai_compatible.py
+++ b/src/esperanto/providers/llm/openai_compatible.py
@@ -15,6 +15,7 @@ from typing import (
 
 from esperanto.common_types import ChatCompletion, ChatCompletionChunk, Model, Tool
 from esperanto.providers.llm.openai import OpenAILanguageModel
+from esperanto.providers.llm.profiles import OpenAICompatibleProfile, get_profile
 from esperanto.utils.logging import logger
 
 if TYPE_CHECKING:
@@ -36,38 +37,68 @@ class OpenAICompatibleLanguageModel(OpenAILanguageModel):
         # Initialize _config first (from base class)
         if not hasattr(self, '_config'):
             self._config = {}
-        
+
         # Update with any provided config
         if hasattr(self, "config") and self.config:
             self._config.update(self.config)
-        
-        # Configuration precedence: Factory config > Environment variables > Default
-        self.base_url = (
-            self.base_url or
-            self._config.get("base_url") or
-            os.getenv("OPENAI_COMPATIBLE_BASE_URL_LLM") or
-            os.getenv("OPENAI_COMPATIBLE_BASE_URL")
-        )
-        self.api_key = (
-            self.api_key or
-            self._config.get("api_key") or
-            os.getenv("OPENAI_COMPATIBLE_API_KEY_LLM") or
-            os.getenv("OPENAI_COMPATIBLE_API_KEY")
-        )
 
-        # Validation
-        if not self.base_url:
-            raise ValueError(
-                "OpenAI-compatible base URL is required. "
-                "Set OPENAI_COMPATIBLE_BASE_URL_LLM or OPENAI_COMPATIBLE_BASE_URL "
-                "environment variable or provide base_url in config."
+        # Resolve provider profile if configured
+        profile_name = self._config.get("_profile_name")
+        self._profile: Optional[OpenAICompatibleProfile] = None
+        if profile_name:
+            self._profile = get_profile(profile_name)
+            if not self._profile:
+                raise ValueError(f"Unknown provider profile: '{profile_name}'")
+
+        if self._profile:
+            # Profile-aware configuration precedence:
+            # explicit param > config dict > profile env var > profile default
+            self.base_url = (
+                self.base_url or
+                self._config.get("base_url") or
+                os.getenv(self._profile.base_url_env or "") or
+                self._profile.base_url
             )
-        # Use a default API key if none is provided (some endpoints don't require authentication)
-        if not self.api_key:
-            self.api_key = "not-required"
+            self.api_key = (
+                self.api_key or
+                self._config.get("api_key") or
+                os.getenv(self._profile.api_key_env)
+            )
+            if not self.api_key:
+                display = self._profile.display_name or self._profile.name.title()
+                raise ValueError(
+                    f"{display} API key not found. "
+                    f"Set {self._profile.api_key_env} environment variable "
+                    f"or provide api_key in config."
+                )
+        else:
+            # Standard OpenAI-compatible configuration precedence
+            self.base_url = (
+                self.base_url or
+                self._config.get("base_url") or
+                os.getenv("OPENAI_COMPATIBLE_BASE_URL_LLM") or
+                os.getenv("OPENAI_COMPATIBLE_BASE_URL")
+            )
+            self.api_key = (
+                self.api_key or
+                self._config.get("api_key") or
+                os.getenv("OPENAI_COMPATIBLE_API_KEY_LLM") or
+                os.getenv("OPENAI_COMPATIBLE_API_KEY")
+            )
+
+            # Validation
+            if not self.base_url:
+                raise ValueError(
+                    "OpenAI-compatible base URL is required. "
+                    "Set OPENAI_COMPATIBLE_BASE_URL_LLM or OPENAI_COMPATIBLE_BASE_URL "
+                    "environment variable or provide base_url in config."
+                )
+            # Use a default API key if none is provided (some endpoints don't require authentication)
+            if not self.api_key:
+                self.api_key = "not-required"
 
         # Ensure base_url doesn't end with trailing slash for consistency
-        if self.base_url.endswith("/"):
+        if self.base_url and self.base_url.endswith("/"):
             self.base_url = self.base_url.rstrip("/")
 
         # Call parent's post_init to set up HTTP clients and normalized response handling
@@ -75,6 +106,9 @@ class OpenAICompatibleLanguageModel(OpenAILanguageModel):
 
         # Track if we've detected that this endpoint doesn't support json_object
         self._response_format_unsupported = False
+        # Apply profile feature flags after parent init
+        if self._profile and not self._profile.supports_response_format:
+            self._response_format_unsupported = True
 
     def _is_likely_lmstudio(self) -> bool:
         """Check if this endpoint is likely LM Studio based on port.
@@ -109,24 +143,48 @@ class OpenAICompatibleLanguageModel(OpenAILanguageModel):
     
     def _normalize_response(self, response_data: Dict[str, Any]) -> "ChatCompletion":
         """Normalize OpenAI-compatible response to our format with graceful fallback."""
-        from esperanto.common_types import ChatCompletion, Choice, Message, Usage
-        
+        from esperanto.common_types import (
+            ChatCompletion,
+            Choice,
+            FunctionCall,
+            Message,
+            ToolCall,
+            Usage,
+        )
+
         # Handle missing or incomplete response fields gracefully
         response_id = response_data.get("id", "chatcmpl-unknown")
         created = response_data.get("created", 0)
         model = response_data.get("model", self.get_model_name())
-        
+
         # Handle choices array
         choices = response_data.get("choices", [])
         normalized_choices = []
-        
+
         for choice in choices:
             message = choice.get("message", {})
+
+            # Extract tool_calls if present
+            tool_calls = None
+            if "tool_calls" in message and message["tool_calls"]:
+                tool_calls = [
+                    ToolCall(
+                        id=tc.get("id", ""),
+                        type=tc.get("type", "function"),
+                        function=FunctionCall(
+                            name=tc.get("function", {}).get("name", ""),
+                            arguments=tc.get("function", {}).get("arguments", "{}"),
+                        ),
+                    )
+                    for tc in message["tool_calls"]
+                ]
+
             normalized_choice = Choice(
                 index=choice.get("index", 0),
                 message=Message(
-                    content=message.get("content", ""),
+                    content=message.get("content", "") if not tool_calls else message.get("content"),
                     role=message.get("role", "assistant"),
+                    tool_calls=tool_calls,
                 ),
                 finish_reason=choice.get("finish_reason", "stop"),
             )
@@ -159,7 +217,11 @@ class OpenAICompatibleLanguageModel(OpenAILanguageModel):
 
     def _normalize_chunk(self, chunk_data: Dict[str, Any]) -> "ChatCompletionChunk":
         """Normalize OpenAI-compatible stream chunk to our format with graceful fallback."""
-        from esperanto.common_types import ChatCompletionChunk, StreamChoice, DeltaMessage
+        from esperanto.common_types import (
+            ChatCompletionChunk,
+            DeltaMessage,
+            StreamChoice,
+        )
         
         # Handle missing or incomplete chunk fields gracefully
         chunk_id = chunk_data.get("id", "chatcmpl-unknown")
@@ -345,9 +407,11 @@ class OpenAICompatibleLanguageModel(OpenAILanguageModel):
 
     def _get_models(self) -> List[Model]:
         """List all available models for this provider.
-        
+
         Note: This attempts to fetch models from the /models endpoint.
         If the endpoint doesn't support this, it will return an empty list.
+        When a profile is active, results are filtered by model_prefix_filter
+        and owned_by is overridden if configured.
         """
         try:
             response = self.client.get(
@@ -355,16 +419,26 @@ class OpenAICompatibleLanguageModel(OpenAILanguageModel):
                 headers=self._get_headers()
             )
             self._handle_error(response)
-            
+
             models_data = response.json()
-            return [
+            owned_by_default = (
+                self._profile.owned_by if self._profile and self._profile.owned_by else "custom"
+            )
+            models = [
                 Model(
                     id=model["id"],
-                    owned_by=model.get("owned_by", "custom"),
+                    owned_by=owned_by_default if self._profile and self._profile.owned_by else model.get("owned_by", "custom"),
                     context_window=model.get("context_window", None),
                 )
                 for model in models_data.get("data", [])
             ]
+
+            # Apply profile-based model filtering
+            if self._profile and self._profile.model_prefix_filter:
+                prefix = self._profile.model_prefix_filter
+                models = [m for m in models if m.id.startswith(prefix)]
+
+            return models
         except Exception as e:
             # Log the error but don't fail completely
             logger.debug(f"Could not fetch models from OpenAI-compatible endpoint: {e}")
@@ -372,15 +446,19 @@ class OpenAICompatibleLanguageModel(OpenAILanguageModel):
 
     def _get_default_model(self) -> str:
         """Get the default model name.
-        
-        For OpenAI-compatible endpoints, we use a generic default
-        that users should override with their specific model.
+
+        Returns the profile's default_model if a profile is active,
+        otherwise a generic default.
         """
+        if self._profile:
+            return self._profile.default_model
         return "gpt-3.5-turbo"
 
     @property
     def provider(self) -> str:
         """Get the provider name."""
+        if self._profile:
+            return self._profile.name
         return "openai-compatible"
 
     def to_langchain(self) -> "ChatOpenAI":

--- a/src/esperanto/providers/llm/profiles.py
+++ b/src/esperanto/providers/llm/profiles.py
@@ -110,7 +110,8 @@ def register_profile(profile: OpenAICompatibleProfile) -> None:
         raise TypeError("profile must be an OpenAICompatibleProfile instance")
     if not profile.name:
         raise ValueError("profile.name must be a non-empty string")
-    _USER_PROFILES[profile.name] = profile
+    normalized_name = profile.name.lower().replace("_", "-")
+    _USER_PROFILES[normalized_name] = profile
 
 
 def get_all_profile_names() -> Set[str]:

--- a/src/esperanto/providers/llm/profiles.py
+++ b/src/esperanto/providers/llm/profiles.py
@@ -1,0 +1,118 @@
+"""OpenAI-compatible provider profiles for config-driven virtual providers."""
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Set
+
+
+@dataclass(frozen=True)
+class OpenAICompatibleProfile:
+    """Declarative configuration for an OpenAI-compatible provider.
+
+    Instead of creating a new Python class for each OpenAI-compatible endpoint,
+    define a profile and register it. The factory will create an
+    OpenAICompatibleLanguageModel configured by the profile.
+
+    Example:
+        >>> from esperanto import AIFactory
+        >>> from esperanto.providers.llm.profiles import OpenAICompatibleProfile
+        >>>
+        >>> AIFactory.register_openai_compatible_profile(
+        ...     OpenAICompatibleProfile(
+        ...         name="together",
+        ...         base_url="https://api.together.xyz/v1",
+        ...         api_key_env="TOGETHER_API_KEY",
+        ...         default_model="meta-llama/Llama-3-70b-chat-hf",
+        ...     )
+        ... )
+        >>> model = AIFactory.create_language("together", "meta-llama/Llama-3-70b-chat-hf")
+    """
+
+    name: str
+    """Provider identifier used in AIFactory.create_language(provider=...)."""
+
+    base_url: str
+    """Default API endpoint URL."""
+
+    api_key_env: str
+    """Environment variable name for the API key (e.g., 'DEEPSEEK_API_KEY')."""
+
+    default_model: str
+    """Default model name when none is specified."""
+
+    base_url_env: Optional[str] = None
+    """Optional environment variable for base URL override."""
+
+    supports_response_format: bool = True
+    """Whether the endpoint supports the response_format parameter."""
+
+    model_prefix_filter: Optional[str] = None
+    """Only include models whose ID starts with this prefix in _get_models()."""
+
+    owned_by: Optional[str] = None
+    """Override the owned_by field in model listings."""
+
+    display_name: Optional[str] = None
+    """Human-readable name for error messages (e.g., 'DeepSeek'). Defaults to name."""
+
+
+BUILTIN_PROFILES: Dict[str, OpenAICompatibleProfile] = {
+    "deepseek": OpenAICompatibleProfile(
+        name="deepseek",
+        base_url="https://api.deepseek.com/v1",
+        api_key_env="DEEPSEEK_API_KEY",
+        base_url_env="DEEPSEEK_BASE_URL",
+        default_model="deepseek-chat",
+        owned_by="DeepSeek",
+        display_name="DeepSeek",
+    ),
+    "xai": OpenAICompatibleProfile(
+        name="xai",
+        base_url="https://api.x.ai/v1",
+        api_key_env="XAI_API_KEY",
+        base_url_env="XAI_BASE_URL",
+        default_model="grok-2-latest",
+        supports_response_format=False,
+        model_prefix_filter="grok",
+        owned_by="X.AI",
+        display_name="XAI",
+    ),
+    "dashscope": OpenAICompatibleProfile(
+        name="dashscope",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        api_key_env="DASHSCOPE_API_KEY",
+        base_url_env="DASHSCOPE_BASE_URL",
+        default_model="qwen-plus",
+        owned_by="Alibaba Cloud",
+        display_name="DashScope",
+    ),
+    "minimax": OpenAICompatibleProfile(
+        name="minimax",
+        base_url="https://api.minimax.io/v1",
+        api_key_env="MINIMAX_API_KEY",
+        base_url_env="MINIMAX_BASE_URL",
+        default_model="MiniMax-M2.5",
+        owned_by="MiniMax",
+        display_name="MiniMax",
+    ),
+}
+
+_USER_PROFILES: Dict[str, OpenAICompatibleProfile] = {}
+
+
+def get_profile(name: str) -> Optional[OpenAICompatibleProfile]:
+    """Look up a profile by name. User profiles take precedence over builtins."""
+    return _USER_PROFILES.get(name) or BUILTIN_PROFILES.get(name)
+
+
+def register_profile(profile: OpenAICompatibleProfile) -> None:
+    """Register a user-defined provider profile."""
+    if not isinstance(profile, OpenAICompatibleProfile):
+        raise TypeError("profile must be an OpenAICompatibleProfile instance")
+    if not profile.name:
+        raise ValueError("profile.name must be a non-empty string")
+    _USER_PROFILES[profile.name] = profile
+
+
+def get_all_profile_names() -> Set[str]:
+    """Return the combined set of builtin and user profile names."""
+    return set(BUILTIN_PROFILES.keys()) | set(_USER_PROFILES.keys())

--- a/src/esperanto/providers/llm/xai.py
+++ b/src/esperanto/providers/llm/xai.py
@@ -1,117 +1,32 @@
-"""XAI language model implementation."""
+"""XAI language model implementation.
 
-import os
+Deprecated: Use AIFactory.create_language('xai', ...) instead.
+XAI is now handled as an OpenAI-compatible provider profile.
+"""
+
+import warnings
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional  # Added Optional
 
-from esperanto.common_types import Model
-from esperanto.providers.llm.openai import OpenAILanguageModel
-from esperanto.utils.logging import logger
-
-if TYPE_CHECKING:
-    from langchain_openai import ChatOpenAI
+from esperanto.providers.llm.openai_compatible import OpenAICompatibleLanguageModel
 
 
 @dataclass
-class XAILanguageModel(OpenAILanguageModel):
-    """XAI language model implementation using OpenAI-compatible API."""
+class XAILanguageModel(OpenAICompatibleLanguageModel):
+    """XAI (Grok) language model.
 
-    base_url: Optional[str] = None  # Changed type hint
-    api_key: Optional[str] = None  # Changed type hint
+    .. deprecated::
+        Use ``AIFactory.create_language('xai', ...)`` instead.
+        This class is kept for backwards compatibility.
+    """
 
     def __post_init__(self):
-        # Extract api_key and base_url from config dict first (before parent sets OpenAI defaults)
-        if hasattr(self, "config") and self.config:
-            if "api_key" in self.config:
-                self.api_key = self.config["api_key"]
-            if "base_url" in self.config:
-                self.base_url = self.config["base_url"]
-
-        # Initialize XAI-specific configuration
-        self.base_url = self.base_url or os.getenv(
-            "XAI_BASE_URL", "https://api.x.ai/v1"
+        warnings.warn(
+            "XAILanguageModel is deprecated. "
+            "Use AIFactory.create_language('xai', ...) instead.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-        self.api_key = self.api_key or os.getenv("XAI_API_KEY")
-
-        if not self.api_key:
-            raise ValueError(
-                "XAI API key not found. Set the XAI_API_KEY environment variable."
-            )
-
-        # Call parent's post_init (won't overwrite since values are already set)
+        if not self.config:
+            self.config = {}
+        self.config.setdefault("_profile_name", "xai")
         super().__post_init__()
-
-
-    def _get_api_kwargs(self, exclude_stream: bool = False) -> Dict[str, Any]:
-        """Get kwargs for API calls, filtering out provider-specific args.
-
-        Note: XAI doesn't support response_format parameter.
-        """
-        kwargs = super()._get_api_kwargs(exclude_stream)
-
-        # Remove response_format as XAI doesn't support it
-        kwargs.pop("response_format", None)
-
-        return kwargs
-
-    def _get_models(self) -> List[Model]:
-        """List all available models for this provider."""
-        response = self.client.get(
-            f"{self.base_url}/models",
-            headers=self._get_headers()
-        )
-        self._handle_error(response)
-        
-        models_data = response.json()
-        return [
-            Model(
-                id=model["id"],
-                owned_by="X.AI",
-                context_window=model.get("context_window", None),
-            )
-            for model in models_data["data"]
-            if model["id"].startswith("grok")  # Only include Grok models
-        ]
-
-    def _get_default_model(self) -> str:
-        """Get the default model name."""
-        return "grok-2-latest"
-
-    @property
-    def provider(self) -> str:
-        """Get the provider name."""
-        return "xai"
-
-    def to_langchain(self) -> "ChatOpenAI":
-        """Convert to a LangChain chat model.
-
-        Raises:
-            ImportError: If langchain_openai is not installed.
-        """
-        try:
-            from langchain_openai import ChatOpenAI
-        except ImportError as e:
-            raise ImportError(
-                "Langchain integration requires langchain_openai. "
-                "Install with: uv add langchain_openai or pip install langchain_openai"
-            ) from e
-
-        langchain_kwargs = {
-            "max_tokens": self.max_tokens,
-            "temperature": self.temperature,
-            "top_p": self.top_p,
-            "streaming": self.streaming,
-            "api_key": self.api_key,  # Pass raw string
-            "base_url": self.base_url,
-            "organization": self.organization,
-            "model": self.get_model_name(),
-            "model_kwargs": {},  # XAI doesn't support response_format
-        }
-
-        # Ensure model name is set
-        model_name = self.get_model_name()
-        if not model_name:
-            raise ValueError("Model name is required for Langchain integration.")
-        langchain_kwargs["model"] = model_name  # Update model name in kwargs
-
-        return ChatOpenAI(**self._clean_config(langchain_kwargs))

--- a/src/esperanto/providers/llm/xai.py
+++ b/src/esperanto/providers/llm/xai.py
@@ -28,5 +28,5 @@ class XAILanguageModel(OpenAICompatibleLanguageModel):
         )
         if not self.config:
             self.config = {}
-        self.config.setdefault("_profile_name", "xai")
+        self.config["_profile_name"] = "xai"
         super().__post_init__()

--- a/tests/providers/llm/test_deepseek_provider.py
+++ b/tests/providers/llm/test_deepseek_provider.py
@@ -7,8 +7,10 @@ import pytest
 from esperanto.common_types import Tool, ToolFunction, ToolCall, ToolCallValidationError
 from esperanto.providers.llm.deepseek import DeepSeekLanguageModel
 
-# Suppress deprecation warnings from DeepSeekLanguageModel throughout this module
-pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+# Suppress the specific DeepSeek deprecation warning throughout this module
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:DeepSeekLanguageModel is deprecated:DeprecationWarning"
+)
 
 
 def test_provider_name():

--- a/tests/providers/llm/test_deepseek_provider.py
+++ b/tests/providers/llm/test_deepseek_provider.py
@@ -1,10 +1,14 @@
 import os
+import warnings
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from esperanto.common_types import Tool, ToolFunction, ToolCall, ToolCallValidationError
 from esperanto.providers.llm.deepseek import DeepSeekLanguageModel
+
+# Suppress deprecation warnings from DeepSeekLanguageModel throughout this module
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
 
 
 def test_provider_name():

--- a/tests/providers/llm/test_profiles.py
+++ b/tests/providers/llm/test_profiles.py
@@ -1,0 +1,371 @@
+"""Tests for the OpenAI-compatible provider profiles system."""
+
+import os
+import warnings
+from unittest.mock import Mock, patch
+
+import pytest
+
+from esperanto.factory import AIFactory
+from esperanto.providers.llm.profiles import (
+    _USER_PROFILES,
+    BUILTIN_PROFILES,
+    OpenAICompatibleProfile,
+    get_all_profile_names,
+    get_profile,
+    register_profile,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_user_profiles():
+    """Ensure user profiles are clean for each test."""
+    _USER_PROFILES.clear()
+    yield
+    _USER_PROFILES.clear()
+
+
+# =============================================================================
+# Profile dataclass tests
+# =============================================================================
+
+
+class TestOpenAICompatibleProfile:
+    def test_profile_is_frozen(self):
+        profile = OpenAICompatibleProfile(
+            name="test", base_url="http://localhost", api_key_env="TEST_KEY", default_model="m"
+        )
+        with pytest.raises(AttributeError):
+            profile.name = "changed"
+
+    def test_defaults(self):
+        profile = OpenAICompatibleProfile(
+            name="test", base_url="http://localhost", api_key_env="TEST_KEY", default_model="m"
+        )
+        assert profile.base_url_env is None
+        assert profile.supports_response_format is True
+        assert profile.model_prefix_filter is None
+        assert profile.owned_by is None
+        assert profile.display_name is None
+
+
+# =============================================================================
+# Profile registry tests
+# =============================================================================
+
+
+class TestProfileRegistry:
+    def test_builtin_profiles_exist(self):
+        assert "deepseek" in BUILTIN_PROFILES
+        assert "xai" in BUILTIN_PROFILES
+
+    def test_get_builtin_profile(self):
+        profile = get_profile("deepseek")
+        assert profile is not None
+        assert profile.name == "deepseek"
+        assert profile.base_url == "https://api.deepseek.com/v1"
+        assert profile.api_key_env == "DEEPSEEK_API_KEY"
+        assert profile.default_model == "deepseek-chat"
+
+    def test_get_xai_profile(self):
+        profile = get_profile("xai")
+        assert profile is not None
+        assert profile.supports_response_format is False
+        assert profile.model_prefix_filter == "grok"
+
+    def test_get_dashscope_profile(self):
+        profile = get_profile("dashscope")
+        assert profile is not None
+        assert profile.name == "dashscope"
+        assert profile.base_url == "https://dashscope.aliyuncs.com/compatible-mode/v1"
+        assert profile.api_key_env == "DASHSCOPE_API_KEY"
+        assert profile.default_model == "qwen-plus"
+
+    def test_get_unknown_profile_returns_none(self):
+        assert get_profile("unknown-provider") is None
+
+    def test_register_user_profile(self):
+        profile = OpenAICompatibleProfile(
+            name="together",
+            base_url="https://api.together.xyz/v1",
+            api_key_env="TOGETHER_API_KEY",
+            default_model="meta-llama/Llama-3-70b-chat-hf",
+        )
+        register_profile(profile)
+        assert get_profile("together") is profile
+
+    def test_user_profile_overrides_builtin(self):
+        custom = OpenAICompatibleProfile(
+            name="deepseek",
+            base_url="https://custom.deepseek.com/v1",
+            api_key_env="CUSTOM_DEEPSEEK_KEY",
+            default_model="deepseek-v3",
+        )
+        register_profile(custom)
+        assert get_profile("deepseek") is custom
+        assert get_profile("deepseek").base_url == "https://custom.deepseek.com/v1"
+
+    def test_register_invalid_type_raises(self):
+        with pytest.raises(TypeError):
+            register_profile({"name": "bad"})
+
+    def test_register_empty_name_raises(self):
+        with pytest.raises(ValueError):
+            register_profile(
+                OpenAICompatibleProfile(
+                    name="", base_url="http://x", api_key_env="X", default_model="m"
+                )
+            )
+
+    def test_get_all_profile_names(self):
+        names = get_all_profile_names()
+        assert "deepseek" in names
+        assert "xai" in names
+
+    def test_get_all_profile_names_includes_user(self):
+        register_profile(
+            OpenAICompatibleProfile(
+                name="custom", base_url="http://x", api_key_env="X", default_model="m"
+            )
+        )
+        assert "custom" in get_all_profile_names()
+
+
+# =============================================================================
+# Factory integration tests
+# =============================================================================
+
+
+class TestFactoryIntegration:
+    def test_create_language_with_deepseek_profile(self):
+        model = AIFactory.create_language(
+            "deepseek", "deepseek-chat", config={"api_key": "test-key"}
+        )
+        assert model.provider == "deepseek"
+        assert model.base_url == "https://api.deepseek.com/v1"
+        assert model.api_key == "test-key"
+
+    def test_create_language_with_xai_profile(self):
+        model = AIFactory.create_language(
+            "xai", "grok-2-latest", config={"api_key": "test-key"}
+        )
+        assert model.provider == "xai"
+        assert model.base_url == "https://api.x.ai/v1"
+        assert model._response_format_unsupported is True
+
+    def test_create_language_with_user_profile(self):
+        AIFactory.register_openai_compatible_profile(
+            OpenAICompatibleProfile(
+                name="together",
+                base_url="https://api.together.xyz/v1",
+                api_key_env="TOGETHER_API_KEY",
+                default_model="meta-llama/Llama-3-70b-chat-hf",
+            )
+        )
+        model = AIFactory.create_language(
+            "together", "meta-llama/Llama-3-70b-chat-hf", config={"api_key": "test"}
+        )
+        assert model.provider == "together"
+        assert model.base_url == "https://api.together.xyz/v1"
+
+    def test_unknown_provider_falls_through(self):
+        """Non-profile providers still use _provider_modules."""
+        model = AIFactory.create_language(
+            "openai", "gpt-4", config={"api_key": "test-key"}
+        )
+        assert model.provider == "openai"
+
+    def test_unknown_provider_raises(self):
+        with pytest.raises(ValueError, match="not supported"):
+            AIFactory.create_language("nonexistent", "model")
+
+    def test_get_available_providers_includes_profiles(self):
+        providers = AIFactory.get_available_providers()
+        assert "deepseek" in providers["language"]
+        assert "xai" in providers["language"]
+        # Class-based providers also present
+        assert "openai" in providers["language"]
+
+    def test_get_available_providers_includes_user_profiles(self):
+        AIFactory.register_openai_compatible_profile(
+            OpenAICompatibleProfile(
+                name="fireworks",
+                base_url="https://api.fireworks.ai/v1",
+                api_key_env="FIREWORKS_API_KEY",
+                default_model="llama-v3-70b",
+            )
+        )
+        providers = AIFactory.get_available_providers()
+        assert "fireworks" in providers["language"]
+
+
+# =============================================================================
+# Profile-based provider behavior tests
+# =============================================================================
+
+
+class TestProfileBehavior:
+    def test_deepseek_default_model(self):
+        model = AIFactory.create_language(
+            "deepseek", "deepseek-chat", config={"api_key": "test-key"}
+        )
+        assert model._get_default_model() == "deepseek-chat"
+
+    def test_xai_default_model(self):
+        model = AIFactory.create_language(
+            "xai", "grok-2-latest", config={"api_key": "test-key"}
+        )
+        assert model._get_default_model() == "grok-2-latest"
+
+    def test_deepseek_env_var_api_key(self):
+        with patch.dict(os.environ, {"DEEPSEEK_API_KEY": "env-key"}, clear=False):
+            model = AIFactory.create_language("deepseek", "deepseek-chat")
+            assert model.api_key == "env-key"
+
+    def test_xai_env_var_api_key(self):
+        with patch.dict(os.environ, {"XAI_API_KEY": "env-key"}, clear=False):
+            model = AIFactory.create_language("xai", "grok-2-latest")
+            assert model.api_key == "env-key"
+
+    def test_deepseek_env_var_base_url(self):
+        with patch.dict(
+            os.environ,
+            {"DEEPSEEK_API_KEY": "key", "DEEPSEEK_BASE_URL": "https://custom.deepseek.com"},
+            clear=False,
+        ):
+            model = AIFactory.create_language("deepseek", "deepseek-chat")
+            assert model.base_url == "https://custom.deepseek.com"
+
+    def test_config_overrides_profile_defaults(self):
+        model = AIFactory.create_language(
+            "deepseek",
+            "deepseek-chat",
+            config={
+                "api_key": "test-key",
+                "base_url": "https://override.deepseek.com/v1",
+            },
+        )
+        assert model.base_url == "https://override.deepseek.com/v1"
+
+    def test_missing_api_key_raises_with_provider_name(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="DeepSeek API key not found"):
+                AIFactory.create_language("deepseek", "deepseek-chat")
+
+    def test_missing_xai_api_key_raises_with_provider_name(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="XAI API key not found"):
+                AIFactory.create_language("xai", "grok-2-latest")
+
+    def test_dashscope_creation(self):
+        model = AIFactory.create_language(
+            "dashscope", "qwen-plus", config={"api_key": "test-key"}
+        )
+        assert model.provider == "dashscope"
+        assert model.base_url == "https://dashscope.aliyuncs.com/compatible-mode/v1"
+        assert model._get_default_model() == "qwen-plus"
+
+    def test_dashscope_env_var(self):
+        with patch.dict(os.environ, {"DASHSCOPE_API_KEY": "env-key"}, clear=False):
+            model = AIFactory.create_language("dashscope", "qwen-max")
+            assert model.api_key == "env-key"
+
+    def test_dashscope_missing_api_key_raises(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="DashScope API key not found"):
+                AIFactory.create_language("dashscope", "qwen-plus")
+
+    def test_minimax_creation(self):
+        model = AIFactory.create_language(
+            "minimax", "MiniMax-M2.5", config={"api_key": "test-key"}
+        )
+        assert model.provider == "minimax"
+        assert model.base_url == "https://api.minimax.io/v1"
+        assert model._get_default_model() == "MiniMax-M2.5"
+
+    def test_minimax_env_var(self):
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "env-key"}, clear=False):
+            model = AIFactory.create_language("minimax", "MiniMax-M2.5")
+            assert model.api_key == "env-key"
+
+    def test_minimax_missing_api_key_raises(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="MiniMax API key not found"):
+                AIFactory.create_language("minimax", "MiniMax-M2.5")
+
+    def test_xai_response_format_stripped(self):
+        model = AIFactory.create_language(
+            "xai",
+            "grok-2-latest",
+            config={"api_key": "test-key", "structured": {"type": "json_object"}},
+        )
+        kwargs = model._get_api_kwargs()
+        assert "response_format" not in kwargs
+
+    def test_model_prefix_filter(self):
+        """xAI profile filters models to grok-* prefix."""
+        model = AIFactory.create_language(
+            "xai", "grok-2-latest", config={"api_key": "test-key"}
+        )
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "data": [
+                {"id": "grok-2-latest", "owned_by": "xai"},
+                {"id": "grok-beta", "owned_by": "xai"},
+                {"id": "some-other-model", "owned_by": "xai"},
+            ]
+        }
+        mock_client = Mock()
+        mock_client.get.return_value = mock_response
+        model.client = mock_client
+
+        models = model._get_models()
+        assert len(models) == 2
+        assert all(m.id.startswith("grok") for m in models)
+        assert all(m.owned_by == "X.AI" for m in models)
+
+
+# =============================================================================
+# Deprecated wrapper tests
+# =============================================================================
+
+
+class TestDeprecatedWrappers:
+    def test_deepseek_direct_import_warns(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            from esperanto.providers.llm.deepseek import DeepSeekLanguageModel
+
+            DeepSeekLanguageModel(api_key="test-key")
+            deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            assert len(deprecation_warnings) >= 1
+            assert "deprecated" in str(deprecation_warnings[0].message).lower()
+
+    def test_xai_direct_import_warns(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            from esperanto.providers.llm.xai import XAILanguageModel
+
+            XAILanguageModel(api_key="test-key")
+            deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            assert len(deprecation_warnings) >= 1
+            assert "deprecated" in str(deprecation_warnings[0].message).lower()
+
+    def test_deprecated_deepseek_still_works(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            from esperanto.providers.llm.deepseek import DeepSeekLanguageModel
+
+            model = DeepSeekLanguageModel(api_key="test-key")
+            assert model.provider == "deepseek"
+            assert model.base_url == "https://api.deepseek.com/v1"
+
+    def test_deprecated_xai_still_works(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            from esperanto.providers.llm.xai import XAILanguageModel
+
+            model = XAILanguageModel(api_key="test-key")
+            assert model.provider == "xai"
+            assert model.base_url == "https://api.x.ai/v1"

--- a/tests/providers/llm/test_xai_provider.py
+++ b/tests/providers/llm/test_xai_provider.py
@@ -7,8 +7,10 @@ import pytest
 from esperanto.common_types import Tool, ToolFunction, ToolCall, ToolCallValidationError
 from esperanto.providers.llm.xai import XAILanguageModel
 
-# Suppress deprecation warnings from XAILanguageModel throughout this module
-pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+# Suppress the specific XAI deprecation warning throughout this module
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:XAILanguageModel is deprecated:DeprecationWarning"
+)
 
 
 def test_provider_name():

--- a/tests/providers/llm/test_xai_provider.py
+++ b/tests/providers/llm/test_xai_provider.py
@@ -1,10 +1,14 @@
 import os
+import warnings
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from esperanto.common_types import Tool, ToolFunction, ToolCall, ToolCallValidationError
 from esperanto.providers.llm.xai import XAILanguageModel
+
+# Suppress deprecation warnings from XAILanguageModel throughout this module
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
 
 
 def test_provider_name():

--- a/uv.lock
+++ b/uv.lock
@@ -497,7 +497,7 @@ wheels = [
 
 [[package]]
 name = "esperanto"
-version = "2.19.5"
+version = "2.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -3312,6 +3312,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/8b/4b61d6e13f7108f36910df9ab4b58fd389cc2520d54d81b88660804aad99/torch-2.10.0-2-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:418997cb02d0a0f1497cf6a09f63166f9f5df9f3e16c8a716ab76a72127c714f", size = 79423467, upload-time = "2026-02-10T21:44:48.711Z" },
     { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
     { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ee/efbd56687be60ef9af0c9c0ebe106964c07400eade5b0af8902a1d8cd58c/torch-2.10.0-3-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a1ff626b884f8c4e897c4c33782bdacdff842a165fee79817b1dd549fdda1321", size = 915510070, upload-time = "2026-03-11T14:16:39.386Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ab/7b562f1808d3f65414cd80a4f7d4bb00979d9355616c034c171249e1a303/torch-2.10.0-3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:ac5bdcbb074384c66fa160c15b1ead77839e3fe7ed117d667249afce0acabfac", size = 915518691, upload-time = "2026-03-11T14:15:43.147Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
     { url = "https://files.pythonhosted.org/packages/0c/1a/c61f36cfd446170ec27b3a4984f072fd06dab6b5d7ce27e11adb35d6c838/torch-2.10.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:5276fa790a666ee8becaffff8acb711922252521b28fbce5db7db5cf9cb2026d", size = 145992962, upload-time = "2026-01-21T16:24:14.04Z" },
     { url = "https://files.pythonhosted.org/packages/b5/60/6662535354191e2d1555296045b63e4279e5a9dbad49acf55a5d38655a39/torch-2.10.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:aaf663927bcd490ae971469a624c322202a2a1e68936eb952535ca4cd3b90444", size = 915599237, upload-time = "2026-01-21T16:23:25.497Z" },
     { url = "https://files.pythonhosted.org/packages/40/b8/66bbe96f0d79be2b5c697b2e0b187ed792a15c6c4b8904613454651db848/torch-2.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:a4be6a2a190b32ff5c8002a0977a25ea60e64f7ba46b1be37093c141d9c49aeb", size = 113720931, upload-time = "2026-01-21T16:24:23.743Z" },


### PR DESCRIPTION
## Summary

- Add config-driven **provider profiles** for OpenAI-compatible endpoints — new providers are a 6-line config instead of a new Python class
- Built-in profiles: **DeepSeek**, **xAI**, **DashScope** (Alibaba Cloud Qwen), **MiniMax**
- Users can register custom profiles at runtime via `AIFactory.register_openai_compatible_profile()`
- DeepSeek and xAI classes deprecated in favor of profiles (backwards-compatible, emits `DeprecationWarning`)
- Fixed pre-existing bug where `OpenAICompatibleLanguageModel._normalize_response` dropped `tool_calls`
- Added `ARCHITECTURE.md` with design principles and provider tier definitions
- Rewrote `CONTRIBUTING.md` with provider acceptance criteria (inspired by Pydantic AI's approach)
- Bump version to 2.20.0

## How it works

```python
# Built-in profiles work transparently through the factory
model = AIFactory.create_language("dashscope", "qwen-plus")
model = AIFactory.create_language("minimax", "MiniMax-M2.5")

# Users can register their own OpenAI-compatible endpoints
from esperanto import AIFactory, OpenAICompatibleProfile

AIFactory.register_openai_compatible_profile(
    OpenAICompatibleProfile(
        name="together",
        base_url="https://api.together.xyz/v1",
        api_key_env="TOGETHER_API_KEY",
        default_model="meta-llama/Llama-3-70b-chat-hf",
    )
)
model = AIFactory.create_language("together", "meta-llama/Llama-3-70b-chat-hf")
```

## Test plan

- [x] All 149 relevant tests passing (profiles, deepseek, xai, openai-compatible, openai, factory)
- [x] Ruff clean on all changed files
- [x] Backwards compatibility: `DeepSeekLanguageModel(api_key="...")` still works (with deprecation warning)
- [x] Factory API unchanged: `AIFactory.create_language("deepseek", ...)` works as before
- [x] New providers: DashScope and MiniMax tested via factory
- [x] Custom profile registration tested
- [x] Model prefix filtering tested (xAI grok-* filter)
- [x] Response format disabling tested (xAI)