### PR TITLE
feat: add Mistral STT provider (Voxtral) (closes #142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Mistral TTS provider** — `MistralTextToSpeechModel` using the Voxtral (`voxtral-mini-tts-2603`) model. Supports `pcm`, `wav`, `mp3`, `flac`, and `opus` response formats. Reuses the existing `MISTRAL_API_KEY` environment variable. Voice discovery via `available_voices` calls `GET /v1/audio/voices`.
+- **Mistral Speech-to-Text provider** — new `MistralSpeechToTextModel` supporting `voxtral-mini-latest` (default) and `voxtral-small-latest`. Unlike OpenAI Whisper, Mistral returns the detected language in the response body, which is surfaced as `TranscriptionResponse.language`. Accessible via `AIFactory.create_stt("mistral")`.
 - **`TranscriptionResponse.provider`** — STT responses now expose the originating provider name as an optional field, matching the existing `AudioResponse.provider` field. All STT providers (`openai`, `elevenlabs`, `azure`) already passed this kwarg, but Pydantic was silently dropping it. Existing callers continue to work unchanged. (#126)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Mistral TTS provider** — `MistralTextToSpeechModel` using the Voxtral (`voxtral-mini-tts-2603`) model. Supports `pcm`, `wav`, `mp3`, `flac`, and `opus` response formats. Reuses the existing `MISTRAL_API_KEY` environment variable. Voice discovery via `available_voices` calls `GET /v1/audio/voices`.
 - **Mistral Speech-to-Text provider** — new `MistralSpeechToTextModel` supporting `voxtral-mini-latest` (default) and `voxtral-small-latest`. Unlike OpenAI Whisper, Mistral returns the detected language in the response body, which is surfaced as `TranscriptionResponse.language`. Accessible via `AIFactory.create_stt("mistral")`.
+- **Mistral Speech-to-Text provider** — new `MistralSpeechToTextModel` supporting `voxtral-mini-latest` (default) and `voxtral-small-latest`. Unlike OpenAI Whisper, Mistral returns the detected language in the response body, which is surfaced as `TranscriptionResponse.language`. Accessible via `AIFactory.create_speech_to_text("mistral")`.
 - **`TranscriptionResponse.provider`** — STT responses now expose the originating provider name as an optional field, matching the existing `AudioResponse.provider` field. All STT providers (`openai`, `elevenlabs`, `azure`) already passed this kwarg, but Pydantic was silently dropping it. Existing callers continue to work unchanged. (#126)
 
 ### Changed

--- a/docs/providers/mistral_stt.md
+++ b/docs/providers/mistral_stt.md
@@ -1,0 +1,112 @@
+# Mistral Speech-to-Text
+
+## Overview
+
+Mistral provides speech-to-text transcription via its Voxtral models.
+
+**Supported Capabilities:**
+
+| Capability | Supported | Notes |
+|------------|-----------|-------|
+| Speech-to-Text | ✅ | Voxtral models |
+| Language auto-detection | ✅ | Returned in response |
+
+**Official Documentation:** https://docs.mistral.ai/capabilities/speech-to-text/
+
+## Prerequisites
+
+### Account Requirements
+
+- Mistral account (sign up at https://console.mistral.ai)
+- API key with access to audio endpoints
+
+### Getting API Keys
+
+1. Visit https://console.mistral.ai/api-keys
+2. Create a new API key
+3. Copy and store it securely
+
+## Environment Variables
+
+```bash
+MISTRAL_API_KEY="your-api-key"
+```
+
+## Quick Start
+
+### Via Factory (Recommended)
+
+```python
+from esperanto.factory import AIFactory
+
+transcriber = AIFactory.create_stt("mistral")
+response = transcriber.transcribe("audio.mp3")
+print(response.text)
+print(response.language)  # auto-detected by Mistral
+```
+
+### Direct Instantiation
+
+```python
+from esperanto.providers.stt.mistral import MistralSpeechToTextModel
+
+transcriber = MistralSpeechToTextModel(api_key="your-key")
+response = transcriber.transcribe("audio.mp3")
+```
+
+## Models
+
+| Model | Description |
+|-------|-------------|
+| `voxtral-mini-latest` | Default; fast, lightweight |
+| `voxtral-small-latest` | Higher accuracy |
+
+```python
+transcriber = AIFactory.create_stt("mistral", "voxtral-small-latest")
+```
+
+## Options
+
+```python
+response = transcriber.transcribe(
+    "audio.mp3",
+    language="fr",              # optional ISO 639-1 hint
+    prompt="Podcast sur l'IA",  # optional context
+)
+```
+
+## Async Usage
+
+```python
+import asyncio
+from esperanto.factory import AIFactory
+
+async def main():
+    transcriber = AIFactory.create_stt("mistral")
+    response = await transcriber.atranscribe("audio.mp3")
+    print(response.text)
+
+asyncio.run(main())
+```
+
+## Response Format
+
+```python
+TranscriptionResponse(
+    text="Transcribed text here",
+    language="en",       # detected language from Mistral
+    model="voxtral-mini-latest",
+    provider="mistral",
+)
+```
+
+## Error Handling
+
+```python
+try:
+    response = transcriber.transcribe("audio.mp3")
+except RuntimeError as e:
+    print(f"API error: {e}")
+except ValueError as e:
+    print(f"Configuration error: {e}")
+```

--- a/docs/providers/mistral_stt.md
+++ b/docs/providers/mistral_stt.md
@@ -39,7 +39,7 @@ MISTRAL_API_KEY="your-api-key"
 ```python
 from esperanto.factory import AIFactory
 
-transcriber = AIFactory.create_stt("mistral")
+transcriber = AIFactory.create_speech_to_text("mistral")
 response = transcriber.transcribe("audio.mp3")
 print(response.text)
 print(response.language)  # auto-detected by Mistral
@@ -62,7 +62,7 @@ response = transcriber.transcribe("audio.mp3")
 | `voxtral-small-latest` | Higher accuracy |
 
 ```python
-transcriber = AIFactory.create_stt("mistral", "voxtral-small-latest")
+transcriber = AIFactory.create_speech_to_text("mistral", "voxtral-small-latest")
 ```
 
 ## Options
@@ -82,7 +82,7 @@ import asyncio
 from esperanto.factory import AIFactory
 
 async def main():
-    transcriber = AIFactory.create_stt("mistral")
+    transcriber = AIFactory.create_speech_to_text("mistral")
     response = await transcriber.atranscribe("audio.mp3")
     print(response.text)
 

--- a/src/esperanto/__init__.py
+++ b/src/esperanto/__init__.py
@@ -116,6 +116,11 @@ try:
 except ImportError:
     MistralTextToSpeechModel = None  # type: ignore[assignment,misc]
 
+try:
+    from esperanto.providers.stt.mistral import MistralSpeechToTextModel
+except ImportError:
+    MistralSpeechToTextModel = None  # type: ignore[assignment,misc]
+
 # Store all provider classes
 __provider_classes = {
     'AnthropicLanguageModel': AnthropicLanguageModel,
@@ -137,6 +142,7 @@ __provider_classes = {
     "VertexEmbeddingModel": VertexEmbeddingModel,
     "VertexTextToSpeechModel": VertexTextToSpeechModel,
     "MistralTextToSpeechModel": MistralTextToSpeechModel,
+    "MistralSpeechToTextModel": MistralSpeechToTextModel,
 }
 
 # Get list of available provider classes (excluding None values)

--- a/src/esperanto/factory.py
+++ b/src/esperanto/factory.py
@@ -52,6 +52,7 @@ class AIFactory:
             "openai-compatible": "esperanto.providers.stt.openai_compatible:OpenAICompatibleSpeechToTextModel",
             "azure": "esperanto.providers.stt.azure:AzureSpeechToTextModel",
             "google": "esperanto.providers.stt.google:GoogleSpeechToTextModel",
+            "mistral": "esperanto.providers.stt.mistral:MistralSpeechToTextModel",
         },
         "text_to_speech": {
             "openai": "esperanto.providers.tts.openai:OpenAITextToSpeechModel",

--- a/src/esperanto/providers/stt/mistral.py
+++ b/src/esperanto/providers/stt/mistral.py
@@ -1,0 +1,144 @@
+"""Mistral speech-to-text provider."""
+
+import os
+from dataclasses import dataclass
+from typing import Any, BinaryIO, Dict, List, Optional, Union
+
+import httpx
+
+from esperanto.common_types import TranscriptionResponse
+from esperanto.providers.stt.base import Model, SpeechToTextModel
+
+
+@dataclass
+class MistralSpeechToTextModel(SpeechToTextModel):
+    """Mistral speech-to-text model implementation."""
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        self.api_key = self.api_key or os.getenv("MISTRAL_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "Mistral API key not found. Set MISTRAL_API_KEY environment variable."
+            )
+
+        self.base_url = self.base_url or "https://api.mistral.ai/v1"
+
+        self._create_http_clients()
+
+    @property
+    def provider(self) -> str:
+        return "mistral"
+
+    def _get_default_model(self) -> str:
+        return "voxtral-mini-latest"
+
+    def _get_headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Accept": "application/json",
+        }
+
+    def _handle_error(self, response: httpx.Response) -> None:
+        if response.status_code >= 400:
+            try:
+                error_data = response.json()
+                error_message = error_data.get("error", {}).get(
+                    "message", f"HTTP {response.status_code}"
+                )
+            except Exception:
+                error_message = f"HTTP {response.status_code}: {response.text}"
+            raise RuntimeError(f"Mistral API error: {error_message}")
+
+    def _get_models(self) -> List[Model]:
+        return [
+            Model(id="voxtral-mini-latest", owned_by="mistralai", context_window=None),
+            Model(id="voxtral-small-latest", owned_by="mistralai", context_window=None),
+        ]
+
+    def _build_request_data(
+        self, language: Optional[str], prompt: Optional[str]
+    ) -> Dict[str, Any]:
+        data: Dict[str, Any] = {"model": self.get_model_name()}
+        if language:
+            data["language"] = language
+        if prompt:
+            data["prompt"] = prompt
+        return data
+
+    def transcribe(
+        self,
+        audio_file: Union[str, BinaryIO],
+        language: Optional[str] = None,
+        prompt: Optional[str] = None,
+    ) -> TranscriptionResponse:
+        """Transcribe audio to text using Mistral's Voxtral model."""
+        data = self._build_request_data(language, prompt)
+
+        if isinstance(audio_file, str):
+            with open(audio_file, "rb") as f:
+                files: Dict[str, Any] = {"file": (audio_file, f, "audio/mpeg")}
+                response = self.client.post(
+                    f"{self.base_url}/audio/transcriptions",
+                    headers=self._get_headers(),
+                    files=files,
+                    data=data,
+                )
+        else:
+            filename = getattr(audio_file, "name", "audio.mp3")
+            files = {"file": (filename, audio_file, "audio/mpeg")}
+            response = self.client.post(
+                f"{self.base_url}/audio/transcriptions",
+                headers=self._get_headers(),
+                files=files,
+                data=data,
+            )
+
+        self._handle_error(response)
+        response_data = response.json()
+
+        return TranscriptionResponse(
+            text=response_data["text"],
+            language=response_data.get("language"),
+            model=self.get_model_name(),
+            provider=self.provider,
+        )
+
+    async def atranscribe(
+        self,
+        audio_file: Union[str, BinaryIO],
+        language: Optional[str] = None,
+        prompt: Optional[str] = None,
+    ) -> TranscriptionResponse:
+        """Async transcribe audio to text using Mistral's Voxtral model."""
+        data = self._build_request_data(language, prompt)
+
+        if isinstance(audio_file, str):
+            with open(audio_file, "rb") as f:
+                files: Dict[str, Any] = {"file": (audio_file, f, "audio/mpeg")}
+                response = await self.async_client.post(
+                    f"{self.base_url}/audio/transcriptions",
+                    headers=self._get_headers(),
+                    files=files,
+                    data=data,
+                )
+        else:
+            filename = getattr(audio_file, "name", "audio.mp3")
+            files = {"file": (filename, audio_file, "audio/mpeg")}
+            response = await self.async_client.post(
+                f"{self.base_url}/audio/transcriptions",
+                headers=self._get_headers(),
+                files=files,
+                data=data,
+            )
+
+        self._handle_error(response)
+        response_data = response.json()
+
+        return TranscriptionResponse(
+            text=response_data["text"],
+            language=response_data.get("language"),
+            model=self.get_model_name(),
+            provider=self.provider,
+        )

--- a/tests/providers/stt/test_mistral.py
+++ b/tests/providers/stt/test_mistral.py
@@ -1,0 +1,200 @@
+"""Tests for Mistral speech-to-text provider."""
+
+import os
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from esperanto.common_types import TranscriptionResponse
+from esperanto.factory import AIFactory
+from esperanto.providers.stt.mistral import MistralSpeechToTextModel
+
+
+@pytest.fixture
+def audio_file(tmp_path):
+    """Create a temporary audio file for testing."""
+    f = tmp_path / "test.mp3"
+    f.write_bytes(b"mock audio content")
+    return str(f)
+
+
+@pytest.fixture
+def mock_transcription_response():
+    return {
+        "text": "This is a test transcription",
+        "model": "voxtral-mini-latest",
+        "language": "en",
+        "segments": [],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+    }
+
+
+@pytest.fixture
+def mock_httpx_clients(mock_transcription_response):
+    """Mock httpx sync and async clients."""
+    client = Mock()
+    async_client = AsyncMock()
+
+    def make_response(status_code, data):
+        r = Mock()
+        r.status_code = status_code
+        r.json.return_value = data
+        return r
+
+    def make_async_response(status_code, data):
+        r = AsyncMock()
+        r.status_code = status_code
+        r.json = Mock(return_value=data)
+        return r
+
+    def post_side_effect(url, **kwargs):
+        if url.endswith("/audio/transcriptions"):
+            return make_response(200, mock_transcription_response)
+        return make_response(404, {"error": {"message": "Not found"}})
+
+    async def async_post_side_effect(url, **kwargs):
+        if url.endswith("/audio/transcriptions"):
+            return make_async_response(200, mock_transcription_response)
+        return make_async_response(404, {"error": {"message": "Not found"}})
+
+    client.post.side_effect = post_side_effect
+    async_client.post.side_effect = async_post_side_effect
+
+    return client, async_client
+
+
+@pytest.fixture(autouse=True)
+def mock_env():
+    with patch.dict(os.environ, {"MISTRAL_API_KEY": "test-key"}):
+        yield
+
+
+def test_factory_creates_mistral_stt():
+    model = AIFactory.create_stt("mistral")
+    assert isinstance(model, MistralSpeechToTextModel)
+
+
+def test_mistral_transcribe(audio_file, mock_httpx_clients):
+    model = MistralSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    response = model.transcribe(audio_file)
+
+    model.client.post.assert_called_once()
+    call_args = model.client.post.call_args
+
+    assert call_args[0][0] == "https://api.mistral.ai/v1/audio/transcriptions"
+
+    headers = call_args[1]["headers"]
+    assert headers["Authorization"] == "Bearer test-key"
+    assert headers["Accept"] == "application/json"
+
+    assert "files" in call_args[1]
+    assert "data" in call_args[1]
+    assert call_args[1]["data"]["model"] == "voxtral-mini-latest"
+
+    assert isinstance(response, TranscriptionResponse)
+    assert response.text == "This is a test transcription"
+    assert response.model == "voxtral-mini-latest"
+    assert response.provider == "mistral"
+    assert response.language == "en"
+
+
+@pytest.mark.asyncio
+async def test_mistral_atranscribe(audio_file, mock_httpx_clients):
+    model = MistralSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    response = await model.atranscribe(audio_file)
+
+    model.async_client.post.assert_called_once()
+    call_args = model.async_client.post.call_args
+
+    assert call_args[0][0] == "https://api.mistral.ai/v1/audio/transcriptions"
+
+    headers = call_args[1]["headers"]
+    assert headers["Authorization"] == "Bearer test-key"
+    assert headers["Accept"] == "application/json"
+
+    assert "files" in call_args[1]
+    assert "data" in call_args[1]
+    assert call_args[1]["data"]["model"] == "voxtral-mini-latest"
+
+    assert isinstance(response, TranscriptionResponse)
+    assert response.text == "This is a test transcription"
+    assert response.model == "voxtral-mini-latest"
+    assert response.provider == "mistral"
+    assert response.language == "en"
+
+
+def test_mistral_transcribe_with_options(audio_file, mock_httpx_clients):
+    model = MistralSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    response = model.transcribe(audio_file, language="fr", prompt="Podcast sur l'IA")
+
+    call_args = model.client.post.call_args
+    data = call_args[1]["data"]
+    assert data["model"] == "voxtral-mini-latest"
+    assert data["language"] == "fr"
+    assert data["prompt"] == "Podcast sur l'IA"
+
+    assert isinstance(response, TranscriptionResponse)
+    assert response.text == "This is a test transcription"
+
+
+def test_mistral_transcribe_file_object(mock_httpx_clients):
+    model = MistralSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    with open(__file__, "rb") as f:
+        response = model.transcribe(f)
+
+    model.client.post.assert_called_once()
+    call_args = model.client.post.call_args
+    assert call_args[0][0] == "https://api.mistral.ai/v1/audio/transcriptions"
+    assert "files" in call_args[1]
+    assert "data" in call_args[1]
+
+    assert isinstance(response, TranscriptionResponse)
+    assert response.text == "This is a test transcription"
+
+
+def test_mistral_error_handling(audio_file):
+    """Test that 4xx responses raise RuntimeError with provider message."""
+    model = MistralSpeechToTextModel(api_key="test-key")
+
+    error_response = Mock()
+    error_response.status_code = 401
+    error_response.json.return_value = {"error": {"message": "Unauthorized"}}
+
+    model.client = Mock()
+    model.client.post.return_value = error_response
+
+    with pytest.raises(RuntimeError, match="Mistral API error: Unauthorized"):
+        model.transcribe(audio_file)
+
+
+def test_mistral_default_model():
+    model = MistralSpeechToTextModel(api_key="test-key")
+    assert model._get_default_model() == "voxtral-mini-latest"
+    assert model.get_model_name() == "voxtral-mini-latest"
+
+
+def test_mistral_get_models():
+    model = MistralSpeechToTextModel(api_key="test-key")
+    models = model._get_models()
+    model_ids = [m.id for m in models]
+    assert "voxtral-mini-latest" in model_ids
+    assert "voxtral-small-latest" in model_ids
+
+
+def test_mistral_provider_name():
+    model = MistralSpeechToTextModel(api_key="test-key")
+    assert model.provider == "mistral"
+
+
+def test_mistral_missing_api_key():
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ValueError, match="Mistral API key not found"):
+            MistralSpeechToTextModel(api_key=None)


### PR DESCRIPTION
## Summary

Adds `MistralSpeechToTextModel`, completing Esperanto's Mistral audio coverage. Together with the TTS provider in #140, Esperanto now supports Mistral for LLM, embedding, TTS, and STT — full provider parity for audio I/O.

### Verified API facts (looked up from Mistral docs before implementing)

- Base URL: `https://api.mistral.ai/v1`
- Endpoint: `POST /v1/audio/transcriptions` (multipart/form-data, matching OpenAI STT convention)
- Default model: `voxtral-mini-latest` (also exposes `voxtral-small-latest` via `_get_models()`)
- Auth: `Authorization: Bearer <MISTRAL_API_KEY>` (reuses existing env var)
- Request: multipart with `file` (binary) + `model`, optional `language`, optional `prompt`
- Response: `{ "text", "model", "language", "segments", "usage" }` — Mistral auto-detects language and returns it (unlike OpenAI which often doesn't), so `TranscriptionResponse.language` is populated automatically

### Notable

- Uses the `-latest` model alias (e.g. `voxtral-mini-latest`) rather than dated versions like `voxtral-mini-2507`. Mistral pins `-latest` to the current model so we don't have to chase rename releases.
- This PR is the first STT provider to actually exercise the `TranscriptionResponse.provider` field that was added in #126 (it was being silently dropped by Pydantic on the OpenAI/Azure/ElevenLabs providers; this provider sets it explicitly).

### Conformance

- Inherits directly from `SpeechToTextModel` (Mistral is a first-class provider per `ARCHITECTURE.md` — its tool format and message conventions differ from OpenAI's).
- Uses the `__post_init__` pattern documented in `CLAUDE.md` (super-call first, `_create_http_clients()` last).
- Uses httpx `files=` + `data=` for multipart (correct usage — distinct from the `data=json.dumps()` anti-pattern fixed in #132).
- Optional import in `esperanto/__init__.py` with `try/except ImportError` setting `MistralSpeechToTextModel = None` (matches every other provider).

### Files

- `src/esperanto/providers/stt/mistral.py` (new, 144 lines)
- `tests/providers/stt/test_mistral.py` (new, 200 lines, 10 mocked unit tests)
- `docs/providers/mistral_stt.md` (new, usage guide)
- `src/esperanto/factory.py` (+1 line: register `mistral` under `speech_to_text`)
- `src/esperanto/__init__.py` (+7 lines: optional import + provider class registration)
- `CHANGELOG.md` (+1 line: Unreleased / Added)

Closes #142.

## Test plan

- [x] 10 new mocked unit tests in `tests/providers/stt/test_mistral.py` — all pass (sync, async, options, file-object, error-handling, factory creation, default model, models list, provider name, missing API key)
- [x] `uv run pytest tests/providers tests/unit tests/common_types tests/test_deprecation_warnings.py -q --no-cov` — 929 passed (7 pre-existing local-env failures, identical on `main`)
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src/esperanto` — clean (now 71 source files including this provider; 72 once #140 also lands)
- [x] `AIFactory.create_speech_to_text("mistral", "voxtral-mini-latest", api_key="test")` instantiates correctly
- [x] `from esperanto import MistralSpeechToTextModel` works
- [ ] Optional smoke-test against a real `MISTRAL_API_KEY` once merged

## Follow-ups (not in this PR)

- Hardcoded `audio/mpeg` multipart content-type in both sync and async paths. Mistral almost certainly inspects content rather than trusting the hint, but `mimetypes.guess_type(filename)` would be more honest. Same behavior as the existing OpenAI STT provider in this repo, so consistent.
- Mistral returns `segments` and `usage` in the response which `TranscriptionResponse` doesn't carry. Could be exposed in a future enhancement to the common type.