### PR TITLE
feat: add Mistral TTS provider (Voxtral)

### DIFF
--- a/src/esperanto/__init__.py
+++ b/src/esperanto/__init__.py
@@ -111,6 +111,11 @@ try:
 except ImportError:
     VertexTextToSpeechModel = None
 
+try:
+    from esperanto.providers.tts.mistral import MistralTextToSpeechModel
+except ImportError:
+    MistralTextToSpeechModel = None
+
 # Store all provider classes
 __provider_classes = {
     'AnthropicLanguageModel': AnthropicLanguageModel,
@@ -130,7 +135,8 @@ __provider_classes = {
     "GroqLanguageModel": GroqLanguageModel,
     "VertexLanguageModel": VertexLanguageModel,
     "VertexEmbeddingModel": VertexEmbeddingModel,
-    "VertexTextToSpeechModel": VertexTextToSpeechModel
+    "VertexTextToSpeechModel": VertexTextToSpeechModel,
+    "MistralTextToSpeechModel": MistralTextToSpeechModel,
 }
 
 # Get list of available provider classes (excluding None values)

--- a/src/esperanto/factory.py
+++ b/src/esperanto/factory.py
@@ -60,6 +60,7 @@ class AIFactory:
             "vertex": "esperanto.providers.tts.vertex:VertexTextToSpeechModel",
             "openai-compatible": "esperanto.providers.tts.openai_compatible:OpenAICompatibleTextToSpeechModel",
             "azure": "esperanto.providers.tts.azure:AzureTextToSpeechModel",
+            "mistral": "esperanto.providers.tts.mistral:MistralTextToSpeechModel",
         },
         "reranker": {
             "jina": "esperanto.providers.reranker.jina:JinaRerankerModel",

--- a/src/esperanto/providers/tts/mistral.py
+++ b/src/esperanto/providers/tts/mistral.py
@@ -1,0 +1,260 @@
+"""Mistral Text-to-Speech provider implementation (Voxtral)."""
+import base64
+import os
+from pathlib import Path
+from typing import Optional, Union, Dict, Any, List
+
+import httpx
+
+from .base import TextToSpeechModel, AudioResponse, Voice, Model
+
+RESPONSE_FORMAT_TO_CONTENT_TYPE = {
+    "mp3": "audio/mp3",
+    "opus": "audio/opus",
+    "flac": "audio/flac",
+    "wav": "audio/wav",
+    "pcm": "audio/pcm",
+}
+
+
+class MistralTextToSpeechModel(TextToSpeechModel):
+    """Mistral Text-to-Speech provider implementation (Voxtral).
+
+    Supports the Voxtral TTS model with 20 preset voice options.
+    """
+
+    DEFAULT_MODEL = "voxtral-mini-tts-2603"
+    DEFAULT_VOICE = "neutral_female"
+    AVAILABLE_VOICES = [
+        "ar_male", "casual_female", "casual_male", "cheerful_female",
+        "de_female", "de_male", "es_female", "es_male",
+        "fr_female", "fr_male", "hi_female", "hi_male",
+        "it_female", "it_male", "neutral_female", "neutral_male",
+        "nl_female", "nl_male", "pt_female", "pt_male",
+    ]
+    PROVIDER = "mistral"
+
+    def __init__(
+        self,
+        model_name: str = DEFAULT_MODEL,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        **kwargs
+    ):
+        """Initialize Mistral TTS provider.
+
+        Args:
+            model_name: Name of the model to use (default: voxtral-mini-tts-2603)
+            api_key: Mistral API key. If not provided, will try to get from MISTRAL_API_KEY env var
+            base_url: Optional base URL for the API
+            **kwargs: Additional configuration options
+        """
+        super().__init__(
+            model_name=model_name,
+            api_key=api_key or os.getenv("MISTRAL_API_KEY"),
+            base_url=base_url,
+            config=kwargs
+        )
+
+        self.base_url = self.base_url or "https://api.mistral.ai/v1"
+
+        self._create_http_clients()
+
+    def _get_headers(self) -> Dict[str, str]:
+        """Get headers for Mistral API requests."""
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    def _handle_error(self, response: httpx.Response) -> None:
+        """Handle HTTP error responses."""
+        if response.status_code >= 400:
+            try:
+                error_data = response.json()
+                error_message = error_data.get("error", {}).get("message", f"HTTP {response.status_code}")
+            except Exception:
+                error_message = f"HTTP {response.status_code}: {response.text}"
+            raise RuntimeError(f"Mistral API error: {error_message}")
+
+    @property
+    def available_voices(self) -> Dict[str, Voice]:
+        """Get available voices from Mistral TTS.
+
+        Returns:
+            Dict[str, Voice]: Dictionary of available voices with their information
+        """
+        voice_metadata = {
+            "ar_male": ("MALE", "ar", "Arabic male voice"),
+            "casual_female": ("FEMALE", "en", "Casual female voice"),
+            "casual_male": ("MALE", "en", "Casual male voice"),
+            "cheerful_female": ("FEMALE", "en", "Cheerful female voice"),
+            "de_female": ("FEMALE", "de", "German female voice"),
+            "de_male": ("MALE", "de", "German male voice"),
+            "es_female": ("FEMALE", "es", "Spanish female voice"),
+            "es_male": ("MALE", "es", "Spanish male voice"),
+            "fr_female": ("FEMALE", "fr", "French female voice"),
+            "fr_male": ("MALE", "fr", "French male voice"),
+            "hi_female": ("FEMALE", "hi", "Hindi female voice"),
+            "hi_male": ("MALE", "hi", "Hindi male voice"),
+            "it_female": ("FEMALE", "it", "Italian female voice"),
+            "it_male": ("MALE", "it", "Italian male voice"),
+            "neutral_female": ("FEMALE", "en", "Neutral female voice"),
+            "neutral_male": ("MALE", "en", "Neutral male voice"),
+            "nl_female": ("FEMALE", "nl", "Dutch female voice"),
+            "nl_male": ("MALE", "nl", "Dutch male voice"),
+            "pt_female": ("FEMALE", "pt", "Portuguese female voice"),
+            "pt_male": ("MALE", "pt", "Portuguese male voice"),
+        }
+        return {
+            name: Voice(
+                name=name,
+                id=name,
+                gender=gender,
+                language_code=lang,
+                description=desc,
+            )
+            for name, (gender, lang, desc) in voice_metadata.items()
+        }
+
+    @property
+    def provider(self) -> str:
+        """Get the provider name."""
+        return self.PROVIDER
+
+    def _get_default_model(self) -> str:
+        """Get the default model name."""
+        return self.DEFAULT_MODEL
+
+    def _get_models(self) -> List[Model]:
+        """List all available models for this provider."""
+        return [
+            Model(
+                id="voxtral-mini-tts-2603",
+                owned_by="mistralai",
+                context_window=None,
+            )
+        ]
+
+    def generate_speech(
+        self,
+        text: str,
+        voice: str = "neutral_female",
+        output_file: Optional[Union[str, Path]] = None,
+        **kwargs
+    ) -> AudioResponse:
+        """Generate speech from text using Mistral's Voxtral TTS API.
+
+        Args:
+            text: Text to convert to speech
+            voice: Voice to use (default: "neutral_female")
+            output_file: Optional path to save the audio file
+            **kwargs: Additional parameters to pass to the Mistral API
+
+        Returns:
+            AudioResponse containing the audio data and metadata
+
+        Raises:
+            RuntimeError: If speech generation fails
+        """
+        try:
+            response_format = kwargs.pop("response_format", "mp3")
+
+            payload = {
+                "model": self.model_name,
+                "voice_id": voice,
+                "input": text,
+                "response_format": response_format,
+                **kwargs
+            }
+
+            response = self.client.post(
+                f"{self.base_url}/audio/speech",
+                headers=self._get_headers(),
+                json=payload
+            )
+            self._handle_error(response)
+
+            audio_data = base64.b64decode(response.json()["audio_data"])
+
+            if output_file:
+                output_file = Path(output_file)
+                output_file.parent.mkdir(parents=True, exist_ok=True)
+                output_file.write_bytes(audio_data)
+
+            content_type = RESPONSE_FORMAT_TO_CONTENT_TYPE.get(
+                response_format, f"audio/{response_format}"
+            )
+            return AudioResponse(
+                audio_data=audio_data,
+                content_type=content_type,
+                model=self.model_name,
+                voice=voice,
+                provider=self.PROVIDER,
+                metadata={"text": text}
+            )
+
+        except Exception as e:
+            raise RuntimeError(f"Failed to generate speech: {str(e)}") from e
+
+    async def agenerate_speech(
+        self,
+        text: str,
+        voice: str = "neutral_female",
+        output_file: Optional[Union[str, Path]] = None,
+        **kwargs
+    ) -> AudioResponse:
+        """Generate speech from text using Mistral's Voxtral TTS API asynchronously.
+
+        Args:
+            text: Text to convert to speech
+            voice: Voice to use (default: "neutral_female")
+            output_file: Optional path to save the audio file
+            **kwargs: Additional parameters to pass to the Mistral API
+
+        Returns:
+            AudioResponse containing the audio data and metadata
+
+        Raises:
+            RuntimeError: If speech generation fails
+        """
+        try:
+            response_format = kwargs.pop("response_format", "mp3")
+
+            payload = {
+                "model": self.model_name,
+                "voice_id": voice,
+                "input": text,
+                "response_format": response_format,
+                **kwargs
+            }
+
+            response = await self.async_client.post(
+                f"{self.base_url}/audio/speech",
+                headers=self._get_headers(),
+                json=payload
+            )
+            self._handle_error(response)
+
+            audio_data = base64.b64decode(response.json()["audio_data"])
+
+            if output_file:
+                output_file = Path(output_file)
+                output_file.parent.mkdir(parents=True, exist_ok=True)
+                output_file.write_bytes(audio_data)
+
+            content_type = RESPONSE_FORMAT_TO_CONTENT_TYPE.get(
+                response_format, f"audio/{response_format}"
+            )
+            return AudioResponse(
+                audio_data=audio_data,
+                content_type=content_type,
+                model=self.model_name,
+                voice=voice,
+                provider=self.PROVIDER,
+                metadata={"text": text}
+            )
+
+        except Exception as e:
+            raise RuntimeError(f"Failed to generate speech: {str(e)}") from e

--- a/tests/providers/tts/test_mistral.py
+++ b/tests/providers/tts/test_mistral.py
@@ -1,0 +1,172 @@
+"""Tests for the Mistral TTS provider."""
+import base64
+
+import pytest
+from unittest.mock import AsyncMock, Mock
+
+from esperanto.providers.tts.mistral import MistralTextToSpeechModel
+
+
+MOCK_AUDIO_BYTES = b"mock audio data for testing"
+
+
+@pytest.fixture
+def mock_tts_audio_response():
+    """Mock base64-encoded JSON audio response data."""
+    return {"audio_data": base64.b64encode(MOCK_AUDIO_BYTES).decode()}
+
+
+@pytest.fixture
+def mock_httpx_clients(mock_tts_audio_response):
+    """Mock httpx clients for Mistral TTS."""
+    client = Mock()
+    async_client = AsyncMock()
+
+    def make_response(status_code, json_data=None):
+        response = Mock()
+        response.status_code = status_code
+        if json_data is not None:
+            response.json.return_value = json_data
+        return response
+
+    def make_async_response(status_code, json_data=None):
+        response = AsyncMock()
+        response.status_code = status_code
+        if json_data is not None:
+            response.json = Mock(return_value=json_data)
+        return response
+
+    def mock_post_side_effect(url, **kwargs):
+        if url.endswith("/audio/speech"):
+            return make_response(200, json_data=mock_tts_audio_response)
+        return make_response(404, json_data={"error": {"message": "Not found"}})
+
+    async def mock_async_post_side_effect(url, **kwargs):
+        if url.endswith("/audio/speech"):
+            return make_async_response(200, json_data=mock_tts_audio_response)
+        return make_async_response(404, json_data={"error": {"message": "Not found"}})
+
+    client.post.side_effect = mock_post_side_effect
+    async_client.post.side_effect = mock_async_post_side_effect
+
+    return client, async_client
+
+
+@pytest.fixture
+def tts_model(mock_httpx_clients):
+    """Create a TTS model instance with mocked HTTP clients."""
+    model = MistralTextToSpeechModel(
+        api_key="test-key",
+        model_name="voxtral-mini-tts-2603"
+    )
+    model.client, model.async_client = mock_httpx_clients
+    return model
+
+
+def test_init(tts_model):
+    """Test model initialization."""
+    assert tts_model.model_name == "voxtral-mini-tts-2603"
+    assert tts_model.PROVIDER == "mistral"
+
+
+def test_generate_speech(tts_model):
+    """Test synchronous speech generation."""
+    response = tts_model.generate_speech(
+        text="Hello world",
+        voice="neutral_female"
+    )
+
+    tts_model.client.post.assert_called_once()
+    call_args = tts_model.client.post.call_args
+
+    assert call_args[0][0] == "https://api.mistral.ai/v1/audio/speech"
+
+    headers = call_args[1]["headers"]
+    assert headers["Authorization"] == "Bearer test-key"
+
+    json_payload = call_args[1]["json"]
+    assert json_payload["model"] == "voxtral-mini-tts-2603"
+    assert json_payload["voice_id"] == "neutral_female"
+    assert json_payload["input"] == "Hello world"
+    assert "voice" not in json_payload
+
+    assert response.audio_data == MOCK_AUDIO_BYTES
+    assert response.content_type == "audio/mp3"
+    assert response.model == "voxtral-mini-tts-2603"
+    assert response.voice == "neutral_female"
+    assert response.provider == "mistral"
+
+
+@pytest.mark.asyncio
+async def test_agenerate_speech(tts_model):
+    """Test asynchronous speech generation."""
+    response = await tts_model.agenerate_speech(
+        text="Hello world",
+        voice="fr_female"
+    )
+
+    tts_model.async_client.post.assert_called_once()
+    call_args = tts_model.async_client.post.call_args
+
+    assert call_args[0][0] == "https://api.mistral.ai/v1/audio/speech"
+
+    headers = call_args[1]["headers"]
+    assert headers["Authorization"] == "Bearer test-key"
+
+    json_payload = call_args[1]["json"]
+    assert json_payload["model"] == "voxtral-mini-tts-2603"
+    assert json_payload["voice_id"] == "fr_female"
+    assert json_payload["input"] == "Hello world"
+
+    assert response.audio_data == MOCK_AUDIO_BYTES
+    assert response.content_type == "audio/mp3"
+    assert response.model == "voxtral-mini-tts-2603"
+    assert response.voice == "fr_female"
+    assert response.provider == "mistral"
+
+
+def test_generate_speech_with_response_format(tts_model):
+    """Test speech generation with explicit response_format."""
+    response = tts_model.generate_speech(
+        text="Hello world",
+        voice="neutral_female",
+        response_format="wav"
+    )
+
+    call_args = tts_model.client.post.call_args
+    json_payload = call_args[1]["json"]
+    assert json_payload["response_format"] == "wav"
+
+    assert response.content_type == "audio/wav"
+
+
+def test_available_voices(tts_model):
+    """Test getting available voices."""
+    voices = tts_model.available_voices
+
+    assert len(voices) == 20
+
+    voice = voices["neutral_female"]
+    assert voice.name == "neutral_female"
+    assert voice.id == "neutral_female"
+    assert voice.gender == "FEMALE"
+
+    voice_male = voices["fr_male"]
+    assert voice_male.gender == "MALE"
+    assert voice_male.language_code == "fr"
+
+
+def test_models(tts_model):
+    """Test that _get_models returns hardcoded model list."""
+    models = tts_model._get_models()
+
+    assert len(models) == 1
+    assert models[0].id == "voxtral-mini-tts-2603"
+    assert models[0].owned_by == "mistralai"
+
+
+def test_missing_api_key(monkeypatch):
+    """Test that missing API key raises ValueError or creates model with None key."""
+    monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+    model = MistralTextToSpeechModel()
+    assert model.api_key is None


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #109

#### What does this implement/fix? Explain your changes.

Adds `MistralTextToSpeechModel` to support Mistral AI's Voxtral text-to-speech API (`voxtral-mini-tts-2603`) through Esperanto's provider-agnostic interface.

**Files changed:**
- `src/esperanto/providers/tts/mistral.py` — New provider implementing `TextToSpeechModel` with sync and async `generate_speech()` methods
- `src/esperanto/factory.py` — Registered `"mistral"` in the `text_to_speech` provider dict
- `src/esperanto/__init__.py` — Added conditional import of `MistralTextToSpeechModel`
- `tests/providers/tts/test_mistral.py` — 7 unit tests covering init, sync/async speech generation, response formats, available voices, model listing, and missing API key

**Key implementation details:**
- Mistral's TTS API returns base64-encoded audio in a JSON response (`{"audio_data": "..."}`) rather than raw binary — the provider decodes this transparently
- The API uses `voice_id` as the payload field name (unlike `voice` in OpenAI); the Esperanto interface still uses `voice` as the parameter name
- 20 preset voices supported: `neutral_female`, `neutral_male`, multilingual variants (Arabic, German, Spanish, French, Hindi, Italian, Dutch, Portuguese)
- No new dependencies — `base64` is stdlib, `httpx` is already a project dependency
- Uses the same `MISTRAL_API_KEY` environment variable as the existing Mistral LLM and embedding providers

**Validation:**
- Static import checks: ✅
- Unit tests: ✅ 7/7 passed
- Full test suite: ✅ 1039 passed, no regressions (pre-existing failures for optional `torch`/`numpy`/`jsonschema` deps are unrelated)

#### Any other comments?

Streaming TTS (Mistral supports SSE) and zero-shot voice cloning via `ref_audio` are out of scope for this initial implementation. They can be added in follow-up PRs once the `TextToSpeechModel` base interface is extended to support streaming.