### PR TITLE
fix: Ollama thinking models and trailing slash in base URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.20.1] - 2026-04-13
+
+### Fixed
+
+- **Ollama thinking models return empty content** — Models like Qwen 3.5 that return a separate `thinking` field in the JSON response (instead of inline `<think>` tags) now have their thinking content correctly merged into the response. Use `message.cleaned_content` for the actual response and `message.thinking` for the reasoning trace. (#112)
+- **Trailing slash in base URL causes double-slash and 301 redirect** — All providers now strip trailing slashes from `base_url` during HTTP client initialization, preventing double-slash URLs (e.g., `http://localhost:11434//api/chat`) that caused silent failures with empty responses. (#113)
+
 ## [2.20.0] - 2026-03-21
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esperanto"
-version = "2.20.0"
+version = "2.20.1"
 description = "A light-weight, production-ready, unified interface for various AI model providers"
 authors = [
     { name = "LUIS NOVO", email = "lfnovo@gmail.com" }

--- a/src/esperanto/common_types/response.py
+++ b/src/esperanto/common_types/response.py
@@ -162,6 +162,16 @@ class Message(BaseModel):
         # If a separate 'thinking' field is provided (e.g., from Ollama thinking models),
         # merge it into content using <think> tags so that Message.thinking and
         # Message.cleaned_content properties work consistently across all providers.
+        # Convert mock objects to strings for content field
+        if "content" in data and data["content"] is not None:
+            try:
+                data["content"] = str(data["content"])
+            except Exception:
+                pass
+
+        # If a separate 'thinking' field is provided (e.g., from Ollama thinking models),
+        # merge it into content using <think> tags so that Message.thinking and
+        # Message.cleaned_content properties work consistently across all providers.
         thinking = data.pop("thinking", None)
         if thinking:
             content = data.get("content") or ""
@@ -169,13 +179,6 @@ class Message(BaseModel):
                 data["content"] = f"<think>{thinking}</think>\n\n{content}"
             else:
                 data["content"] = f"<think>{thinking}</think>"
-
-        # Convert mock objects to strings for content field
-        if "content" in data and data["content"] is not None:
-            try:
-                data["content"] = str(data["content"])
-            except Exception:
-                pass
 
         # Convert dict tool_calls to ToolCall objects for backward compatibility
         if "tool_calls" in data and data["tool_calls"]:

--- a/src/esperanto/common_types/response.py
+++ b/src/esperanto/common_types/response.py
@@ -159,6 +159,17 @@ class Message(BaseModel):
         if not isinstance(data, dict):
             data = to_dict(data)
 
+        # If a separate 'thinking' field is provided (e.g., from Ollama thinking models),
+        # merge it into content using <think> tags so that Message.thinking and
+        # Message.cleaned_content properties work consistently across all providers.
+        thinking = data.pop("thinking", None)
+        if thinking:
+            content = data.get("content") or ""
+            if content:
+                data["content"] = f"<think>{thinking}</think>\n\n{content}"
+            else:
+                data["content"] = f"<think>{thinking}</think>"
+
         # Convert mock objects to strings for content field
         if "content" in data and data["content"] is not None:
             try:

--- a/src/esperanto/providers/llm/ollama.py
+++ b/src/esperanto/providers/llm/ollama.py
@@ -462,6 +462,7 @@ class OllamaLanguageModel(LanguageModel):
                     message=Message(
                         role=message.get("role", "assistant"),
                         content=message.get("content") or "",
+                        thinking=message.get("thinking"),
                         tool_calls=tool_calls,
                     ),
                     finish_reason=finish_reason,
@@ -516,6 +517,7 @@ class OllamaLanguageModel(LanguageModel):
                     delta=DeltaMessage(
                         role=message.get("role", "assistant"),
                         content=message.get("content") or "",
+                        thinking=message.get("thinking"),
                         tool_calls=tool_calls_data,
                     ),
                     finish_reason=finish_reason,

--- a/src/esperanto/utils/connect.py
+++ b/src/esperanto/utils/connect.py
@@ -32,6 +32,10 @@ class HttpConnectionMixin(TimeoutMixin, SSLMixin, ABC):
         Call this method in provider's __post_init__ after setting up
         API keys and base URLs.
         """
+        # Strip trailing slashes from base_url to avoid double-slash in URL paths
+        if hasattr(self, "base_url") and self.base_url:
+            self.base_url = self.base_url.rstrip("/")
+
         timeout = self._get_timeout()
         verify = self._get_ssl_verify()
         self.client = httpx.Client(timeout=timeout, verify=verify)

--- a/tests/providers/llm/test_ollama_provider.py
+++ b/tests/providers/llm/test_ollama_provider.py
@@ -545,6 +545,226 @@ class TestToolCallValidation:
         assert response.choices[0].message.tool_calls is not None
 
 
+# =============================================================================
+# Thinking Model Tests
+# =============================================================================
+
+
+class TestOllamaThinkingModels:
+    """Tests for Ollama thinking models (e.g., Qwen 3.5) that return a separate thinking field."""
+
+    def test_chat_complete_with_thinking(self):
+        """Test that thinking field from Ollama response is preserved."""
+        model = OllamaLanguageModel(model_name="qwen3.5:9b")
+
+        mock_response_data = {
+            "model": "qwen3.5:9b",
+            "message": {
+                "role": "assistant",
+                "content": "Hello",
+                "thinking": "The user asked me to say hello. I should respond with a greeting.",
+            },
+            "done": True,
+            "eval_count": 50,
+            "prompt_eval_count": 10,
+        }
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = mock_response_data
+
+        mock_client = Mock()
+        mock_client.post.return_value = mock_response
+        model.client = mock_client
+
+        completion = model.chat_complete([{"role": "user", "content": "Say hello"}])
+
+        msg = completion.choices[0].message
+        assert msg.cleaned_content == "Hello"
+        assert msg.thinking == "The user asked me to say hello. I should respond with a greeting."
+
+    def test_chat_complete_thinking_with_empty_content(self):
+        """Test thinking model response when content is empty."""
+        model = OllamaLanguageModel(model_name="qwen3.5:9b")
+
+        mock_response_data = {
+            "model": "qwen3.5:9b",
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "thinking": "Extensive reasoning here...",
+            },
+            "done": True,
+            "eval_count": 850,
+            "prompt_eval_count": 10,
+        }
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = mock_response_data
+
+        mock_client = Mock()
+        mock_client.post.return_value = mock_response
+        model.client = mock_client
+
+        completion = model.chat_complete([{"role": "user", "content": "Think hard"}])
+
+        msg = completion.choices[0].message
+        assert msg.thinking == "Extensive reasoning here..."
+        assert msg.cleaned_content == ""
+
+    def test_chat_complete_without_thinking(self):
+        """Test that normal responses (no thinking field) still work."""
+        model = OllamaLanguageModel(model_name="gemma2")
+
+        mock_response_data = {
+            "model": "gemma2",
+            "message": {
+                "role": "assistant",
+                "content": "Normal response",
+            },
+            "done": True,
+            "eval_count": 5,
+            "prompt_eval_count": 10,
+        }
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = mock_response_data
+
+        mock_client = Mock()
+        mock_client.post.return_value = mock_response
+        model.client = mock_client
+
+        completion = model.chat_complete([{"role": "user", "content": "Hello"}])
+
+        msg = completion.choices[0].message
+        assert msg.content == "Normal response"
+        assert msg.thinking is None
+        assert msg.cleaned_content == "Normal response"
+
+    @pytest.mark.asyncio
+    async def test_achat_complete_with_thinking(self):
+        """Test async chat completion with thinking field."""
+        model = OllamaLanguageModel(model_name="qwen3.5:9b")
+
+        mock_response_data = {
+            "model": "qwen3.5:9b",
+            "message": {
+                "role": "assistant",
+                "content": "42",
+                "thinking": "The answer to life, the universe, and everything.",
+            },
+            "done": True,
+            "eval_count": 30,
+            "prompt_eval_count": 10,
+        }
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = mock_response_data
+
+        mock_async_client = AsyncMock()
+        mock_async_client.post.return_value = mock_response
+        model.async_client = mock_async_client
+
+        completion = await model.achat_complete(
+            [{"role": "user", "content": "What is the answer?"}]
+        )
+
+        msg = completion.choices[0].message
+        assert msg.cleaned_content == "42"
+        assert msg.thinking == "The answer to life, the universe, and everything."
+
+    def test_streaming_with_thinking(self):
+        """Test streaming response with thinking field in chunks."""
+        model = OllamaLanguageModel(model_name="qwen3.5:9b")
+
+        stream_data = [
+            '{"model":"qwen3.5:9b","message":{"role":"assistant","content":"","thinking":"Let me think..."},"done":false}',
+            '{"model":"qwen3.5:9b","message":{"role":"assistant","content":"Hello"},"done":false}',
+            '{"model":"qwen3.5:9b","message":{"role":"assistant","content":""},"done":true}',
+        ]
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.iter_lines.return_value = stream_data
+
+        mock_client = Mock()
+        mock_client.post.return_value = mock_response
+        model.client = mock_client
+
+        chunks = list(
+            model.chat_complete(
+                [{"role": "user", "content": "Hello"}], stream=True
+            )
+        )
+
+        assert len(chunks) == 3
+        # First chunk has thinking
+        assert chunks[0].choices[0].delta.thinking == "Let me think..."
+        # Second chunk has content
+        assert chunks[1].choices[0].delta.cleaned_content == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_async_streaming_with_thinking(self):
+        """Test async streaming response with thinking field."""
+        model = OllamaLanguageModel(model_name="qwen3.5:9b")
+
+        async def mock_aiter_lines():
+            yield '{"model":"qwen3.5:9b","message":{"role":"assistant","content":"","thinking":"Reasoning..."},"done":false}'
+            yield '{"model":"qwen3.5:9b","message":{"role":"assistant","content":"Result"},"done":true}'
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.aiter_lines = mock_aiter_lines
+
+        mock_async_client = AsyncMock()
+        mock_async_client.post.return_value = mock_response
+        model.async_client = mock_async_client
+
+        stream = await model.achat_complete(
+            [{"role": "user", "content": "Think"}], stream=True
+        )
+        chunks = []
+        async for chunk in stream:
+            chunks.append(chunk)
+
+        assert len(chunks) == 2
+        assert chunks[0].choices[0].delta.thinking == "Reasoning..."
+        assert chunks[1].choices[0].delta.cleaned_content == "Result"
+
+
+# =============================================================================
+# Trailing Slash Tests
+# =============================================================================
+
+
+def test_ollama_base_url_trailing_slash_stripped():
+    """Test that trailing slash in base_url is stripped to avoid double-slash."""
+    model = OllamaLanguageModel(base_url="http://localhost:11434/")
+    assert model.base_url == "http://localhost:11434"
+
+
+def test_ollama_base_url_multiple_trailing_slashes_stripped():
+    """Test that multiple trailing slashes are stripped."""
+    model = OllamaLanguageModel(base_url="http://localhost:11434///")
+    assert model.base_url == "http://localhost:11434"
+
+
+def test_ollama_base_url_no_trailing_slash_unchanged():
+    """Test that base_url without trailing slash is unchanged."""
+    model = OllamaLanguageModel(base_url="http://localhost:11434")
+    assert model.base_url == "http://localhost:11434"
+
+
+def test_ollama_base_url_env_var_trailing_slash_stripped():
+    """Test that trailing slash from env var is also stripped."""
+    with patch.dict(os.environ, {"OLLAMA_BASE_URL": "http://env:11434/"}):
+        model = OllamaLanguageModel()
+        assert model.base_url == "http://env:11434"
+
+
 def test_ollama_default_num_ctx():
     """Test that default num_ctx (128000) is applied when not specified."""
     model = OllamaLanguageModel(model_name="gemma2")

--- a/tests/test_message_thinking.py
+++ b/tests/test_message_thinking.py
@@ -117,6 +117,87 @@ More response"""
         assert "The result" in msg.cleaned_content
 
 
+class TestMessageThinkingFieldMerge:
+    """Tests for merging a separate 'thinking' field into content via <think> tags.
+
+    Some providers (e.g., Ollama) return thinking as a separate JSON field
+    instead of inline <think> tags. The Message validator merges it automatically.
+    """
+
+    def test_thinking_field_merged_with_content(self):
+        """Test that a separate thinking field is merged into content."""
+        msg = Message(
+            content="Hello",
+            role="assistant",
+            thinking="I should greet the user.",
+        )
+        assert msg.content == "<think>I should greet the user.</think>\n\nHello"
+        assert msg.thinking == "I should greet the user."
+        assert msg.cleaned_content == "Hello"
+
+    def test_thinking_field_with_empty_content(self):
+        """Test thinking field when content is empty."""
+        msg = Message(
+            content="",
+            role="assistant",
+            thinking="Some reasoning here.",
+        )
+        assert msg.content == "<think>Some reasoning here.</think>"
+        assert msg.thinking == "Some reasoning here."
+        assert msg.cleaned_content == ""
+
+    def test_thinking_field_with_none_content(self):
+        """Test thinking field when content is None."""
+        msg = Message(
+            content=None,
+            role="assistant",
+            thinking="Some reasoning here.",
+        )
+        assert msg.content == "<think>Some reasoning here.</think>"
+        assert msg.thinking == "Some reasoning here."
+
+    def test_no_thinking_field_leaves_content_unchanged(self):
+        """Test that absence of thinking field doesn't affect content."""
+        msg = Message(content="Hello", role="assistant")
+        assert msg.content == "Hello"
+        assert msg.thinking is None
+
+    def test_empty_thinking_field_leaves_content_unchanged(self):
+        """Test that empty thinking field doesn't affect content."""
+        msg = Message(content="Hello", role="assistant", thinking="")
+        assert msg.content == "Hello"
+        assert msg.thinking is None
+
+    def test_none_thinking_field_leaves_content_unchanged(self):
+        """Test that None thinking field doesn't affect content."""
+        msg = Message(content="Hello", role="assistant", thinking=None)
+        assert msg.content == "Hello"
+        assert msg.thinking is None
+
+    def test_thinking_field_with_multiline_reasoning(self):
+        """Test thinking field with multiline reasoning content."""
+        reasoning = "Step 1: Analyze the request.\nStep 2: Formulate response.\nStep 3: Reply."
+        msg = Message(
+            content="The answer is 42.",
+            role="assistant",
+            thinking=reasoning,
+        )
+        assert msg.thinking == reasoning
+        assert msg.cleaned_content == "The answer is 42."
+
+    def test_thinking_field_does_not_conflict_with_inline_tags(self):
+        """Test that thinking field works alongside inline <think> tags in content."""
+        msg = Message(
+            content="<think>Inline reasoning</think>\n\nResult",
+            role="assistant",
+            thinking="Field reasoning",
+        )
+        # The field thinking wraps the whole content
+        assert "Field reasoning" in msg.thinking
+        assert "Inline reasoning" in msg.thinking
+        assert "Result" in msg.cleaned_content
+
+
 class TestMessageThinkingIntegration:
     """Integration tests for thinking/cleaned_content with real-world examples."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -497,7 +497,7 @@ wheels = [
 
 [[package]]
 name = "esperanto"
-version = "2.20.0"
+version = "2.20.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- **Fix #112**: Ollama thinking models (e.g., Qwen 3.5) return a separate `thinking` JSON field instead of inline `<think>` tags, causing `content` to appear empty. The `Message` validator now generically merges any `thinking` field into content using `<think>` tags, so `message.cleaned_content` returns the actual response and `message.thinking` returns the reasoning trace.
- **Fix #113**: Trailing slashes in `base_url` (e.g., `OLLAMA_BASE_URL=http://localhost:11434/`) caused double-slash URLs and 301 redirects with empty responses. `HttpConnectionMixin._create_http_clients()` now strips trailing slashes — applies to all providers generically.
- Bump version to 2.20.1

## Test plan

- [x] 8 new tests for generic `thinking` field merge in `Message` validator
- [x] 6 new Ollama-specific tests: sync, async, streaming sync/async, empty content, no thinking
- [x] 4 new trailing slash tests for Ollama (explicit, env var, multiple slashes, no slash)
- [x] All 436 existing LLM tests pass with no regressions