### PR TITLE
feat: add Novita AI as LLM provider

### DIFF
--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -20,6 +20,7 @@ Welcome to the Esperanto provider guide. This page helps you choose the right AI
 | [xAI](./xai.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | [DashScope (Qwen)](./dashscope.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | [MiniMax](./minimax.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Novita* | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | [OpenRouter](./openrouter.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | [Transformers](./transformers.md) | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
 | [Jina](./jina.md) | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
@@ -27,6 +28,8 @@ Welcome to the Esperanto provider guide. This page helps you choose the right AI
 | [ElevenLabs](./elevenlabs.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
 
 *⚠️ OpenAI-Compatible: JSON mode support depends on the specific endpoint implementation
+
+*Novita is available as a built-in OpenAI-compatible LLM profile. Use `AIFactory.create_language("novita", "moonshotai/kimi-k2.5")` with `NOVITA_API_KEY`. See [OpenAI-Compatible](./openai-compatible.md) for the shared setup path.
 
 ## Quick Selection Guide
 

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -20,7 +20,7 @@ Welcome to the Esperanto provider guide. This page helps you choose the right AI
 | [xAI](./xai.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | [DashScope (Qwen)](./dashscope.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | [MiniMax](./minimax.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| Novita* | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| [Novita](./openai-compatible.md)* | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | [OpenRouter](./openrouter.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | [Transformers](./transformers.md) | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
 | [Jina](./jina.md) | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
@@ -316,6 +316,7 @@ Require API keys, pay-per-use:
 - [Perplexity](./perplexity.md)
 - [xAI](./xai.md)
 - [OpenRouter](./openrouter.md)
+- [Novita](./openai-compatible.md) (OpenAI-compatible profile)
 - [Jina](./jina.md)
 - [Voyage](./voyage.md)
 - [ElevenLabs](./elevenlabs.md)

--- a/docs/providers/openai-compatible.md
+++ b/docs/providers/openai-compatible.md
@@ -95,7 +95,7 @@ model = AIFactory.create_language("my-company", "llama-3-70b")
 response = model.chat_complete(messages)
 ```
 
-Several OpenAI-compatible providers are already registered as built-in profiles: **DeepSeek**, **xAI**, **DashScope** (Qwen), and **MiniMax**. See their individual provider docs for details.
+Several OpenAI-compatible providers are already registered as built-in profiles: **DeepSeek**, **xAI**, **DashScope** (Qwen), **MiniMax**, and **Novita**. Use `AIFactory.create_language("novita", "moonshotai/kimi-k2.5")` with `NOVITA_API_KEY` for the built-in Novita profile.
 
 ## Quick Start
 

--- a/src/esperanto/providers/llm/profiles.py
+++ b/src/esperanto/providers/llm/profiles.py
@@ -94,6 +94,15 @@ BUILTIN_PROFILES: Dict[str, OpenAICompatibleProfile] = {
         owned_by="MiniMax",
         display_name="MiniMax",
     ),
+    "novita": OpenAICompatibleProfile(
+        name="novita",
+        base_url="https://api.novita.ai/openai",
+        api_key_env="NOVITA_API_KEY",
+        base_url_env="NOVITA_BASE_URL",
+        default_model="moonshotai/kimi-k2.5",
+        owned_by="Novita",
+        display_name="Novita",
+    ),
 }
 
 _USER_PROFILES: Dict[str, OpenAICompatibleProfile] = {}

--- a/tests/providers/llm/test_profiles.py
+++ b/tests/providers/llm/test_profiles.py
@@ -163,14 +163,6 @@ class TestFactoryIntegration:
         assert model.base_url == "https://api.x.ai/v1"
         assert model._response_format_unsupported is True
 
-    def test_create_language_with_novita_profile(self):
-        model = AIFactory.create_language(
-            "novita", "moonshotai/kimi-k2.5", config={"api_key": "test-key"}
-        )
-        assert model.provider == "novita"
-        assert model.base_url == "https://api.novita.ai/openai"
-        assert model.api_key == "test-key"
-
     def test_create_language_with_user_profile(self):
         AIFactory.register_openai_compatible_profile(
             OpenAICompatibleProfile(

--- a/tests/providers/llm/test_profiles.py
+++ b/tests/providers/llm/test_profiles.py
@@ -58,6 +58,7 @@ class TestProfileRegistry:
     def test_builtin_profiles_exist(self):
         assert "deepseek" in BUILTIN_PROFILES
         assert "xai" in BUILTIN_PROFILES
+        assert "novita" in BUILTIN_PROFILES
 
     def test_get_builtin_profile(self):
         profile = get_profile("deepseek")
@@ -80,6 +81,14 @@ class TestProfileRegistry:
         assert profile.base_url == "https://dashscope.aliyuncs.com/compatible-mode/v1"
         assert profile.api_key_env == "DASHSCOPE_API_KEY"
         assert profile.default_model == "qwen-plus"
+
+    def test_get_novita_profile(self):
+        profile = get_profile("novita")
+        assert profile is not None
+        assert profile.name == "novita"
+        assert profile.base_url == "https://api.novita.ai/openai"
+        assert profile.api_key_env == "NOVITA_API_KEY"
+        assert profile.default_model == "moonshotai/kimi-k2.5"
 
     def test_get_unknown_profile_returns_none(self):
         assert get_profile("unknown-provider") is None
@@ -121,6 +130,7 @@ class TestProfileRegistry:
         names = get_all_profile_names()
         assert "deepseek" in names
         assert "xai" in names
+        assert "novita" in names
 
     def test_get_all_profile_names_includes_user(self):
         register_profile(
@@ -153,6 +163,14 @@ class TestFactoryIntegration:
         assert model.base_url == "https://api.x.ai/v1"
         assert model._response_format_unsupported is True
 
+    def test_create_language_with_novita_profile(self):
+        model = AIFactory.create_language(
+            "novita", "moonshotai/kimi-k2.5", config={"api_key": "test-key"}
+        )
+        assert model.provider == "novita"
+        assert model.base_url == "https://api.novita.ai/openai"
+        assert model.api_key == "test-key"
+
     def test_create_language_with_user_profile(self):
         AIFactory.register_openai_compatible_profile(
             OpenAICompatibleProfile(
@@ -183,6 +201,7 @@ class TestFactoryIntegration:
         providers = AIFactory.get_available_providers()
         assert "deepseek" in providers["language"]
         assert "xai" in providers["language"]
+        assert "novita" in providers["language"]
         # Class-based providers also present
         assert "openai" in providers["language"]
 
@@ -274,6 +293,24 @@ class TestProfileBehavior:
         with patch.dict(os.environ, {}, clear=True):
             with pytest.raises(ValueError, match="DashScope API key not found"):
                 AIFactory.create_language("dashscope", "qwen-plus")
+
+    def test_novita_creation(self):
+        model = AIFactory.create_language(
+            "novita", "moonshotai/kimi-k2.5", config={"api_key": "test-key"}
+        )
+        assert model.provider == "novita"
+        assert model.base_url == "https://api.novita.ai/openai"
+        assert model._get_default_model() == "moonshotai/kimi-k2.5"
+
+    def test_novita_env_var(self):
+        with patch.dict(os.environ, {"NOVITA_API_KEY": "env-key"}, clear=False):
+            model = AIFactory.create_language("novita", "moonshotai/kimi-k2.5")
+            assert model.api_key == "env-key"
+
+    def test_novita_missing_api_key_raises(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="Novita API key not found"):
+                AIFactory.create_language("novita", "moonshotai/kimi-k2.5")
 
     def test_minimax_creation(self):
         model = AIFactory.create_language(


### PR DESCRIPTION
## Summary

Add [Novita AI](https://novita.ai) as a built-in OpenAI-compatible provider profile in Esperanto.

### Changes
- add a built-in `novita` OpenAI-compatible profile with Novita defaults
- configure `NOVITA_API_KEY` and `NOVITA_BASE_URL` environment variable support
- extend profile tests for registration, factory creation, env var loading, and missing-key errors
- update shared provider docs to mention the built-in Novita profile

### Configuration
```bash
NOVITA_API_KEY=your_novita_key
# optional override
NOVITA_BASE_URL=https://api.novita.ai/openai
```

### Example
```python
from esperanto import AIFactory

model = AIFactory.create_language("novita", "moonshotai/kimi-k2.5")
```

**Endpoint**: `https://api.novita.ai/openai`

### Validation
- `PYTHONPATH=src python -m pytest --override-ini addopts='' tests/providers/llm/test_profiles.py -q`
