### PR TITLE
docs(claude): add "For Automated Agents" section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,38 @@ All providers use utility mixins:
 - **Check types**: `uv run mypy src/esperanto`
 - **Format code**: `uv run black src/ tests/`
 
+## For Automated Agents
+
+If you are an automated coding agent (harny, Claude Code in headless mode, etc.) running against this repo, read this section before deciding what to validate.
+
+### Validator command
+
+The single command to confirm a change is acceptable:
+
+```bash
+uv sync --all-extras && uv run pytest tests/providers tests/unit -q --no-cov
+```
+
+This runs ~830 tests (mocked, no real API calls) in roughly 75 seconds. Pass = exit 0.
+
+### Do NOT use as gates
+
+The following tools have **pre-existing technical debt** on `main`. Running them as part of your validator will produce hundreds of failures unrelated to your change, and trying to fix them will derail the task:
+
+- `uv run mypy src/esperanto` — main has ~273 type errors at the time of writing.
+- `ruff check .` — main has ~200+ lint errors at the time of writing.
+
+If you introduced *new* type or lint regressions, that's worth fixing — but do not gate on the existing debt. Run them out-of-band only, and only act on the delta you introduced.
+
+### Integration tests
+
+`tests/integration/` requires real provider API keys and external network. Always exclude from automated runs unless the user has explicitly set up credentials and asked for it.
+
+### Other notes
+
+- The `notebooks/` directory is local-only (gitignored). If you see modifications there, leave them alone — they aren't part of the project.
+- Do not commit `.env`, `google-credentials.json`, or any other credential file. The `.gitignore` covers the common cases but always double-check before staging.
+
 ## Critical Principles
 
 See @ARCHITECTURE.md for the full design principles. The key rules:


### PR DESCRIPTION
## Summary

Tell coding agents (harny, Claude Code in headless mode, etc.) the exact validator command to use against this repo, and which tools to keep out of the validator loop.

## Why

When an agent runs in this repo, it reads `CLAUDE.md` to figure out how to validate its changes. Today the file lists `mypy` and `ruff` under "Common Commands" without any caveat. Both currently have substantial pre-existing debt on `main` (~273 mypy errors, ~200+ ruff errors). An agent that picks them up as gates produces hundreds of failures unrelated to the change it was sent to make, and then either derails into "fix the debt" or gives up.

The fix is one block of text telling agents:

- which command actually validates a change (`uv sync --all-extras && uv run pytest tests/providers tests/unit -q --no-cov` — ~830 mocked tests, ~75s)
- which tools to skip and why
- that integration tests require real credentials and should stay out
- a few ground rules around credentials and notebooks

## Changes

- Add a new section "For Automated Agents" to `CLAUDE.md`, between "Common Commands" and "Critical Principles".

No code changes, no behavior changes for human contributors.

## Test plan

- [ ] Section renders as expected on GitHub
- [ ] Existing "Common Commands" entries unchanged