### PR TITLE
chore: union merge driver for CHANGELOG.md to prevent parallel-PR conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# CHANGELOG.md is append-only under [Unreleased]: every PR adds a bullet at the
+# bottom of its section. Without union merge, two parallel PRs that both add a
+# bullet to the same section produce a textbook three-way merge conflict even
+# though both changes are independent. The `merge=union` driver tells git to
+# combine both sides' added lines instead of conflicting.
+#
+# Edge cases that still conflict (both rare):
+#   - two PRs editing the same existing line
+#   - two PRs renaming/restructuring the same section heading
+# In either case, fall back to a manual rebase + resolve.
+CHANGELOG.md merge=union


### PR DESCRIPTION
## Summary

Every PR adds a bullet under `[Unreleased]` in `CHANGELOG.md`. When two PRs are open in parallel, both inserting a bullet at the same anchor (typically the line just before `## [2.20.1]`), they produce a textbook three-way merge conflict — even though the changes are completely independent. We've now hit this twice in quick succession (#127/#129 and again with #134/#135/#136).

This PR adds a `.gitattributes` rule that enables git's built-in `union` merge driver for `CHANGELOG.md`. The driver auto-combines additions from both sides when merging or rebasing, so the common case ("each PR appends one bullet to the Fixed list") becomes conflict-free.

### What still conflicts

Rare edge cases that fall back to manual resolution:
- Two PRs editing the same existing line.
- Two PRs renaming/restructuring the same section heading.

In those cases the existing rebase-and-resolve flow still applies.

### Why not changelog fragments (`scriv` / `towncrier`)?

Considered. Heavier infrastructure (new tool, new convention contributors must learn, release-time concatenation step) for a project at this scale. Union merge gives ~95% of the benefit with one line of config. We can revisit if/when contributor volume grows.

## Test plan

- [x] `.gitattributes` syntax verified — git recognizes the `merge=union` driver
- [ ] Implicit verification: future parallel PRs adding entries to `[Unreleased]/Fixed` should auto-merge without human intervention. The next batch will exercise this.