### PR TITLE
fix: use BitsAndBytesConfig for transformers quantization (closes #129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **OpenRouter providers send malformed request bodies** — both the LLM and embedding OpenRouter providers were posting payloads via httpx's `data=json.dumps(payload)` instead of `json=payload`. In httpx, `data=` with a string is treated as a form-encoded body (Content-Type `application/x-www-form-urlencoded`), so requests carried JSON bytes with the wrong content type. The four affected call sites now use `json=payload`, which serializes the dict and sets `Content-Type: application/json` automatically. Tests updated to assert on the `json` kwarg so a regression would fail loudly. (#127)
+- **`TransformersEmbeddingModel` quantization not applied** — `_initialize_model` was constructing a `quantization_config` dict with `load_in_4bit` / `load_in_8bit` and spreading it as top-level kwargs to `AutoModel.from_pretrained`, an API form that recent transformers versions deprecated in favor of a `BitsAndBytesConfig` object. The provider now constructs `BitsAndBytesConfig(load_in_4bit=..., load_in_8bit=...)` and passes it via `quantization_config=`. Added mocked unit tests (parametrized over 4bit/8bit) that fail if the config stops reaching `from_pretrained`. (#129)
 
 ## [2.20.1] - 2026-04-13
 

--- a/src/esperanto/providers/embedding/transformers.py
+++ b/src/esperanto/providers/embedding/transformers.py
@@ -115,20 +115,21 @@ class TransformersEmbeddingModel(EmbeddingModel):
         if quantize:
             try:
                 import bitsandbytes  # type: ignore[import-not-found]  # noqa: F401  # availability check
-
-                quantization_config = {
-                    "load_in_4bit": quantize == "4bit",
-                    "load_in_8bit": quantize == "8bit",
-                }
             except ImportError:
                 raise ImportError(
                     "bitsandbytes is required for quantization. "
                     "Install it with: pip install bitsandbytes"
                 )
+            from transformers import BitsAndBytesConfig
+
+            bnb_config = BitsAndBytesConfig(
+                load_in_4bit=quantize == "4bit",
+                load_in_8bit=quantize == "8bit",
+            )
             self.model = AutoModel.from_pretrained(
                 model_name,
                 device_map="auto" if self.device == "cuda" else None,
-                **quantization_config,
+                quantization_config=bnb_config,
             )
         else:
             self.model = AutoModel.from_pretrained(model_name)

--- a/tests/providers/embedding/test_transformers_provider.py
+++ b/tests/providers/embedding/test_transformers_provider.py
@@ -1,5 +1,9 @@
 """Tests for the Transformers embedding model provider."""
 
+import importlib.metadata
+import sys
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from esperanto.factory import AIFactory
@@ -103,3 +107,90 @@ def test_quantization():
     embeddings = model.embed(["Test text"])
     assert len(embeddings) == 1
     assert len(embeddings[0]) == 768
+
+
+def _mock_metadata_version(name: str) -> str:
+    if name == "bitsandbytes":
+        return "0.42.0"
+    return importlib.metadata.version(name)
+
+
+def test_quantization_4bit_uses_bits_and_bytes_config():
+    """Test that 4bit quantization passes a BitsAndBytesConfig to from_pretrained."""
+    from transformers import BitsAndBytesConfig
+
+    from esperanto.providers.embedding.transformers import TransformersEmbeddingModel
+
+    mock_bnb = MagicMock()
+    mock_model = MagicMock()
+    mock_tokenizer = MagicMock()
+    bnb_modules = {
+        "bitsandbytes": mock_bnb,
+        "bitsandbytes.nn": mock_bnb.nn,
+        "bitsandbytes.functional": mock_bnb.functional,
+    }
+
+    with (
+        patch.dict(sys.modules, bnb_modules),
+        patch("importlib.metadata.version", side_effect=_mock_metadata_version),
+        patch(
+            "esperanto.providers.embedding.transformers.AutoModel.from_pretrained",
+            return_value=mock_model,
+        ) as mock_from_pretrained,
+        patch(
+            "esperanto.providers.embedding.transformers.AutoTokenizer.from_pretrained",
+            return_value=mock_tokenizer,
+        ),
+    ):
+        TransformersEmbeddingModel(
+            model_name="bert-base-uncased",
+            device="cpu",
+            quantize="4bit",
+        )
+
+        call_kwargs = mock_from_pretrained.call_args.kwargs
+        assert "quantization_config" in call_kwargs
+        bnb_config = call_kwargs["quantization_config"]
+        assert isinstance(bnb_config, BitsAndBytesConfig)
+        assert bnb_config.load_in_4bit is True
+        assert bnb_config.load_in_8bit is False
+
+
+def test_quantization_8bit_uses_bits_and_bytes_config():
+    """Test that 8bit quantization passes a BitsAndBytesConfig to from_pretrained."""
+    from transformers import BitsAndBytesConfig
+
+    from esperanto.providers.embedding.transformers import TransformersEmbeddingModel
+
+    mock_bnb = MagicMock()
+    mock_model = MagicMock()
+    mock_tokenizer = MagicMock()
+    bnb_modules = {
+        "bitsandbytes": mock_bnb,
+        "bitsandbytes.nn": mock_bnb.nn,
+        "bitsandbytes.functional": mock_bnb.functional,
+    }
+
+    with (
+        patch.dict(sys.modules, bnb_modules),
+        patch(
+            "esperanto.providers.embedding.transformers.AutoModel.from_pretrained",
+            return_value=mock_model,
+        ) as mock_from_pretrained,
+        patch(
+            "esperanto.providers.embedding.transformers.AutoTokenizer.from_pretrained",
+            return_value=mock_tokenizer,
+        ),
+    ):
+        TransformersEmbeddingModel(
+            model_name="bert-base-uncased",
+            device="cpu",
+            quantize="8bit",
+        )
+
+        call_kwargs = mock_from_pretrained.call_args.kwargs
+        assert "quantization_config" in call_kwargs
+        bnb_config = call_kwargs["quantization_config"]
+        assert isinstance(bnb_config, BitsAndBytesConfig)
+        assert bnb_config.load_in_8bit is True
+        assert bnb_config.load_in_4bit is False

--- a/tests/providers/embedding/test_transformers_provider.py
+++ b/tests/providers/embedding/test_transformers_provider.py
@@ -115,8 +115,15 @@ def _mock_metadata_version(name: str) -> str:
     return importlib.metadata.version(name)
 
 
-def test_quantization_4bit_uses_bits_and_bytes_config():
-    """Test that 4bit quantization passes a BitsAndBytesConfig to from_pretrained."""
+@pytest.mark.parametrize(
+    "quantize, expected_4bit, expected_8bit",
+    [
+        ("4bit", True, False),
+        ("8bit", False, True),
+    ],
+)
+def test_quantization_uses_bits_and_bytes_config(quantize, expected_4bit, expected_8bit):
+    """Test that quantization passes a BitsAndBytesConfig with the correct flags to from_pretrained."""
     from transformers import BitsAndBytesConfig
 
     from esperanto.providers.embedding.transformers import TransformersEmbeddingModel
@@ -132,6 +139,8 @@ def test_quantization_4bit_uses_bits_and_bytes_config():
 
     with (
         patch.dict(sys.modules, bnb_modules),
+        # 4bit path triggers a bnb version check in BitsAndBytesConfig.__post_init__;
+        # patching unconditionally is harmless for the 8bit path.
         patch("importlib.metadata.version", side_effect=_mock_metadata_version),
         patch(
             "esperanto.providers.embedding.transformers.AutoModel.from_pretrained",
@@ -145,52 +154,12 @@ def test_quantization_4bit_uses_bits_and_bytes_config():
         TransformersEmbeddingModel(
             model_name="bert-base-uncased",
             device="cpu",
-            quantize="4bit",
+            quantize=quantize,
         )
 
         call_kwargs = mock_from_pretrained.call_args.kwargs
         assert "quantization_config" in call_kwargs
         bnb_config = call_kwargs["quantization_config"]
         assert isinstance(bnb_config, BitsAndBytesConfig)
-        assert bnb_config.load_in_4bit is True
-        assert bnb_config.load_in_8bit is False
-
-
-def test_quantization_8bit_uses_bits_and_bytes_config():
-    """Test that 8bit quantization passes a BitsAndBytesConfig to from_pretrained."""
-    from transformers import BitsAndBytesConfig
-
-    from esperanto.providers.embedding.transformers import TransformersEmbeddingModel
-
-    mock_bnb = MagicMock()
-    mock_model = MagicMock()
-    mock_tokenizer = MagicMock()
-    bnb_modules = {
-        "bitsandbytes": mock_bnb,
-        "bitsandbytes.nn": mock_bnb.nn,
-        "bitsandbytes.functional": mock_bnb.functional,
-    }
-
-    with (
-        patch.dict(sys.modules, bnb_modules),
-        patch(
-            "esperanto.providers.embedding.transformers.AutoModel.from_pretrained",
-            return_value=mock_model,
-        ) as mock_from_pretrained,
-        patch(
-            "esperanto.providers.embedding.transformers.AutoTokenizer.from_pretrained",
-            return_value=mock_tokenizer,
-        ),
-    ):
-        TransformersEmbeddingModel(
-            model_name="bert-base-uncased",
-            device="cpu",
-            quantize="8bit",
-        )
-
-        call_kwargs = mock_from_pretrained.call_args.kwargs
-        assert "quantization_config" in call_kwargs
-        bnb_config = call_kwargs["quantization_config"]
-        assert isinstance(bnb_config, BitsAndBytesConfig)
-        assert bnb_config.load_in_8bit is True
-        assert bnb_config.load_in_4bit is False
+        assert bnb_config.load_in_4bit is expected_4bit
+        assert bnb_config.load_in_8bit is expected_8bit


### PR DESCRIPTION
## Summary

- `TransformersEmbeddingModel._initialize_model` was building a `quantization_config` dict with `load_in_4bit`/`load_in_8bit` and spreading it as top-level kwargs to `AutoModel.from_pretrained`. Recent transformers versions deprecated that form in favor of a `BitsAndBytesConfig` object passed via `quantization_config=`. The provider now constructs `BitsAndBytesConfig(load_in_4bit=..., load_in_8bit=...)` and passes it via the supported keyword.
- The `bitsandbytes` availability check is preserved.
- Added a parametrized mocked unit test covering both 4bit and 8bit paths. The test injects a fake `bitsandbytes` into `sys.modules` and patches `AutoModel.from_pretrained` / `AutoTokenizer.from_pretrained`, so it runs without bitsandbytes installed and without downloading any model. It captures the `quantization_config` kwarg and asserts on the `BitsAndBytesConfig` flags — would fail if the config stops reaching `from_pretrained`.
- The pre-existing real-bitsandbytes test (`test_quantization`) is preserved with `pytest.importorskip` so it still smoke-tests the integration when the dependency is installed.

Closes #129.

## Test plan

- [x] `uv run pytest tests/providers/embedding/test_transformers_provider.py -q --no-cov` — 8 passed, 1 skipped (bitsandbytes not installed locally)
- [x] `uv run pytest tests/providers tests/unit tests/common_types -q --no-cov` — 890 passed, 1 skipped (7 pre-existing local-env failures, identical on `main`)
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src/esperanto` — clean