### PR TITLE
fix(tts/mistral): paginate available_voices across all voice pages (closes #148)

### DIFF
--- a/src/esperanto/providers/tts/mistral.py
+++ b/src/esperanto/providers/tts/mistral.py
@@ -66,12 +66,20 @@ class MistralTextToSpeechModel(TextToSpeechModel):
     def available_voices(self) -> Dict[str, Voice]:
         if self._voices_cache is not None:
             return self._voices_cache
-        response = self.client.get(
-            f"{self.base_url}/audio/voices",
-            headers=self._get_headers(),
-        )
-        self._handle_error(response)
-        items = response.json().get("items", [])
+        items = []
+        page = 1
+        while True:
+            response = self.client.get(
+                f"{self.base_url}/audio/voices",
+                headers=self._get_headers(),
+                params={"page": page},
+            )
+            self._handle_error(response)
+            body = response.json()
+            items.extend(body.get("items", []))
+            if page >= body.get("total_pages", 1):
+                break
+            page += 1
         self._voices_cache = {
             item["id"]: Voice(
                 id=item["id"],

--- a/tests/providers/tts/test_mistral.py
+++ b/tests/providers/tts/test_mistral.py
@@ -17,7 +17,11 @@ VOICES_RESPONSE = {
             "gender": "NEUTRAL",
             "languages": ["en"],
         }
-    ]
+    ],
+    "page": 1,
+    "page_size": 1,
+    "total": 1,
+    "total_pages": 1,
 }
 
 
@@ -159,6 +163,7 @@ def test_available_voices(tts_model):
     tts_model.client.get.assert_called_once_with(
         "https://api.mistral.ai/v1/audio/voices",
         headers=tts_model._get_headers(),
+        params={"page": 1},
     )
 
     assert "gb_jane_neutral" in voices
@@ -197,3 +202,38 @@ def test_error_handling_5xx(tts_model):
 
     with pytest.raises(RuntimeError, match="Mistral API error"):
         tts_model.generate_speech(text="Hello", voice="gb_jane_neutral")
+
+
+def test_available_voices_paginated():
+    voice_a = {"id": "voice_a", "name": "Voice A", "gender": "FEMALE", "languages": ["en"]}
+    voice_b = {"id": "voice_b", "name": "Voice B", "gender": "MALE", "languages": ["fr"]}
+
+    page1_response = Mock()
+    page1_response.status_code = 200
+    page1_response.json.return_value = {
+        "items": [voice_a],
+        "page": 1,
+        "page_size": 1,
+        "total": 2,
+        "total_pages": 2,
+    }
+
+    page2_response = Mock()
+    page2_response.status_code = 200
+    page2_response.json.return_value = {
+        "items": [voice_b],
+        "page": 2,
+        "page_size": 1,
+        "total": 2,
+        "total_pages": 2,
+    }
+
+    model = MistralTextToSpeechModel(api_key="test-key")
+    model.client = Mock()
+    model.client.get.side_effect = [page1_response, page2_response]
+
+    voices = model.available_voices
+
+    assert "voice_a" in voices
+    assert "voice_b" in voices
+    assert model.client.get.call_count == 2


### PR DESCRIPTION
## Summary

\`MistralTextToSpeechModel.available_voices\` was reading only the first page of \`GET /v1/audio/voices\` (today's preset list of ~20 voices). If Mistral grows the list past one page, additional voices were silently truncated.

This PR loops until pagination is exhausted, accumulating items across all pages. Pagination uses Mistral's \`total_pages\` + \`page\` convention (verified against the actual response shape).

## Implementation

\`\`\`python
items = []
page = 1
while True:
    response = self.client.get(
        f\"{self.base_url}/audio/voices\",
        headers=self._get_headers(),
        params={\"page\": page},
    )
    self._handle_error(response)
    body = response.json()
    items.extend(body.get(\"items\", []))
    if page >= body.get(\"total_pages\", 1):
        break
    page += 1
\`\`\`

Cache semantics preserved: \`self._voices_cache\` populated once with the full set, reused on subsequent calls.

## Test plan

- [x] New \`test_available_voices_paginated\` mocks a 2-page response, asserts all voices from both pages appear, asserts \`client.get.call_count == 2\`
- [x] Existing \`test_available_voices_cached\` confirms second call hits cache (\`call_count == 1\` after two \`available_voices\` invocations)
- [x] All 9 Mistral TTS tests pass
- [x] Validator (\`uv sync --all-extras && uv run pytest tests/providers tests/unit tests/common_types tests/test_deprecation_warnings.py -q --no-cov\`): 938 passed (7 pre-existing env-pollution failures unrelated; #144 fixes those)
- [x] \`uv run ruff check .\` clean
- [x] \`uv run mypy src/esperanto\` clean

Closes #148.