### PR TITLE
fix: use json= kwarg in OpenRouter httpx calls (closes #127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`types-jsonschema`** added to dev dependencies so `jsonschema` is properly type-checked.
 - **Ruff exclusions:** `notebooks/`, `.harny/`, and `examples/` are now excluded from lint runs (the first two are gitignored scratch directories; `examples/` contains illustrative scripts).
 
+### Fixed
+
+- **OpenRouter providers send malformed request bodies** — both the LLM and embedding OpenRouter providers were posting payloads via httpx's `data=json.dumps(payload)` instead of `json=payload`. In httpx, `data=` with a string is treated as a form-encoded body (Content-Type `application/x-www-form-urlencoded`), so requests carried JSON bytes with the wrong content type. The four affected call sites now use `json=payload`, which serializes the dict and sets `Content-Type: application/json` automatically. Tests updated to assert on the `json` kwarg so a regression would fail loudly. (#127)
+
 ## [2.20.1] - 2026-04-13
 
 ### Fixed

--- a/src/esperanto/providers/embedding/openrouter.py
+++ b/src/esperanto/providers/embedding/openrouter.py
@@ -1,6 +1,5 @@
 """OpenRouter embedding model implementation."""
 
-import json
 import os
 from dataclasses import dataclass
 from typing import Dict, List, Optional
@@ -80,11 +79,10 @@ class OpenRouterEmbeddingModel(OpenAIEmbeddingModel):
             **{**self._get_api_kwargs(), **kwargs}
         }
 
-        # Make HTTP request using OpenRouter format (data parameter with JSON string)
         response = self.client.post(
             f"{self.base_url}/embeddings",
             headers=self._get_headers(),
-            data=json.dumps(payload)  # type: ignore[arg-type]  # OpenRouter expects raw JSON body, httpx stub typing prefers Mapping
+            json=payload
         )
         self._handle_error(response)
 
@@ -112,11 +110,10 @@ class OpenRouterEmbeddingModel(OpenAIEmbeddingModel):
             **{**self._get_api_kwargs(), **kwargs}
         }
 
-        # Make async HTTP request using OpenRouter format (data parameter with JSON string)
         response = await self.async_client.post(
             f"{self.base_url}/embeddings",
             headers=self._get_headers(),
-            data=json.dumps(payload)  # type: ignore[arg-type]
+            json=payload
         )
         self._handle_error(response)
 

--- a/src/esperanto/providers/llm/openrouter.py
+++ b/src/esperanto/providers/llm/openrouter.py
@@ -1,6 +1,5 @@
 """OpenRouter language model implementation."""
 
-import json
 import os
 from dataclasses import dataclass
 from typing import (
@@ -80,24 +79,22 @@ class OpenRouterLanguageModel(OpenAILanguageModel):
 
     def _make_http_request(self, payload: Dict[str, Any]) -> Any:
         """Make HTTP request in OpenRouter's expected format."""
-        # OpenRouter expects data as JSON string, not json parameter
         headers = self._get_headers()
-        
+
         response = self.client.post(
             f"{self.base_url}/chat/completions",
             headers=headers,
-            data=json.dumps(payload)  # type: ignore[arg-type]  # OpenRouter expects raw JSON body
+            json=payload
         )
         self._handle_error(response)
         return response
 
     async def _make_async_http_request(self, payload: Dict[str, Any]) -> Any:
         """Make async HTTP request in OpenRouter's expected format."""
-        # OpenRouter expects data as JSON string, not json parameter
         response = await self.async_client.post(
             f"{self.base_url}/chat/completions",
             headers=self._get_headers(),
-            data=json.dumps(payload)  # type: ignore[arg-type]
+            json=payload
         )
         self._handle_error(response)
         return response

--- a/tests/providers/embedding/test_openrouter_provider.py
+++ b/tests/providers/embedding/test_openrouter_provider.py
@@ -133,9 +133,9 @@ def test_embed(openrouter_model):
     # Check URL
     assert call_args[0][0] == "https://openrouter.ai/api/v1/embeddings"
 
-    # Check that data parameter was used (not json)
-    assert "data" in call_args[1]
-    assert "json" not in call_args[1]
+    # Check that json parameter was used (not data)
+    assert "json" in call_args[1]
+    assert "data" not in call_args[1]
 
     # Check headers include OpenRouter-specific headers
     headers = call_args[1]["headers"]
@@ -162,9 +162,9 @@ async def test_aembed(openrouter_model):
     # Check URL
     assert call_args[0][0] == "https://openrouter.ai/api/v1/embeddings"
 
-    # Check that data parameter was used (not json)
-    assert "data" in call_args[1]
-    assert "json" not in call_args[1]
+    # Check that json parameter was used (not data)
+    assert "json" in call_args[1]
+    assert "data" not in call_args[1]
 
     # Check headers
     headers = call_args[1]["headers"]
@@ -223,11 +223,9 @@ def test_text_cleaning(openrouter_model):
     texts = ["Hello\nWorld", "Test\nText"]
     openrouter_model.embed(texts)
 
-    # Check that the input was cleaned - need to parse the JSON from data parameter
+    # Check that the input was cleaned
     call_args = openrouter_model.client.post.call_args
-    import json
-    data_str = call_args[1]["data"]
-    payload = json.loads(data_str)
+    payload = call_args[1]["json"]
     assert payload["input"] == ["Hello World", "Test Text"]
 
 

--- a/tests/providers/llm/test_openrouter_provider.py
+++ b/tests/providers/llm/test_openrouter_provider.py
@@ -1,4 +1,3 @@
-import json
 import os
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -250,9 +249,9 @@ class TestToolCallResponse:
             messages, tools=sample_tools
         )
 
-        # Check payload included tools (OpenRouter uses data= with JSON string, not json=)
+        # Check payload included tools
         call_args = openrouter_model_with_tool_response.client.post.call_args
-        json_payload = json.loads(call_args.kwargs["data"])
+        json_payload = call_args.kwargs["json"]
         assert "tools" in json_payload
         assert len(json_payload["tools"]) == 2
 
@@ -275,9 +274,8 @@ class TestToolCallResponse:
             messages, tools=sample_tools, tool_choice="required"
         )
 
-        # OpenRouter uses data= with JSON string, not json=
         call_args = openrouter_model_with_tool_response.client.post.call_args
-        json_payload = json.loads(call_args.kwargs["data"])
+        json_payload = call_args.kwargs["json"]
         assert json_payload["tool_choice"] == "required"
 
     @pytest.mark.asyncio
@@ -289,9 +287,9 @@ class TestToolCallResponse:
             messages, tools=sample_tools
         )
 
-        # Check payload included tools (OpenRouter uses data= with JSON string, not json=)
+        # Check payload included tools
         call_args = openrouter_model_with_tool_response.async_client.post.call_args
-        json_payload = json.loads(call_args.kwargs["data"])
+        json_payload = call_args.kwargs["json"]
         assert "tools" in json_payload
 
         # Check response has tool calls


### PR DESCRIPTION
## Summary

- The OpenRouter LLM and embedding providers were posting payloads via httpx's `data=json.dumps(payload)` instead of `json=payload`. In httpx, `data=` with a string is treated as a form-encoded body (`Content-Type: application/x-www-form-urlencoded`), so requests carried JSON bytes with the wrong content type — OpenRouter only accepted them due to lenient content-type handling.
- All four affected call sites (`_make_http_request`, `_make_async_http_request`, `embed`, `aembed`) now use `json=payload`, which serializes the dict and sets `Content-Type: application/json` automatically — matching what OpenAI, Anthropic, and the rest of Esperanto's first-class providers do.
- Removed the `# type: ignore[arg-type]` stopgaps that were added during the lint/typecheck cleanup PR, plus the now-unused `import json` from both source files.
- Updated tests to assert on the `json` kwarg (and explicitly assert `data` is absent) so a regression would fail loudly. The previous tests only inspected `data=`, which is what let the bug slip through originally.

Closes #127.

## Test plan

- [x] `uv run pytest tests/providers tests/unit tests/common_types -q --no-cov` — 888 passed (7 pre-existing local-env failures, identical on `main`)
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src/esperanto` — clean
- [ ] Optional: smoke-test against a real OpenRouter API key once merged