### PR TITLE
docs: capture design principles from issues #100, #101, #104, #107

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,6 +23,51 @@ This means:
 
 3. **Graceful degradation when needed.** Some providers genuinely can't support certain features. In those rare cases, raise a clear error — never silently ignore or return unexpected results. The user should always know what to expect.
 
+## Parameter Handling
+
+### Model Quirks vs Unsupported Features
+
+Distinguish **unsupported features** from **model-specific quirks**:
+
+- When a provider can't support a feature at all (e.g. no streaming), raise a clear error.
+- When a model has a request-shape quirk that breaks an otherwise-supported parameter (e.g. Claude 4.x rejecting `temperature` + `top_p` together), the provider's request-builder sanitizes the request silently with a debug log. Users should not need to know per-model quirks.
+
+**Why:** Raising forces users to know which model has which quirk, which defeats the parity promise. But silently dropping a *feature* the provider doesn't support would mislead users into thinking it ran. The split keeps both honest.
+
+**Scope:** Provider request-builders (LLM, embedding, etc.). Refines the "graceful degradation" principle above.
+
+**Origin:** Issue #100, 2026-05-01.
+
+### Hot-Swap-First Defaults
+
+Esperanto's defaults must make provider hot-swap "just work." Where the underlying provider's native default would break the parity promise (e.g. Ollama's 2048 `num_ctx` failing typical chat that worked on cloud providers), Esperanto picks a workable default — even if that overrides the provider's default. Users can always override via config or per-call.
+
+**Why:** Provider-agnostic interface is the core promise. If switching from OpenAI to Ollama breaks user code with the same messages, we've failed the promise.
+
+**Scope:** All provider runtime defaults. When in doubt, prefer a default that makes typical workloads succeed over mirroring the upstream provider's native default.
+
+**Origin:** Issues #107 + #101, 2026-05-01.
+
+### Demand-Driven Abstraction Extension
+
+Extend abstractions (profile systems, base classes, parameter surfaces) only when there's concrete demand — typically two or more provider requests for the same shape. Don't pre-emptively generalize.
+
+**Why:** YAGNI. Abstractions built without demand often miss the actual shape of the demand when it arrives. Building on demand grounds the abstraction in real cases.
+
+**Scope:** Adding new tiers, profile systems for new model types (embedding/TTS/STT profiles), parameter surfaces beyond the universal set.
+
+**Origin:** Group A.1 design session, 2026-05-01.
+
+### Prefer OpenAI-Compatible
+
+When a provider offers both OpenAI-compatible and a native (non-OpenAI) endpoint, integrate via the OpenAI-compatible path. Native-format integrations (Anthropic message format, Cohere native, etc.) are reserved for providers that genuinely lack an OpenAI-compatible endpoint. If a future need for native-only features emerges, a dedicated subclass can be added per-provider.
+
+**Why:** OpenAI-compatible is the de-facto standard. Going native when a compatible endpoint exists creates duplicate code paths and maintenance burden without parity benefit.
+
+**Scope:** Adding new providers. Belongs in the "When to Add a New Provider" checklist.
+
+**Origin:** Issue #104, 2026-05-01.
+
 ## Provider Tiers
 
 Not all providers require the same level of implementation effort. We classify them into tiers:


### PR DESCRIPTION
## Summary

Captures four design principles in \`ARCHITECTURE.md\` that emerged from earlier design sessions but were never committed:

- **Model Quirks vs Unsupported Features** (origin: issue #100) — request-builders silently sanitize per-model quirks; unsupported features still raise.
- **Hot-Swap-First Defaults** (origin: issues #107 + #101) — Esperanto picks workable defaults to preserve provider-swap parity, even when overriding the upstream default.
- **Demand-Driven Abstraction Extension** (origin: Group A.1 design session) — extend abstractions only when concrete demand exists (typically 2+ requests for the same shape).
- **Prefer OpenAI-Compatible** (origin: issue #104) — when both OpenAI-compatible and native endpoints exist, integrate via OpenAI-compatible.

These principles were already informing review decisions and were referenced in CLAUDE.md and the triage/design skills — this commit just makes them canonical in the principle store.

## Why now

A working-tree audit during a follow-up session found these as uncommitted local changes. They were sitting in limbo even though the codebase already reflects them.

## Test plan

- [x] Pure docs change — no code touched
- [x] No CHANGELOG entry needed (principle docs don't affect releases)