### PR TITLE
feat: add Mistral TTS provider (Voxtral) (closes #109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Mistral TTS provider** — `MistralTextToSpeechModel` using the Voxtral (`voxtral-mini-tts-2603`) model. Supports `pcm`, `wav`, `mp3`, `flac`, and `opus` response formats. Reuses the existing `MISTRAL_API_KEY` environment variable. Voice discovery via `available_voices` calls `GET /v1/audio/voices`.
 - **`TranscriptionResponse.provider`** — STT responses now expose the originating provider name as an optional field, matching the existing `AudioResponse.provider` field. All STT providers (`openai`, `elevenlabs`, `azure`) already passed this kwarg, but Pydantic was silently dropping it. Existing callers continue to work unchanged. (#126)
 
 ### Changed

--- a/docs/providers/mistral_tts.md
+++ b/docs/providers/mistral_tts.md
@@ -1,0 +1,179 @@
+# Mistral Text-to-Speech (Voxtral)
+
+## Overview
+
+Mistral's Voxtral model provides high-quality text-to-speech generation with multiple voices.
+
+**Supported Capabilities:**
+
+| Capability | Supported | Notes |
+|------------|-----------|-------|
+| Language Models (LLM) | ✅ | See [mistral.md](mistral.md) |
+| Embeddings | ✅ | See [mistral.md](mistral.md) |
+| Reranking | ❌ | Not available |
+| Speech-to-Text | ❌ | Not available |
+| Text-to-Speech | ✅ | Voxtral model |
+
+**Official Documentation:** https://docs.mistral.ai/capabilities/audio/
+
+## Prerequisites
+
+### Account Requirements
+- Mistral AI account
+- API key with access to Voxtral
+
+### Getting API Keys
+1. Visit https://console.mistral.ai/api-keys
+2. Create a new API key
+3. Store the key securely
+
+## Environment Variables
+
+```bash
+# Mistral API key (required) — same key used for LLM and embedding providers
+MISTRAL_API_KEY="your-api-key"
+```
+
+**Variable Priority:**
+1. Direct parameter in code (`api_key="..."`)
+2. Environment variable (`MISTRAL_API_KEY`)
+
+## Quick Start
+
+### Via Factory (Recommended)
+
+```python
+from esperanto.factory import AIFactory
+
+tts = AIFactory.create_text_to_speech(
+    "mistral",
+    "voxtral-mini-tts-2603",
+    config={"api_key": "your-api-key"},
+)
+
+response = tts.generate_speech(
+    text="Hello, world!",
+    voice="gb_jane_neutral",
+)
+```
+
+### Direct Instantiation
+
+```python
+from esperanto.providers.tts.mistral import MistralTextToSpeechModel
+
+tts = MistralTextToSpeechModel(
+    model_name="voxtral-mini-tts-2603",
+    api_key="your-api-key",
+)
+
+response = tts.generate_speech(
+    text="Hello, world!",
+    voice="gb_jane_neutral",
+)
+```
+
+## Available Models
+
+| Model | Description |
+|-------|-------------|
+| `voxtral-mini-tts-2603` | Voxtral Mini — default TTS model |
+
+## Voice Selection
+
+Mistral provides preset voices accessible via the `available_voices` property:
+
+```python
+voices = tts.available_voices
+for voice_id, voice in voices.items():
+    print(f"{voice_id}: {voice.name} ({voice.gender})")
+```
+
+**Known preset voices:**
+
+| Voice ID | Description |
+|----------|-------------|
+| `gb_jane_neutral` | Jane — neutral British English voice |
+| `en_paul_neutral` | Paul — neutral English voice |
+
+To discover all available voices dynamically:
+
+```python
+voices = tts.available_voices
+```
+
+## Response Formats
+
+Mistral supports the following audio formats:
+
+| Format | Content-Type | Notes |
+|--------|-------------|-------|
+| `mp3` | `audio/mp3` | Default format |
+| `wav` | `audio/wav` | Uncompressed audio |
+| `flac` | `audio/flac` | Lossless compression |
+| `opus` | `audio/opus` | Efficient compression |
+| `pcm` | `audio/pcm` | Raw PCM audio |
+
+```python
+response = tts.generate_speech(
+    text="Hello",
+    voice="gb_jane_neutral",
+    response_format="wav",
+)
+```
+
+## Saving to File
+
+```python
+response = tts.generate_speech(
+    text="Hello, world!",
+    voice="gb_jane_neutral",
+    output_file="output.mp3",
+)
+```
+
+## Async Usage
+
+```python
+import asyncio
+from esperanto.factory import AIFactory
+
+async def main():
+    tts = AIFactory.create_text_to_speech(
+        "mistral",
+        "voxtral-mini-tts-2603",
+        config={"api_key": "your-api-key"},
+    )
+    response = await tts.agenerate_speech(
+        text="Hello, world!",
+        voice="gb_jane_neutral",
+    )
+    with open("output.mp3", "wb") as f:
+        f.write(response.audio_data)
+
+asyncio.run(main())
+```
+
+## Response Object
+
+`generate_speech` and `agenerate_speech` return an `AudioResponse`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `audio_data` | `bytes` | Raw audio bytes (base64-decoded from API) |
+| `content_type` | `str` | MIME type (e.g., `audio/mp3`) |
+| `model` | `str` | Model used |
+| `voice` | `str` | Voice ID used |
+| `provider` | `str` | Always `"mistral"` |
+| `metadata` | `dict` | Contains the original `text` |
+
+## Error Handling
+
+```python
+try:
+    response = tts.generate_speech(text="Hello", voice="gb_jane_neutral")
+except RuntimeError as e:
+    print(f"TTS failed: {e}")
+```
+
+Errors raised by the Mistral API are wrapped in `RuntimeError` with the message prefix `"Mistral API error: ..."`.

--- a/src/esperanto/__init__.py
+++ b/src/esperanto/__init__.py
@@ -111,6 +111,11 @@ try:
 except ImportError:
     VertexTextToSpeechModel = None  # type: ignore[assignment,misc]
 
+try:
+    from esperanto.providers.tts.mistral import MistralTextToSpeechModel
+except ImportError:
+    MistralTextToSpeechModel = None  # type: ignore[assignment,misc]
+
 # Store all provider classes
 __provider_classes = {
     'AnthropicLanguageModel': AnthropicLanguageModel,
@@ -130,7 +135,8 @@ __provider_classes = {
     "GroqLanguageModel": GroqLanguageModel,
     "VertexLanguageModel": VertexLanguageModel,
     "VertexEmbeddingModel": VertexEmbeddingModel,
-    "VertexTextToSpeechModel": VertexTextToSpeechModel
+    "VertexTextToSpeechModel": VertexTextToSpeechModel,
+    "MistralTextToSpeechModel": MistralTextToSpeechModel,
 }
 
 # Get list of available provider classes (excluding None values)

--- a/src/esperanto/factory.py
+++ b/src/esperanto/factory.py
@@ -61,6 +61,7 @@ class AIFactory:
             "openai-compatible": "esperanto.providers.tts.openai_compatible:OpenAICompatibleTextToSpeechModel",
             "azure": "esperanto.providers.tts.azure:AzureTextToSpeechModel",
             "xai": "esperanto.providers.tts.xai:XAITextToSpeechModel",
+            "mistral": "esperanto.providers.tts.mistral:MistralTextToSpeechModel",
         },
         "reranker": {
             "jina": "esperanto.providers.reranker.jina:JinaRerankerModel",

--- a/src/esperanto/providers/tts/mistral.py
+++ b/src/esperanto/providers/tts/mistral.py
@@ -1,0 +1,176 @@
+"""Mistral Text-to-Speech provider implementation."""
+import base64
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+import httpx
+
+from .base import AudioResponse, Model, TextToSpeechModel, Voice
+
+RESPONSE_FORMAT_TO_CONTENT_TYPE = {
+    "mp3": "audio/mp3",
+    "opus": "audio/opus",
+    "flac": "audio/flac",
+    "wav": "audio/wav",
+    "pcm": "audio/pcm",
+}
+
+
+class MistralTextToSpeechModel(TextToSpeechModel):
+    """Mistral Text-to-Speech provider (Voxtral)."""
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.api_key = self.api_key or os.getenv("MISTRAL_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "Mistral API key not found. Set MISTRAL_API_KEY environment variable."
+            )
+        self.base_url = self.base_url or "https://api.mistral.ai/v1"
+        self.model_name = self.model_name or self._get_default_model()
+        self._voices_cache: Optional[Dict[str, Voice]] = None
+        self._create_http_clients()
+
+    def _get_headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    def _handle_error(self, response: httpx.Response) -> None:
+        if response.status_code >= 400:
+            try:
+                error_data = response.json()
+                error_message = error_data.get("error", {}).get(
+                    "message", f"HTTP {response.status_code}"
+                )
+            except Exception:
+                error_message = f"HTTP {response.status_code}: {response.text}"
+            raise RuntimeError(f"Mistral API error: {error_message}")
+
+    @property
+    def provider(self) -> str:
+        return "mistral"
+
+    def _get_default_model(self) -> str:
+        return "voxtral-mini-tts-2603"
+
+    def _get_models(self) -> List[Model]:
+        return [
+            Model(id="voxtral-mini-tts-2603", owned_by="mistralai", context_window=None)
+        ]
+
+    @property
+    def available_voices(self) -> Dict[str, Voice]:
+        if self._voices_cache is not None:
+            return self._voices_cache
+        response = self.client.get(
+            f"{self.base_url}/audio/voices",
+            headers=self._get_headers(),
+        )
+        self._handle_error(response)
+        items = response.json().get("items", [])
+        self._voices_cache = {
+            item["id"]: Voice(
+                id=item["id"],
+                name=item.get("name", item["id"]),
+                gender=item.get("gender", "NEUTRAL"),
+                language_code=item["languages"][0] if item.get("languages") else None,
+            )
+            for item in items
+        }
+        return self._voices_cache
+
+    def generate_speech(
+        self,
+        text: str,
+        voice: str,
+        output_file: Optional[Union[str, Path]] = None,
+        **kwargs: Any,
+    ) -> AudioResponse:
+        try:
+            self.validate_parameters(text, voice)
+            response_format = kwargs.pop("response_format", "mp3")
+
+            payload: Dict[str, Any] = {
+                "model": self.model_name or self._get_default_model(),
+                "input": text,
+                "voice_id": voice,
+                "response_format": response_format,
+            }
+
+            response = self.client.post(
+                f"{self.base_url}/audio/speech",
+                headers=self._get_headers(),
+                json=payload,
+            )
+            self._handle_error(response)
+
+            audio_data = base64.b64decode(response.json()["audio_data"])
+
+            if output_file:
+                self.save_audio(audio_data, output_file)
+
+            content_type = RESPONSE_FORMAT_TO_CONTENT_TYPE.get(
+                str(response_format), f"audio/{response_format}"
+            )
+            return AudioResponse(
+                audio_data=audio_data,
+                content_type=content_type,
+                model=self.model_name or self._get_default_model(),
+                voice=voice,
+                provider="mistral",
+                metadata={"text": text},
+            )
+        except RuntimeError:
+            raise
+        except Exception as e:
+            raise RuntimeError(f"Failed to generate speech: {str(e)}") from e
+
+    async def agenerate_speech(
+        self,
+        text: str,
+        voice: str,
+        output_file: Optional[Union[str, Path]] = None,
+        **kwargs: Any,
+    ) -> AudioResponse:
+        try:
+            self.validate_parameters(text, voice)
+            response_format = kwargs.pop("response_format", "mp3")
+
+            payload: Dict[str, Any] = {
+                "model": self.model_name or self._get_default_model(),
+                "input": text,
+                "voice_id": voice,
+                "response_format": response_format,
+            }
+
+            response = await self.async_client.post(
+                f"{self.base_url}/audio/speech",
+                headers=self._get_headers(),
+                json=payload,
+            )
+            self._handle_error(response)
+
+            audio_data = base64.b64decode(response.json()["audio_data"])
+
+            if output_file:
+                self.save_audio(audio_data, output_file)
+
+            content_type = RESPONSE_FORMAT_TO_CONTENT_TYPE.get(
+                str(response_format), f"audio/{response_format}"
+            )
+            return AudioResponse(
+                audio_data=audio_data,
+                content_type=content_type,
+                model=self.model_name or self._get_default_model(),
+                voice=voice,
+                provider="mistral",
+                metadata={"text": text},
+            )
+        except RuntimeError:
+            raise
+        except Exception as e:
+            raise RuntimeError(f"Failed to generate speech: {str(e)}") from e

--- a/tests/providers/tts/test_mistral.py
+++ b/tests/providers/tts/test_mistral.py
@@ -1,0 +1,199 @@
+"""Tests for the Mistral TTS provider."""
+import base64
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from esperanto.providers.tts.mistral import MistralTextToSpeechModel
+
+RAW_AUDIO = b"mock audio data"
+B64_AUDIO = base64.b64encode(RAW_AUDIO).decode()
+
+VOICES_RESPONSE = {
+    "items": [
+        {
+            "id": "gb_jane_neutral",
+            "name": "Jane",
+            "gender": "NEUTRAL",
+            "languages": ["en"],
+        }
+    ]
+}
+
+
+@pytest.fixture
+def mock_httpx_clients():
+    """Mock httpx clients for Mistral TTS."""
+    client = Mock()
+    async_client = AsyncMock()
+
+    def make_response(status_code, json_data=None):
+        response = Mock()
+        response.status_code = status_code
+        if json_data is not None:
+            response.json.return_value = json_data
+        else:
+            response.json.return_value = {}
+        response.text = ""
+        return response
+
+    def make_async_response(status_code, json_data=None):
+        response = AsyncMock()
+        response.status_code = status_code
+        if json_data is not None:
+            response.json = Mock(return_value=json_data)
+        else:
+            response.json = Mock(return_value={})
+        response.text = ""
+        return response
+
+    def mock_post_side_effect(url, **kwargs):
+        if url.endswith("/audio/speech"):
+            return make_response(200, json_data={"audio_data": B64_AUDIO})
+        return make_response(404, json_data={"error": {"message": "Not found"}})
+
+    def mock_get_side_effect(url, **kwargs):
+        if url.endswith("/audio/voices"):
+            return make_response(200, json_data=VOICES_RESPONSE)
+        return make_response(404, json_data={"error": {"message": "Not found"}})
+
+    async def mock_async_post_side_effect(url, **kwargs):
+        if url.endswith("/audio/speech"):
+            return make_async_response(200, json_data={"audio_data": B64_AUDIO})
+        return make_async_response(404, json_data={"error": {"message": "Not found"}})
+
+    client.post.side_effect = mock_post_side_effect
+    client.get.side_effect = mock_get_side_effect
+    async_client.post.side_effect = mock_async_post_side_effect
+
+    return client, async_client
+
+
+@pytest.fixture
+def tts_model(mock_httpx_clients):
+    model = MistralTextToSpeechModel(
+        api_key="test-key",
+        model_name="voxtral-mini-tts-2603",
+    )
+    model.client, model.async_client = mock_httpx_clients
+    return model
+
+
+def test_init(tts_model):
+    assert tts_model.model_name == "voxtral-mini-tts-2603"
+    assert tts_model.provider == "mistral"
+    assert tts_model.base_url == "https://api.mistral.ai/v1"
+
+
+def test_generate_speech(tts_model):
+    response = tts_model.generate_speech(
+        text="Hello world",
+        voice="gb_jane_neutral",
+    )
+
+    tts_model.client.post.assert_called_once()
+    call_args = tts_model.client.post.call_args
+
+    assert call_args[0][0] == "https://api.mistral.ai/v1/audio/speech"
+
+    headers = call_args[1]["headers"]
+    assert headers["Authorization"] == "Bearer test-key"
+
+    payload = call_args[1]["json"]
+    assert payload["input"] == "Hello world"
+    assert payload["voice_id"] == "gb_jane_neutral"
+    assert payload["model"] == "voxtral-mini-tts-2603"
+    assert payload["response_format"] == "mp3"
+
+    assert response.audio_data == RAW_AUDIO
+    assert response.content_type == "audio/mp3"
+    assert response.model == "voxtral-mini-tts-2603"
+    assert response.voice == "gb_jane_neutral"
+    assert response.provider == "mistral"
+
+
+@pytest.mark.asyncio
+async def test_agenerate_speech(tts_model):
+    response = await tts_model.agenerate_speech(
+        text="Hello world",
+        voice="en_paul_neutral",
+    )
+
+    tts_model.async_client.post.assert_called_once()
+    call_args = tts_model.async_client.post.call_args
+
+    assert call_args[0][0] == "https://api.mistral.ai/v1/audio/speech"
+
+    headers = call_args[1]["headers"]
+    assert headers["Authorization"] == "Bearer test-key"
+
+    payload = call_args[1]["json"]
+    assert payload["input"] == "Hello world"
+    assert payload["voice_id"] == "en_paul_neutral"
+    assert payload["model"] == "voxtral-mini-tts-2603"
+    assert payload["response_format"] == "mp3"
+
+    assert response.audio_data == RAW_AUDIO
+    assert response.content_type == "audio/mp3"
+    assert response.model == "voxtral-mini-tts-2603"
+    assert response.voice == "en_paul_neutral"
+    assert response.provider == "mistral"
+
+
+def test_generate_speech_with_response_format(tts_model):
+    response = tts_model.generate_speech(
+        text="Hello world",
+        voice="gb_jane_neutral",
+        response_format="wav",
+    )
+
+    call_args = tts_model.client.post.call_args
+    payload = call_args[1]["json"]
+    assert payload["response_format"] == "wav"
+    assert response.content_type == "audio/wav"
+
+
+def test_available_voices(tts_model):
+    voices = tts_model.available_voices
+
+    tts_model.client.get.assert_called_once_with(
+        "https://api.mistral.ai/v1/audio/voices",
+        headers=tts_model._get_headers(),
+    )
+
+    assert "gb_jane_neutral" in voices
+    voice = voices["gb_jane_neutral"]
+    assert voice.id == "gb_jane_neutral"
+    assert voice.name == "Jane"
+    assert voice.gender == "NEUTRAL"
+    assert voice.language_code == "en"
+
+
+def test_available_voices_cached(tts_model):
+    _ = tts_model.available_voices
+    _ = tts_model.available_voices
+    assert tts_model.client.get.call_count == 1
+
+
+def test_error_handling_4xx(tts_model):
+    tts_model.client.post.side_effect = None
+    error_response = Mock()
+    error_response.status_code = 400
+    error_response.json.return_value = {"error": {"message": "Bad request"}}
+    error_response.text = "Bad request"
+    tts_model.client.post.return_value = error_response
+
+    with pytest.raises(RuntimeError, match="Mistral API error"):
+        tts_model.generate_speech(text="Hello", voice="gb_jane_neutral")
+
+
+def test_error_handling_5xx(tts_model):
+    tts_model.client.post.side_effect = None
+    error_response = Mock()
+    error_response.status_code = 500
+    error_response.json.side_effect = Exception("no json")
+    error_response.text = "Internal Server Error"
+    tts_model.client.post.return_value = error_response
+
+    with pytest.raises(RuntimeError, match="Mistral API error"):
+        tts_model.generate_speech(text="Hello", voice="gb_jane_neutral")


### PR DESCRIPTION
## Summary

Adds `MistralTextToSpeechModel` so Esperanto's TTS interface now covers Mistral via the Voxtral model — alongside the existing `MistralLanguageModel` and `MistralEmbeddingModel`. Same `MISTRAL_API_KEY` env var, same provider-agnostic interface as OpenAI, ElevenLabs, etc.

### Verified API facts (looked up from Mistral docs before implementing)

- Base URL: `https://api.mistral.ai/v1`
- Endpoint: `POST /v1/audio/speech`
- Default model: `voxtral-mini-tts-2603`
- Auth: `Authorization: Bearer <MISTRAL_API_KEY>`
- Request payload: `{ "model": ..., "input": <text>, "voice_id": <voice>, "response_format": <format> }`
- Response: JSON `{ "audio_data": "<base64-encoded-bytes>" }` (different from OpenAI's raw-bytes response — base64-decoded before being placed into `AudioResponse.audio_data`)
- Voice discovery: `GET /v1/audio/voices` returns `{ "items": [{ id, name, gender, languages }] }`. Pulled dynamically into `available_voices` and cached.
- Supported response formats: `pcm`, `wav`, `mp3`, `flac`, `opus`

### Conformance

- Uses the `__post_init__` pattern documented in `CLAUDE.md` (super-call first, `_create_http_clients()` last).
- Uses `json=payload` (not `data=json.dumps(...)`), consistent with the OpenRouter fix in #132.
- Reuses base class `validate_parameters` and `save_audio` helpers — no per-provider reinvention.
- Optional import in `esperanto/__init__.py` with `try/except ImportError` setting `MistralTextToSpeechModel = None` (matches every other provider).

### Files

- `src/esperanto/providers/tts/mistral.py` (new, 176 lines)
- `tests/providers/tts/test_mistral.py` (new, 199 lines, 8 mocked unit tests)
- `docs/providers/mistral_tts.md` (new, usage guide)
- `src/esperanto/factory.py` (+1 line: register `mistral` under `text_to_speech`)
- `src/esperanto/__init__.py` (+7 lines: optional import + provider class registration)
- `CHANGELOG.md` (+1 line: Unreleased / Added)

### Replaces #115

[PR #115](https://github.com/lfnovo/esperanto/pull/115) was an earlier automation attempt at the same issue. It had the right endpoint and model name, but used `__init__` instead of `__post_init__`, hardcoded a list of 20 invented voice names instead of querying `/v1/audio/voices`, and had been idle for 2 weeks without review. Closed in favor of this fresh, dynamic implementation.

Closes #109.

## Test plan

- [x] 8 new mocked unit tests in `tests/providers/tts/test_mistral.py` — all pass
- [x] `uv run pytest tests/providers tests/unit tests/common_types tests/test_deprecation_warnings.py -q --no-cov` — 927 passed, 1 skipped (7 pre-existing local-env failures, identical on `main`)
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src/esperanto` — clean (now 71 source files, +1 for the new provider)
- [x] `AIFactory.create_text_to_speech("mistral", "voxtral-mini-tts-2603", api_key="test")` instantiates correctly
- [x] `from esperanto import MistralTextToSpeechModel` works
- [ ] Optional smoke-test against a real `MISTRAL_API_KEY` once merged

## Follow-ups (not in this PR)

- `available_voices` reads only the first page of `/v1/audio/voices`. If Mistral's preset list grows beyond one page, additional voices will be silently truncated. A small pagination loop would be a clean follow-up.