### PR TITLE
refactor: extract embedding null-guard into shared helper (closes #145)

### DIFF
--- a/src/esperanto/providers/embedding/azure.py
+++ b/src/esperanto/providers/embedding/azure.py
@@ -6,6 +6,7 @@ from typing import Dict, List
 import httpx
 
 from esperanto.providers.embedding.base import EmbeddingModel, Model
+from esperanto.utils import validate_and_decode_embedding
 
 
 class AzureEmbeddingModel(EmbeddingModel):
@@ -132,13 +133,7 @@ class AzureEmbeddingModel(EmbeddingModel):
         results = []
         for idx, data in enumerate(response_data["data"]):
             raw = data.get("embedding")
-            if raw is None or len(raw) == 0 or any(v is None for v in raw):
-                raise RuntimeError(
-                    f"Embedding at index {idx} is null, empty, or contains null values. "
-                    "This typically happens when the input is too short or contains only special tokens. "
-                    "Consider filtering very short inputs before embedding."
-                )
-            results.append([float(v) for v in raw])
+            results.append(validate_and_decode_embedding(idx, raw))
         return results
 
     async def aembed(self, texts: List[str], **kwargs) -> List[List[float]]:
@@ -179,13 +174,7 @@ class AzureEmbeddingModel(EmbeddingModel):
         results = []
         for idx, data in enumerate(response_data["data"]):
             raw = data.get("embedding")
-            if raw is None or len(raw) == 0 or any(v is None for v in raw):
-                raise RuntimeError(
-                    f"Embedding at index {idx} is null, empty, or contains null values. "
-                    "This typically happens when the input is too short or contains only special tokens. "
-                    "Consider filtering very short inputs before embedding."
-                )
-            results.append([float(v) for v in raw])
+            results.append(validate_and_decode_embedding(idx, raw))
         return results
 
     def _get_default_model(self) -> str:

--- a/src/esperanto/providers/embedding/jina.py
+++ b/src/esperanto/providers/embedding/jina.py
@@ -7,6 +7,7 @@ import httpx
 
 from esperanto.common_types import Model
 from esperanto.common_types.task_type import EmbeddingTaskType
+from esperanto.utils import validate_and_decode_embedding
 
 from .base import EmbeddingModel
 
@@ -165,13 +166,7 @@ class JinaEmbeddingModel(EmbeddingModel):
             embeddings = []
             for idx, item in enumerate(response_data.get("data", [])):
                 embedding = item.get("embedding")
-                if embedding is None or len(embedding) == 0 or any(v is None for v in embedding):
-                    raise RuntimeError(
-                        f"Embedding at index {idx} is null, empty, or contains null values. "
-                        "This typically happens when the input is too short or contains only special tokens. "
-                        "Consider filtering very short inputs before embedding."
-                    )
-                embeddings.append([float(value) for value in embedding])
+                embeddings.append(validate_and_decode_embedding(idx, embedding))
 
             return embeddings
 
@@ -213,13 +208,7 @@ class JinaEmbeddingModel(EmbeddingModel):
             embeddings = []
             for idx, item in enumerate(response_data.get("data", [])):
                 embedding = item.get("embedding")
-                if embedding is None or len(embedding) == 0 or any(v is None for v in embedding):
-                    raise RuntimeError(
-                        f"Embedding at index {idx} is null, empty, or contains null values. "
-                        "This typically happens when the input is too short or contains only special tokens. "
-                        "Consider filtering very short inputs before embedding."
-                    )
-                embeddings.append([float(value) for value in embedding])
+                embeddings.append(validate_and_decode_embedding(idx, embedding))
 
             return embeddings
 

--- a/src/esperanto/providers/embedding/mistral.py
+++ b/src/esperanto/providers/embedding/mistral.py
@@ -5,6 +5,7 @@ from typing import Dict, List
 import httpx
 
 from esperanto.providers.embedding.base import EmbeddingModel, Model
+from esperanto.utils import validate_and_decode_embedding
 
 
 class MistralEmbeddingModel(EmbeddingModel):
@@ -69,13 +70,7 @@ class MistralEmbeddingModel(EmbeddingModel):
         results = []
         for idx, data in enumerate(response_data["data"]):
             raw = data.get("embedding")
-            if raw is None or len(raw) == 0 or any(v is None for v in raw):
-                raise RuntimeError(
-                    f"Embedding at index {idx} is null, empty, or contains null values. "
-                    "This typically happens when the input is too short or contains only special tokens. "
-                    "Consider filtering very short inputs before embedding."
-                )
-            results.append([float(v) for v in raw])
+            results.append(validate_and_decode_embedding(idx, raw))
         return results
 
     async def aembed(self, texts: List[str], **kwargs) -> List[List[float]]:
@@ -103,13 +98,7 @@ class MistralEmbeddingModel(EmbeddingModel):
         results = []
         for idx, data in enumerate(response_data["data"]):
             raw = data.get("embedding")
-            if raw is None or len(raw) == 0 or any(v is None for v in raw):
-                raise RuntimeError(
-                    f"Embedding at index {idx} is null, empty, or contains null values. "
-                    "This typically happens when the input is too short or contains only special tokens. "
-                    "Consider filtering very short inputs before embedding."
-                )
-            results.append([float(v) for v in raw])
+            results.append(validate_and_decode_embedding(idx, raw))
         return results
 
     def _get_default_model(self) -> str:

--- a/src/esperanto/providers/embedding/ollama.py
+++ b/src/esperanto/providers/embedding/ollama.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List
 import httpx
 
 from esperanto.providers.embedding.base import EmbeddingModel, Model
+from esperanto.utils import validate_and_decode_embedding
 
 
 class OllamaEmbeddingModel(EmbeddingModel):
@@ -92,13 +93,7 @@ class OllamaEmbeddingModel(EmbeddingModel):
             response_data = response.json()
             results = []
             for idx, embedding in enumerate(response_data["embeddings"]):
-                if embedding is None or len(embedding) == 0 or any(v is None for v in embedding):
-                    raise RuntimeError(
-                        f"Embedding at index {idx} is null, empty, or contains null values. "
-                        "This typically happens when the input is too short or contains only special tokens. "
-                        "Consider filtering very short inputs before embedding."
-                    )
-                results.append([float(v) for v in embedding])
+                results.append(validate_and_decode_embedding(idx, embedding))
             return results
         except Exception as e:
             raise RuntimeError(f"Failed to get embeddings: {str(e)}") from e
@@ -150,13 +145,7 @@ class OllamaEmbeddingModel(EmbeddingModel):
             response_data = response.json()
             results = []
             for idx, embedding in enumerate(response_data["embeddings"]):
-                if embedding is None or len(embedding) == 0 or any(v is None for v in embedding):
-                    raise RuntimeError(
-                        f"Embedding at index {idx} is null, empty, or contains null values. "
-                        "This typically happens when the input is too short or contains only special tokens. "
-                        "Consider filtering very short inputs before embedding."
-                    )
-                results.append([float(v) for v in embedding])
+                results.append(validate_and_decode_embedding(idx, embedding))
             return results
         except Exception as e:
             raise RuntimeError(f"Failed to get embeddings: {str(e)}") from e

--- a/src/esperanto/providers/embedding/openai.py
+++ b/src/esperanto/providers/embedding/openai.py
@@ -5,6 +5,7 @@ from typing import Dict, List
 import httpx
 
 from esperanto.providers.embedding.base import EmbeddingModel, Model
+from esperanto.utils import validate_and_decode_embedding
 
 
 class OpenAIEmbeddingModel(EmbeddingModel):
@@ -87,13 +88,7 @@ class OpenAIEmbeddingModel(EmbeddingModel):
         results = []
         for idx, data in enumerate(response_data["data"]):
             raw = data.get("embedding")
-            if raw is None or len(raw) == 0 or any(v is None for v in raw):
-                raise RuntimeError(
-                    f"Embedding at index {idx} is null, empty, or contains null values. "
-                    "This typically happens when the input is too short or contains only special tokens. "
-                    "Consider filtering very short inputs before embedding."
-                )
-            results.append([float(v) for v in raw])
+            results.append(validate_and_decode_embedding(idx, raw))
         return results
 
     async def aembed(self, texts: List[str], **kwargs) -> List[List[float]]:
@@ -129,13 +124,7 @@ class OpenAIEmbeddingModel(EmbeddingModel):
         results = []
         for idx, data in enumerate(response_data["data"]):
             raw = data.get("embedding")
-            if raw is None or len(raw) == 0 or any(v is None for v in raw):
-                raise RuntimeError(
-                    f"Embedding at index {idx} is null, empty, or contains null values. "
-                    "This typically happens when the input is too short or contains only special tokens. "
-                    "Consider filtering very short inputs before embedding."
-                )
-            results.append([float(v) for v in raw])
+            results.append(validate_and_decode_embedding(idx, raw))
         return results
 
     def _get_default_model(self) -> str:

--- a/src/esperanto/providers/embedding/openai_compatible.py
+++ b/src/esperanto/providers/embedding/openai_compatible.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from esperanto.common_types import Model
+from esperanto.utils import validate_and_decode_embedding
 from esperanto.utils.logging import logger
 
 from .base import EmbeddingModel
@@ -217,13 +218,7 @@ class OpenAICompatibleEmbeddingModel(EmbeddingModel):
             results = []
             for idx, data in enumerate(response_data["data"]):
                 raw = data.get("embedding")
-                if raw is None or len(raw) == 0 or any(v is None for v in raw):
-                    raise RuntimeError(
-                        f"Embedding at index {idx} is null, empty, or contains null values. "
-                        "This typically happens when the input is too short or contains only special tokens. "
-                        "Consider filtering very short inputs before embedding."
-                    )
-                results.append([float(v) for v in raw])
+                results.append(validate_and_decode_embedding(idx, raw))
             return results
 
         except Exception as e:
@@ -265,13 +260,7 @@ class OpenAICompatibleEmbeddingModel(EmbeddingModel):
             results = []
             for idx, data in enumerate(response_data["data"]):
                 raw = data.get("embedding")
-                if raw is None or len(raw) == 0 or any(v is None for v in raw):
-                    raise RuntimeError(
-                        f"Embedding at index {idx} is null, empty, or contains null values. "
-                        "This typically happens when the input is too short or contains only special tokens. "
-                        "Consider filtering very short inputs before embedding."
-                    )
-                results.append([float(v) for v in raw])
+                results.append(validate_and_decode_embedding(idx, raw))
             return results
 
         except Exception as e:

--- a/src/esperanto/providers/embedding/voyage.py
+++ b/src/esperanto/providers/embedding/voyage.py
@@ -6,6 +6,7 @@ from typing import Dict, List
 import httpx
 
 from esperanto.providers.embedding.base import EmbeddingModel, Model
+from esperanto.utils import validate_and_decode_embedding
 
 
 class VoyageEmbeddingModel(EmbeddingModel):
@@ -86,13 +87,7 @@ class VoyageEmbeddingModel(EmbeddingModel):
         results = []
         for idx, data in enumerate(response_data["data"]):
             raw = data.get("embedding")
-            if raw is None or len(raw) == 0 or any(v is None for v in raw):
-                raise RuntimeError(
-                    f"Embedding at index {idx} is null, empty, or contains null values. "
-                    "This typically happens when the input is too short or contains only special tokens. "
-                    "Consider filtering very short inputs before embedding."
-                )
-            results.append([float(v) for v in raw])
+            results.append(validate_and_decode_embedding(idx, raw))
         return results
 
     async def aembed(self, texts: List[str], **kwargs) -> List[List[float]]:
@@ -128,13 +123,7 @@ class VoyageEmbeddingModel(EmbeddingModel):
         results = []
         for idx, data in enumerate(response_data["data"]):
             raw = data.get("embedding")
-            if raw is None or len(raw) == 0 or any(v is None for v in raw):
-                raise RuntimeError(
-                    f"Embedding at index {idx} is null, empty, or contains null values. "
-                    "This typically happens when the input is too short or contains only special tokens. "
-                    "Consider filtering very short inputs before embedding."
-                )
-            results.append([float(v) for v in raw])
+            results.append(validate_and_decode_embedding(idx, raw))
         return results
 
     def _get_default_model(self) -> str:

--- a/src/esperanto/utils/__init__.py
+++ b/src/esperanto/utils/__init__.py
@@ -1,5 +1,6 @@
 """Utility modules for Esperanto."""
 
+from esperanto.utils.embedding import validate_and_decode_embedding
 from esperanto.utils.model_cache import ModelCache
 
-__all__ = ["ModelCache"]
+__all__ = ["ModelCache", "validate_and_decode_embedding"]

--- a/src/esperanto/utils/embedding.py
+++ b/src/esperanto/utils/embedding.py
@@ -1,0 +1,17 @@
+"""Embedding validation utilities."""
+
+from typing import Any, List
+
+
+def validate_and_decode_embedding(idx: int, raw: Any) -> List[float]:
+    """Validate and decode a raw embedding value from a provider response.
+
+    Raises RuntimeError if the embedding is null, empty, or contains null values.
+    """
+    if raw is None or len(raw) == 0 or any(v is None for v in raw):
+        raise RuntimeError(
+            f"Embedding at index {idx} is null, empty, or contains null values. "
+            "This typically happens when the input is too short or contains only special tokens. "
+            "Consider filtering very short inputs before embedding."
+        )
+    return [float(v) for v in raw]


### PR DESCRIPTION
## Summary

Hoists the embedding null/empty/element-null validation+conversion block out of 14 inline call sites across 7 standalone embedding providers into a single shared helper at \`src/esperanto/utils/embedding.py\`:

\`\`\`python
def validate_and_decode_embedding(idx: int, raw: Any) -> List[float]:
    if raw is None or len(raw) == 0 or any(v is None for v in raw):
        raise RuntimeError(
            f\"Embedding at index {idx} is null, empty, or contains null values. \"
            \"This typically happens when the input is too short or contains only special tokens. \"
            \"Consider filtering very short inputs before embedding.\"
        )
    return [float(v) for v in raw]
\`\`\`

Replaces 14 call sites (sync + async paths in each of openai, openai_compatible, azure, ollama, mistral, voyage, jina). Behavior is byte-identical: same error message, same trigger conditions, same return shape.

## Why

After #136 (PR for #119), the same ~10-line guard ended up duplicated across 14 sites. The empty-vector gap that cubic caught on jina was the same bug in all 7 providers — we shipped 7 instances of one fix instead of one. This refactor enforces provider parity at the helper level.

## Diff shape

\`\`\`
src/esperanto/providers/embedding/azure.py             | 17 +++--------------
src/esperanto/providers/embedding/jina.py              | 17 +++--------------
src/esperanto/providers/embedding/mistral.py           | 17 +++--------------
src/esperanto/providers/embedding/ollama.py            | 17 +++--------------
src/esperanto/providers/embedding/openai.py            | 17 +++--------------
src/esperanto/providers/embedding/openai_compatible.py | 17 +++--------------
src/esperanto/providers/embedding/voyage.py            | 17 +++--------------
src/esperanto/utils/__init__.py                        |  3 ++-
src/esperanto/utils/embedding.py                       | 17 +++++++++++++++++
9 files changed, 40 insertions(+), 99 deletions(-)
\`\`\`

Net: −59 lines.

## Test plan

- [x] All existing null/empty/null-element tests across the 7 providers pass without modification
- [x] \`uv run pytest tests/providers tests/unit tests/common_types tests/test_deprecation_warnings.py -q --no-cov\` exits 0 (937 passed; 7 pre-existing env-pollution failures will be fixed by #144)
- [x] Probe script confirmed byte-identical behavior: None/empty/list-with-None each raise RuntimeError with identical message
- [x] \`uv run ruff check .\` clean
- [x] \`uv run mypy src/esperanto\` clean

Closes #145.