### PR TITLE
feat: add CAMB AI text-to-speech provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ transformers = [
     "einops>=0.8.1",
     "accelerate>=1.12.0,<2.0.0"
 ]
+camb = [
+    "camb-sdk>=1.0.0",
+]
 validation = [
     "jsonschema>=4.0.0,<5.0.0",
 ]

--- a/src/esperanto/factory.py
+++ b/src/esperanto/factory.py
@@ -60,6 +60,7 @@ class AIFactory:
             "vertex": "esperanto.providers.tts.vertex:VertexTextToSpeechModel",
             "openai-compatible": "esperanto.providers.tts.openai_compatible:OpenAICompatibleTextToSpeechModel",
             "azure": "esperanto.providers.tts.azure:AzureTextToSpeechModel",
+            "camb": "esperanto.providers.tts.camb:CambTextToSpeechModel",
         },
         "reranker": {
             "jina": "esperanto.providers.reranker.jina:JinaRerankerModel",

--- a/src/esperanto/providers/tts/camb.py
+++ b/src/esperanto/providers/tts/camb.py
@@ -1,0 +1,288 @@
+"""CAMB AI Text-to-Speech provider implementation."""
+
+import asyncio
+import concurrent.futures
+import os
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+import httpx
+
+from .base import AudioResponse, Model, TextToSpeechModel, Voice
+
+_CAMB_TTS_RESULT_URL = "https://client.camb.ai/apis/tts-result/{run_id}"
+
+
+def _parse_voice_id(voice: str) -> int:
+    """Convert string voice ID to int for the CAMB API."""
+    try:
+        return int(voice)
+    except (ValueError, TypeError):
+        raise ValueError(
+            f"CAMB voice ID must be numeric, got: {voice!r}"
+        )
+
+
+def _run_async(coro):
+    """Run an async coroutine from any context (sync or async)."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop and loop.is_running():
+        with concurrent.futures.ThreadPoolExecutor() as pool:
+            return pool.submit(asyncio.run, coro).result()
+    else:
+        return asyncio.run(coro)
+
+
+class CambTextToSpeechModel(TextToSpeechModel):
+    """CAMB AI Text-to-Speech provider implementation.
+
+    Supports multiple models including:
+    - mars-pro: High-quality TTS
+    - mars-flash: Fast TTS
+    - mars-instruct: Instructable TTS with user instructions
+    """
+
+    DEFAULT_MODEL = "mars-pro"
+    DEFAULT_VOICE = "147320"
+    PROVIDER = "camb"
+
+    def __init__(
+        self,
+        model_name: Optional[str] = None,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        **kwargs,
+    ):
+        api_key = api_key or os.getenv("CAMB_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "CAMB API key not provided. Set CAMB_API_KEY environment "
+                "variable or pass api_key parameter."
+            )
+
+        super().__init__(
+            model_name=model_name or self.DEFAULT_MODEL,
+            api_key=api_key,
+            base_url=base_url,
+            config=kwargs,
+        )
+
+        self.language = self._config.get("language", "en-us")
+        self._available_voices: Optional[Dict[str, Voice]] = None
+        self._client_instance = None
+        self._create_http_clients()
+
+    def _create_camb_client(self):
+        """Create a new AsyncCambAI client instance."""
+        try:
+            from camb.client import AsyncCambAI
+        except ImportError as exc:
+            raise ImportError(
+                "The 'camb' package is required to use CAMB TTS provider. "
+                "Install it with: pip install camb-sdk"
+            ) from exc
+        return AsyncCambAI(
+            api_key=self.api_key, timeout=self.timeout or 60.0
+        )
+
+    def _get_async_client(self):
+        """Get a lazily-initialized AsyncCambAI client."""
+        if self._client_instance is None:
+            self._client_instance = self._create_camb_client()
+        return self._client_instance
+
+    async def _stream_tts(self, text: str, voice: str, **kwargs) -> bytes:
+        """Stream TTS audio chunks and return concatenated bytes."""
+        from camb import StreamTtsOutputConfiguration
+
+        client = self._get_async_client()
+        language = kwargs.get("language", self.language)
+
+        tts_kwargs = {
+            "text": text,
+            "language": language,
+            "voice_id": _parse_voice_id(voice),
+            "speech_model": self.model_name,
+            "output_configuration": StreamTtsOutputConfiguration(format="mp3"),
+        }
+
+        user_instructions = kwargs.get("user_instructions")
+        if user_instructions and self.model_name == "mars-instruct":
+            tts_kwargs["user_instructions"] = user_instructions
+
+        chunks = []
+        async for chunk in client.text_to_speech.tts(**tts_kwargs):
+            chunks.append(chunk)
+
+        audio_bytes = b"".join(chunks)
+        if not audio_bytes:
+            raise RuntimeError("No audio data received from CAMB API")
+        return audio_bytes
+
+    async def _translated_tts(self, text: str, voice: str, **kwargs) -> bytes:
+        """Generate translated TTS using CAMB's translation API."""
+        client = self._get_async_client()
+        source_language = kwargs["source_language"]
+        target_language = kwargs["target_language"]
+
+        tts_kwargs = {
+            "text": text,
+            "voice_id": _parse_voice_id(voice),
+            "source_language": source_language,
+            "target_language": target_language,
+        }
+        formality = kwargs.get("formality")
+        if formality:
+            tts_kwargs["formality"] = formality
+
+        result = await client.translated_tts.create_translated_tts(**tts_kwargs)
+
+        # Poll for completion using configurable timeout
+        timeout = self.timeout or 120.0
+        poll_interval = 2.0
+        max_attempts = int(timeout / poll_interval)
+        for _ in range(max_attempts):
+            status = await client.translated_tts.get_translated_tts_task_status(
+                result.task_id, run_id=None
+            )
+            if hasattr(status, "status"):
+                if status.status in ("completed", "SUCCESS"):
+                    break
+                if status.status in ("failed", "FAILED", "error"):
+                    raise RuntimeError(
+                        f"Translated TTS failed: {getattr(status, 'error', 'Unknown error')}"
+                    )
+            await asyncio.sleep(poll_interval)
+        else:
+            raise TimeoutError(
+                f"Translated TTS task did not complete within {timeout}s"
+            )
+
+        run_id = getattr(status, "run_id", None)
+        if not run_id:
+            raise RuntimeError("Translated TTS completed but no run_id returned")
+
+        url = _CAMB_TTS_RESULT_URL.format(run_id=run_id)
+        async with httpx.AsyncClient(timeout=self.timeout or 60.0) as http:
+            resp = await http.get(
+                url, headers={"x-api-key": self.api_key or ""}
+            )
+            if resp.status_code != 200:
+                raise RuntimeError(
+                    f"Failed to fetch translated TTS audio: HTTP {resp.status_code}"
+                )
+            return resp.content
+
+    def generate_speech(
+        self,
+        text: str,
+        voice: str,
+        output_file: Optional[Union[str, Path]] = None,
+        **kwargs,
+    ) -> AudioResponse:
+        """Generate speech synchronously."""
+        self.validate_parameters(text, voice)
+        audio_bytes = _run_async(self._do_generate(text, voice, **kwargs))
+        return self._build_response(audio_bytes, voice, output_file)
+
+    async def agenerate_speech(
+        self,
+        text: str,
+        voice: str,
+        output_file: Optional[Union[str, Path]] = None,
+        **kwargs,
+    ) -> AudioResponse:
+        """Generate speech asynchronously."""
+        self.validate_parameters(text, voice)
+        audio_bytes = await self._do_generate(text, voice, **kwargs)
+        return self._build_response(audio_bytes, voice, output_file)
+
+    async def _do_generate(self, text: str, voice: str, **kwargs) -> bytes:
+        """Route to streaming TTS or translated TTS based on kwargs."""
+        if "target_language" in kwargs and "source_language" in kwargs:
+            return await self._translated_tts(text, voice, **kwargs)
+        return await self._stream_tts(text, voice, **kwargs)
+
+    def _build_response(
+        self,
+        audio_bytes: bytes,
+        voice: str,
+        output_file: Optional[Union[str, Path]] = None,
+    ) -> AudioResponse:
+        """Build AudioResponse and optionally save to file."""
+        response = AudioResponse(
+            audio_data=audio_bytes,
+            content_type="audio/mp3",
+            model=self.model_name,
+            voice=voice,
+            provider="camb",
+        )
+
+        if output_file:
+            output_path = Path(output_file)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(audio_bytes)
+
+        return response
+
+    @property
+    def available_voices(self) -> Dict[str, Voice]:
+        """Get available voices from CAMB AI."""
+        if self._available_voices is not None:
+            return self._available_voices
+
+        self._available_voices = _run_async(self._fetch_voices())
+        return self._available_voices
+
+    async def _fetch_voices(self) -> Dict[str, Voice]:
+        """Fetch voices from the CAMB API."""
+        try:
+            # Use a fresh client to avoid event loop issues when called
+            # from a background thread via _run_async
+            client = self._create_camb_client()
+            voice_list = await client.voice_cloning.list_voices()
+        except Exception:
+            return {}
+
+        voices = {}
+        for v in voice_list:
+            # Voice list items can be dicts or Voice objects
+            if isinstance(v, dict):
+                voice_id = str(v.get("id", ""))
+                voice_name = v.get("voice_name", v.get("name", "Unknown"))
+                gender_code = v.get("gender", 0)
+                language = v.get("language")
+                age = v.get("age")
+            else:
+                voice_id = str(getattr(v, "id", ""))
+                voice_name = getattr(v, "voice_name", getattr(v, "name", "Unknown"))
+                gender_code = getattr(v, "gender", 0)
+                language = getattr(v, "language", None)
+                age = getattr(v, "age", None)
+
+            gender = {0: "NEUTRAL", 1: "MALE", 2: "FEMALE", 9: "NEUTRAL"}.get(
+                gender_code, "NEUTRAL"
+            )
+
+            voices[voice_id] = Voice(
+                name=voice_name,
+                id=voice_id,
+                gender=gender,
+                language_code=str(language) if language else None,
+                description=None,
+                age=str(age) if age is not None else None,
+            )
+
+        return voices
+
+    def _get_models(self) -> List[Model]:
+        """List available CAMB TTS models."""
+        return [
+            Model(id="mars-pro", owned_by="camb"),
+            Model(id="mars-flash", owned_by="camb"),
+            Model(id="mars-instruct", owned_by="camb"),
+        ]

--- a/tests/providers/tts/test_camb.py
+++ b/tests/providers/tts/test_camb.py
@@ -1,0 +1,371 @@
+"""Tests for the CAMB AI TTS provider."""
+
+import asyncio
+import os
+import sys
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+# Mock the camb module before importing the provider
+camb_mock = MagicMock()
+camb_mock.StreamTtsOutputConfiguration = MagicMock
+sys.modules.setdefault("camb", camb_mock)
+sys.modules.setdefault("camb.client", MagicMock())
+
+from esperanto.providers.tts.camb import CambTextToSpeechModel, _parse_voice_id
+
+
+@pytest.fixture(autouse=True)
+def set_api_key():
+    """Set CAMB_API_KEY for all tests."""
+    os.environ["CAMB_API_KEY"] = "test-key"
+    yield
+    os.environ.pop("CAMB_API_KEY", None)
+
+
+@pytest.fixture
+def tts_model():
+    """Create a CAMB TTS model instance."""
+    return CambTextToSpeechModel(api_key="test-key", model_name="mars-pro")
+
+
+def _make_mock_client(chunks=None):
+    """Create a mock CAMB client with a streaming TTS method."""
+    if chunks is None:
+        chunks = [b"audio"]
+
+    captured_kwargs = {}
+
+    async def mock_tts_stream(**kwargs):
+        captured_kwargs.update(kwargs)
+        for chunk in chunks:
+            yield chunk
+
+    mock_client = MagicMock()
+    mock_client.text_to_speech.tts = mock_tts_stream
+    return mock_client, captured_kwargs
+
+
+class TestInit:
+    """Test initialization."""
+
+    def test_init_defaults(self, tts_model):
+        assert tts_model.model_name == "mars-pro"
+        assert tts_model.PROVIDER == "camb"
+        assert tts_model.api_key == "test-key"
+        assert tts_model.language == "en-us"
+
+    def test_init_custom_language(self):
+        model = CambTextToSpeechModel(api_key="test-key", language="fr-fr")
+        assert model.language == "fr-fr"
+
+    def test_init_default_model(self):
+        model = CambTextToSpeechModel(api_key="test-key")
+        assert model.model_name == "mars-pro"
+
+    def test_init_missing_api_key(self):
+        os.environ.pop("CAMB_API_KEY", None)
+        with pytest.raises(ValueError, match="CAMB API key not provided"):
+            CambTextToSpeechModel()
+
+    def test_init_from_env(self):
+        model = CambTextToSpeechModel()
+        assert model.api_key == "test-key"
+
+
+class TestGenerateSpeech:
+    """Test speech generation."""
+
+    @pytest.mark.asyncio
+    async def test_agenerate_speech_streams_chunks(self, tts_model):
+        """Test that agenerate_speech accumulates streaming chunks correctly."""
+        mock_client, _ = _make_mock_client([b"chunk1", b"chunk2", b"chunk3"])
+        tts_model._client_instance = mock_client
+
+        response = await tts_model.agenerate_speech(
+            text="Hello world", voice="147320"
+        )
+
+        assert response.audio_data == b"chunk1chunk2chunk3"
+        assert response.content_type == "audio/mp3"
+        assert response.model == "mars-pro"
+        assert response.voice == "147320"
+        assert response.provider == "camb"
+
+    def test_generate_speech_sync(self, tts_model):
+        """Test synchronous speech generation wraps async correctly."""
+        mock_client, _ = _make_mock_client([b"audio_data"])
+        tts_model._client_instance = mock_client
+
+        response = tts_model.generate_speech(text="Hello world", voice="147320")
+
+        assert response.audio_data == b"audio_data"
+        assert response.provider == "camb"
+
+    @pytest.mark.asyncio
+    async def test_voice_id_converted_to_int(self, tts_model):
+        """Test that string voice ID is converted to int for CAMB API."""
+        mock_client, captured = _make_mock_client()
+        tts_model._client_instance = mock_client
+
+        await tts_model.agenerate_speech(text="Hello", voice="147320")
+
+        assert captured["voice_id"] == 147320
+        assert isinstance(captured["voice_id"], int)
+
+    @pytest.mark.asyncio
+    async def test_language_propagation(self, tts_model):
+        """Test that language parameter is propagated correctly."""
+        mock_client, captured = _make_mock_client()
+        tts_model._client_instance = mock_client
+
+        await tts_model.agenerate_speech(
+            text="Bonjour", voice="147320", language="fr-fr"
+        )
+
+        assert captured["language"] == "fr-fr"
+
+    @pytest.mark.asyncio
+    async def test_default_language_used(self, tts_model):
+        """Test that default language is used when not specified."""
+        mock_client, captured = _make_mock_client()
+        tts_model._client_instance = mock_client
+
+        await tts_model.agenerate_speech(text="Hello", voice="147320")
+
+        assert captured["language"] == "en-us"
+
+    @pytest.mark.asyncio
+    async def test_user_instructions_mars_instruct(self):
+        """Test user_instructions only passed for mars-instruct model."""
+        model = CambTextToSpeechModel(
+            api_key="test-key", model_name="mars-instruct"
+        )
+        mock_client, captured = _make_mock_client()
+        model._client_instance = mock_client
+
+        await model.agenerate_speech(
+            text="Hello",
+            voice="147320",
+            user_instructions="Speak slowly",
+        )
+
+        assert captured["user_instructions"] == "Speak slowly"
+
+    @pytest.mark.asyncio
+    async def test_user_instructions_ignored_non_instruct(self, tts_model):
+        """Test user_instructions is ignored for non-instruct models."""
+        mock_client, captured = _make_mock_client()
+        tts_model._client_instance = mock_client
+
+        await tts_model.agenerate_speech(
+            text="Hello",
+            voice="147320",
+            user_instructions="Speak slowly",
+        )
+
+        assert "user_instructions" not in captured
+
+    @pytest.mark.asyncio
+    async def test_output_file_saves(self, tts_model, tmp_path):
+        """Test that output file is saved correctly."""
+        mock_client, _ = _make_mock_client([b"audio_data"])
+        tts_model._client_instance = mock_client
+
+        output_file = tmp_path / "output.mp3"
+        response = await tts_model.agenerate_speech(
+            text="Hello", voice="147320", output_file=str(output_file)
+        )
+
+        assert output_file.read_bytes() == b"audio_data"
+        assert response.audio_data == b"audio_data"
+
+
+class TestTranslatedTTS:
+    """Test translated TTS functionality."""
+
+    @pytest.mark.asyncio
+    async def test_translated_tts_routes_correctly(self, tts_model):
+        """Test that target_language + source_language triggers translation path."""
+        mock_client = MagicMock()
+
+        mock_result = MagicMock()
+        mock_result.task_id = "task-123"
+        mock_client.translated_tts.create_translated_tts = AsyncMock(
+            return_value=mock_result
+        )
+
+        mock_status = MagicMock()
+        mock_status.status = "completed"
+        mock_status.run_id = "run-456"
+        mock_client.translated_tts.get_translated_tts_task_status = AsyncMock(
+            return_value=mock_status
+        )
+
+        tts_model._client_instance = mock_client
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = b"translated_audio"
+
+        mock_http_client = AsyncMock()
+        mock_http_client.__aenter__ = AsyncMock(return_value=mock_http_client)
+        mock_http_client.__aexit__ = AsyncMock(return_value=None)
+        mock_http_client.get = AsyncMock(return_value=mock_resp)
+
+        with patch("esperanto.providers.tts.camb.httpx") as mock_httpx:
+            mock_httpx.AsyncClient.return_value = mock_http_client
+
+            response = await tts_model.agenerate_speech(
+                text="Hello",
+                voice="147320",
+                source_language=1,
+                target_language=2,
+            )
+
+        assert response.audio_data == b"translated_audio"
+        mock_client.translated_tts.create_translated_tts.assert_called_once()
+
+
+class TestAvailableVoices:
+    """Test voice listing."""
+
+    def test_available_voices(self, tts_model):
+        """Test fetching and mapping voices."""
+        mock_voice = MagicMock()
+        mock_voice.id = 147320
+        mock_voice.voice_name = "Test Voice"
+        mock_voice.gender = 2  # female
+        mock_voice.language = "en"
+        mock_voice.age = 21
+
+        mock_client = MagicMock()
+        mock_client.voice_cloning.list_voices = AsyncMock(
+            return_value=[mock_voice]
+        )
+
+        with patch.object(tts_model, "_create_camb_client", return_value=mock_client):
+            voices = tts_model.available_voices
+
+        assert "147320" in voices
+        assert voices["147320"].name == "Test Voice"
+        assert voices["147320"].id == "147320"
+        assert voices["147320"].gender == "FEMALE"
+        assert voices["147320"].age == "21"
+
+    def test_voices_cached(self, tts_model):
+        """Test that voices are cached after first fetch."""
+        mock_voice = MagicMock()
+        mock_voice.id = 1
+        mock_voice.voice_name = "Voice"
+        mock_voice.gender = 1
+        mock_voice.language = "en"
+        mock_voice.age = None
+
+        mock_client = MagicMock()
+        mock_client.voice_cloning.list_voices = AsyncMock(
+            return_value=[mock_voice]
+        )
+
+        with patch.object(tts_model, "_create_camb_client", return_value=mock_client):
+            voices1 = tts_model.available_voices
+            voices2 = tts_model.available_voices
+
+        # Should only create client once (cached after first call)
+        assert voices1 is voices2
+
+    def test_fetch_voices_api_failure_returns_empty(self, tts_model):
+        """Test that API failure returns empty dict instead of crashing."""
+        mock_client = MagicMock()
+        mock_client.voice_cloning.list_voices = AsyncMock(
+            side_effect=RuntimeError("API error")
+        )
+
+        with patch.object(tts_model, "_create_camb_client", return_value=mock_client):
+            voices = tts_model.available_voices
+
+        assert voices == {}
+
+    def test_fetch_voices_dict_format(self, tts_model):
+        """Test voice list items returned as dicts."""
+        voice_dict = {
+            "id": 99999,
+            "voice_name": "Dict Voice",
+            "gender": 1,
+            "language": "fr",
+            "age": 30,
+        }
+
+        mock_client = MagicMock()
+        mock_client.voice_cloning.list_voices = AsyncMock(
+            return_value=[voice_dict]
+        )
+
+        with patch.object(tts_model, "_create_camb_client", return_value=mock_client):
+            voices = tts_model.available_voices
+
+        assert "99999" in voices
+        assert voices["99999"].name == "Dict Voice"
+        assert voices["99999"].gender == "MALE"
+        assert voices["99999"].age == "30"
+
+
+class TestGetModels:
+    """Test model listing."""
+
+    def test_get_models(self, tts_model):
+        models = tts_model._get_models()
+        model_ids = [m.id for m in models]
+        assert "mars-pro" in model_ids
+        assert "mars-flash" in model_ids
+        assert "mars-instruct" in model_ids
+
+
+class TestVoiceIdParsing:
+    """Test voice ID validation."""
+
+    def test_valid_numeric_string(self):
+        assert _parse_voice_id("147320") == 147320
+
+    def test_non_numeric_raises(self):
+        with pytest.raises(ValueError, match="CAMB voice ID must be numeric"):
+            _parse_voice_id("invalid")
+
+    def test_empty_string_raises(self):
+        with pytest.raises(ValueError, match="CAMB voice ID must be numeric"):
+            _parse_voice_id("")
+
+    @pytest.mark.asyncio
+    async def test_non_numeric_voice_in_agenerate(self, tts_model):
+        """Test that non-numeric voice ID raises clear error in agenerate_speech."""
+        mock_client, _ = _make_mock_client()
+        tts_model._client_instance = mock_client
+
+        with pytest.raises(ValueError, match="CAMB voice ID must be numeric"):
+            await tts_model.agenerate_speech(text="Hello", voice="not-a-number")
+
+
+class TestEmptyAudioValidation:
+    """Test empty audio response handling."""
+
+    @pytest.mark.asyncio
+    async def test_empty_stream_raises(self, tts_model):
+        """Test that empty audio stream raises RuntimeError."""
+        mock_client, _ = _make_mock_client(chunks=[])
+        tts_model._client_instance = mock_client
+
+        with pytest.raises(RuntimeError, match="No audio data received"):
+            await tts_model.agenerate_speech(text="Hello", voice="147320")
+
+
+class TestValidation:
+    """Test input validation."""
+
+    def test_empty_text_raises(self, tts_model):
+        with pytest.raises(ValueError, match="Text must be"):
+            tts_model.generate_speech(text="", voice="147320")
+
+    def test_empty_voice_raises(self, tts_model):
+        with pytest.raises(ValueError, match="Voice must be"):
+            tts_model.generate_speech(text="Hello", voice="")

--- a/uv.lock
+++ b/uv.lock
@@ -131,6 +131,22 @@ wheels = [
 ]
 
 [[package]]
+name = "camb-sdk"
+version = "1.5.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+    { name = "websocket-client" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/38/31fcc633963804a150175078c167f237bbd56dedba9903e4800a630ab944/camb_sdk-1.5.10.tar.gz", hash = "sha256:e1d23cbccea5aef5944612740b5c2e109a3c3ce778caa9664678a23b3a254419", size = 83643, upload-time = "2026-03-12T11:40:36.822Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/12/f294bf4f343b663dced6d8ea840985d58b0afd66cd40e221fc19dc6639f4/camb_sdk-1.5.10-py3-none-any.whl", hash = "sha256:5ec6014af18cf108041c921f743fbcabc17015df2fc4b7a17793ef17d0fe593a", size = 152463, upload-time = "2026-03-12T11:38:37.934Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -382,8 +398,10 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/49/498c86566a1d80e978b42f0d702795f69887005548c041636df6ae1ca64c/cryptography-46.0.3-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:01ca9ff2885f3acc98c29f1860552e37f6d7c7d013d7334ff2a9de43a449315d", size = 4450807, upload-time = "2025-10-15T23:16:56.414Z" },
     { url = "https://files.pythonhosted.org/packages/4b/0a/863a3604112174c8624a2ac3c038662d9e59970c7f926acdcfaed8d61142/cryptography-46.0.3-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6eae65d4c3d33da080cff9c4ab1f711b15c1d9760809dad6ea763f3812d254cb", size = 4299615, upload-time = "2025-10-15T23:16:58.442Z" },
     { url = "https://files.pythonhosted.org/packages/64/02/b73a533f6b64a69f3cd3872acb6ebc12aef924d8d103133bb3ea750dc703/cryptography-46.0.3-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5bf0ed4490068a2e72ac03d786693adeb909981cc596425d09032d372bcc849", size = 4016800, upload-time = "2025-10-15T23:17:00.378Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d5/16e41afbfa450cde85a3b7ec599bebefaef16b5c6ba4ec49a3532336ed72/cryptography-46.0.3-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5ecfccd2329e37e9b7112a888e76d9feca2347f12f37918facbb893d7bb88ee8", size = 4984707, upload-time = "2025-10-15T23:17:01.98Z" },
     { url = "https://files.pythonhosted.org/packages/c9/56/e7e69b427c3878352c2fb9b450bd0e19ed552753491d39d7d0a2f5226d41/cryptography-46.0.3-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a2c0cd47381a3229c403062f764160d57d4d175e022c1df84e168c6251a22eec", size = 4482541, upload-time = "2025-10-15T23:17:04.078Z" },
     { url = "https://files.pythonhosted.org/packages/78/f6/50736d40d97e8483172f1bb6e698895b92a223dba513b0ca6f06b2365339/cryptography-46.0.3-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:549e234ff32571b1f4076ac269fcce7a808d3bf98b76c8dd560e42dbc66d7d91", size = 4299464, upload-time = "2025-10-15T23:17:05.483Z" },
+    { url = "https://files.pythonhosted.org/packages/00/de/d8e26b1a855f19d9994a19c702fa2e93b0456beccbcfe437eda00e0701f2/cryptography-46.0.3-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:c0a7bb1a68a5d3471880e264621346c48665b3bf1c3759d682fc0864c540bd9e", size = 4950838, upload-time = "2025-10-15T23:17:07.425Z" },
     { url = "https://files.pythonhosted.org/packages/8f/29/798fc4ec461a1c9e9f735f2fc58741b0daae30688f41b2497dcbc9ed1355/cryptography-46.0.3-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:10b01676fc208c3e6feeb25a8b83d81767e8059e1fe86e1dc62d10a3018fa926", size = 4481596, upload-time = "2025-10-15T23:17:09.343Z" },
     { url = "https://files.pythonhosted.org/packages/15/8d/03cd48b20a573adfff7652b76271078e3045b9f49387920e7f1f631d125e/cryptography-46.0.3-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0abf1ffd6e57c67e92af68330d05760b7b7efb243aab8377e583284dbab72c71", size = 4426782, upload-time = "2025-10-15T23:17:11.22Z" },
     { url = "https://files.pythonhosted.org/packages/fa/b1/ebacbfe53317d55cf33165bda24c86523497a6881f339f9aae5c2e13e57b/cryptography-46.0.3-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a04bee9ab6a4da801eb9b51f1b708a1b5b5c9eb48c03f74198464c66f0d344ac", size = 4698381, upload-time = "2025-10-15T23:17:12.829Z" },
@@ -391,8 +409,10 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/26/42/fa8389d4478368743e24e61eea78846a0006caffaf72ea24a15159215a14/cryptography-46.0.3-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:15ab9b093e8f09daab0f2159bb7e47532596075139dd74365da52ecc9cb46c5d", size = 4440029, upload-time = "2025-10-15T23:17:49.837Z" },
     { url = "https://files.pythonhosted.org/packages/5f/eb/f483db0ec5ac040824f269e93dd2bd8a21ecd1027e77ad7bdf6914f2fd80/cryptography-46.0.3-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:46acf53b40ea38f9c6c229599a4a13f0d46a6c3fa9ef19fc1a124d62e338dfa0", size = 4297222, upload-time = "2025-10-15T23:17:51.357Z" },
     { url = "https://files.pythonhosted.org/packages/fd/cf/da9502c4e1912cb1da3807ea3618a6829bee8207456fbbeebc361ec38ba3/cryptography-46.0.3-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:10ca84c4668d066a9878890047f03546f3ae0a6b8b39b697457b7757aaf18dbc", size = 4012280, upload-time = "2025-10-15T23:17:52.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8f/9adb86b93330e0df8b3dcf03eae67c33ba89958fc2e03862ef1ac2b42465/cryptography-46.0.3-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:36e627112085bb3b81b19fed209c05ce2a52ee8b15d161b7c643a7d5a88491f3", size = 4978958, upload-time = "2025-10-15T23:17:54.965Z" },
     { url = "https://files.pythonhosted.org/packages/d1/a0/5fa77988289c34bdb9f913f5606ecc9ada1adb5ae870bd0d1054a7021cc4/cryptography-46.0.3-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1000713389b75c449a6e979ffc7dcc8ac90b437048766cef052d4d30b8220971", size = 4473714, upload-time = "2025-10-15T23:17:56.754Z" },
     { url = "https://files.pythonhosted.org/packages/14/e5/fc82d72a58d41c393697aa18c9abe5ae1214ff6f2a5c18ac470f92777895/cryptography-46.0.3-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:b02cf04496f6576afffef5ddd04a0cb7d49cf6be16a9059d793a30b035f6b6ac", size = 4296970, upload-time = "2025-10-15T23:17:58.588Z" },
+    { url = "https://files.pythonhosted.org/packages/78/06/5663ed35438d0b09056973994f1aec467492b33bd31da36e468b01ec1097/cryptography-46.0.3-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:71e842ec9bc7abf543b47cf86b9a743baa95f4677d22baa4c7d5c69e49e9bc04", size = 4940236, upload-time = "2025-10-15T23:18:00.897Z" },
     { url = "https://files.pythonhosted.org/packages/fc/59/873633f3f2dcd8a053b8dd1d38f783043b5fce589c0f6988bf55ef57e43e/cryptography-46.0.3-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:402b58fc32614f00980b66d6e56a5b4118e6cb362ae8f3fda141ba4689bd4506", size = 4472642, upload-time = "2025-10-15T23:18:02.749Z" },
     { url = "https://files.pythonhosted.org/packages/3d/39/8e71f3930e40f6877737d6f69248cf74d4e34b886a3967d32f919cc50d3b/cryptography-46.0.3-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef639cb3372f69ec44915fafcd6698b6cc78fbe0c2ea41be867f6ed612811963", size = 4423126, upload-time = "2025-10-15T23:18:04.85Z" },
     { url = "https://files.pythonhosted.org/packages/cd/c7/f65027c2810e14c3e7268353b1681932b87e5a48e65505d8cc17c99e36ae/cryptography-46.0.3-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3b51b8ca4f1c6453d8829e1eb7299499ca7f313900dd4d89a24b8b87c0a780d4", size = 4686573, upload-time = "2025-10-15T23:18:06.908Z" },
@@ -497,7 +517,7 @@ wheels = [
 
 [[package]]
 name = "esperanto"
-version = "2.19.5"
+version = "2.19.7"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -505,6 +525,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+camb = [
+    { name = "camb-sdk" },
+]
 transformers = [
     { name = "accelerate" },
     { name = "einops" },
@@ -550,6 +573,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "accelerate", marker = "extra == 'transformers'", specifier = ">=1.12.0,<2.0.0" },
+    { name = "camb-sdk", marker = "extra == 'camb'", specifier = ">=1.0.0" },
     { name = "einops", marker = "extra == 'transformers'", specifier = ">=0.8.1" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "jsonschema", marker = "extra == 'validation'", specifier = ">=4.0.0,<5.0.0" },
@@ -561,7 +585,7 @@ requires-dist = [
     { name = "torch", marker = "extra == 'transformers'", specifier = ">=2.9.1,<3.0.0" },
     { name = "transformers", marker = "extra == 'transformers'", specifier = ">=4.57.3,<5.0.0" },
 ]
-provides-extras = ["transformers", "validation"]
+provides-extras = ["transformers", "camb", "validation"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3312,6 +3336,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/8b/4b61d6e13f7108f36910df9ab4b58fd389cc2520d54d81b88660804aad99/torch-2.10.0-2-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:418997cb02d0a0f1497cf6a09f63166f9f5df9f3e16c8a716ab76a72127c714f", size = 79423467, upload-time = "2026-02-10T21:44:48.711Z" },
     { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
     { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ee/efbd56687be60ef9af0c9c0ebe106964c07400eade5b0af8902a1d8cd58c/torch-2.10.0-3-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a1ff626b884f8c4e897c4c33782bdacdff842a165fee79817b1dd549fdda1321", size = 915510070, upload-time = "2026-03-11T14:16:39.386Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ab/7b562f1808d3f65414cd80a4f7d4bb00979d9355616c034c171249e1a303/torch-2.10.0-3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:ac5bdcbb074384c66fa160c15b1ead77839e3fe7ed117d667249afce0acabfac", size = 915518691, upload-time = "2026-03-11T14:15:43.147Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
     { url = "https://files.pythonhosted.org/packages/0c/1a/c61f36cfd446170ec27b3a4984f072fd06dab6b5d7ce27e11adb35d6c838/torch-2.10.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:5276fa790a666ee8becaffff8acb711922252521b28fbce5db7db5cf9cb2026d", size = 145992962, upload-time = "2026-01-21T16:24:14.04Z" },
     { url = "https://files.pythonhosted.org/packages/b5/60/6662535354191e2d1555296045b63e4279e5a9dbad49acf55a5d38655a39/torch-2.10.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:aaf663927bcd490ae971469a624c322202a2a1e68936eb952535ca4cd3b90444", size = 915599237, upload-time = "2026-01-21T16:23:25.497Z" },
     { url = "https://files.pythonhosted.org/packages/40/b8/66bbe96f0d79be2b5c697b2e0b187ed792a15c6c4b8904613454651db848/torch-2.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:a4be6a2a190b32ff5c8002a0977a25ea60e64f7ba46b1be37093c141d9c49aeb", size = 113720931, upload-time = "2026-01-21T16:24:23.743Z" },
@@ -3506,6 +3535,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/38/75/2144b65e4fba12a2d9868e9a3f99db7fa0760670d064603634bef9ff1709/wcwidth-0.3.0.tar.gz", hash = "sha256:af1a2fb0b83ef4a7fc0682a4c95ca2576e14d0280bca2a9e67b7dc9f2733e123", size = 172238, upload-time = "2026-01-21T17:44:09.508Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/0e/a5f0257ab47492b7afb5fb60347d14ba19445e2773fc8352d4be6bd2f6f8/wcwidth-0.3.0-py3-none-any.whl", hash = "sha256:073a1acb250e4add96cfd5ef84e0036605cd6e0d0782c8c15c80e42202348458", size = 85520, upload-time = "2026-01-21T17:44:08.002Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Hi! We're the team at [CAMB AI](https://camb.ai) — we build the localization engine trusted by major sports brands like the Premier League, NASCAR, the Australian Open, and the NBA.

We'd love to be included in esperanto as a TTS provider. This PR adds full CAMB AI TTS support:

- **Streaming TTS** via `mars-pro`, `mars-flash`, and `mars-instruct` models
- **Translated TTS** — translate + speak in one API call (140+ languages)
- **Voice listing** from the CAMB API with caching
- **Async-first** design with sync wrapper support
- Registered in `AIFactory` as `"camb"` provider
- `camb-sdk` added as optional dependency (`pip install esperanto[camb]`)

### Usage

```python
from esperanto import AIFactory

tts = AIFactory.create_text_to_speech("camb", "mars-pro", api_key="...")
response = await tts.agenerate_speech(
    text="Hello world",
    voice="147320",
    language="en-us",
)
```

### Files changed
- `src/esperanto/providers/tts/camb.py` — new provider implementation
- `src/esperanto/factory.py` — register `"camb"` provider
- `pyproject.toml` — add `[camb]` optional dependency
- `tests/providers/tts/test_camb.py` — 26 unit tests