### PR TITLE
fix: lower Ollama default context window

### DIFF
--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -119,12 +119,12 @@ model = AIFactory.create_language(
 
 **Context Window (`num_ctx`):**
 
-Esperanto uses a default context window of **128,000 tokens** for Ollama models, which is much larger than Ollama's built-in default of 2,048 tokens. This ensures that large documents and long conversations work out of the box.
+Esperanto uses a default context window of **8,192 tokens** for Ollama models. This keeps local models usable on modest VRAM machines by default while still leaving enough room for typical chat workloads.
 
 You can customize this value if needed:
 
 ```python
-# Use a smaller context window for memory efficiency
+# Use the default context window
 model = AIFactory.create_language(
     "ollama",
     "llama3.1",
@@ -489,7 +489,7 @@ Error: Out of memory
 Issue: Model gives generic answers ignoring provided context
 ```
 **Solution:**
-This usually means the context window is too small and your input is being truncated. Esperanto defaults to 128K tokens, but if you're overriding `num_ctx` with a smaller value, increase it:
+This usually means the context window is too small and your input is being truncated. Esperanto defaults to 8,192 tokens; if your workload needs more room, increase `num_ctx` explicitly:
 ```python
 model = AIFactory.create_language(
     "ollama",

--- a/src/esperanto/providers/llm/ollama.py
+++ b/src/esperanto/providers/llm/ollama.py
@@ -39,6 +39,9 @@ if TYPE_CHECKING:
     from langchain_ollama import ChatOllama
 
 
+DEFAULT_NUM_CTX = 8192
+
+
 class OllamaLanguageModel(LanguageModel):
     """Ollama language model implementation."""
 
@@ -96,9 +99,8 @@ class OllamaLanguageModel(LanguageModel):
                 else:
                     kwargs[key] = value
 
-        # Handle Ollama-specific options from _config (num_ctx for context window)
-        # Default to 128000 tokens if not specified (Ollama's default of 2048 is too small)
-        options["num_ctx"] = self._config.get("num_ctx", 128000)
+        # Use a modest default so local Ollama models work on typical 8GB VRAM machines.
+        options["num_ctx"] = self._config.get("num_ctx", DEFAULT_NUM_CTX)
 
         # Handle keep_alive (top-level parameter, not in options)
         # Only set if explicitly provided - don't force memory usage on users
@@ -578,7 +580,7 @@ class OllamaLanguageModel(LanguageModel):
             "temperature": self.temperature,
             "top_p": self.top_p,
             "num_predict": self.max_tokens,
-            "num_ctx": self._config.get("num_ctx", 128000),
+            "num_ctx": self._config.get("num_ctx", DEFAULT_NUM_CTX),
             "base_url": self.base_url,
         }
 

--- a/tests/providers/llm/test_ollama_provider.py
+++ b/tests/providers/llm/test_ollama_provider.py
@@ -805,12 +805,12 @@ def test_ollama_base_url_env_var_trailing_slash_stripped():
 
 
 def test_ollama_default_num_ctx():
-    """Test that default num_ctx (128000) is applied when not specified."""
+    """Test that default num_ctx is applied when not specified."""
     model = OllamaLanguageModel(model_name="gemma2")
     api_kwargs = model._get_api_kwargs()
 
     assert "options" in api_kwargs
-    assert api_kwargs["options"]["num_ctx"] == 128000
+    assert api_kwargs["options"]["num_ctx"] == 8192
 
 
 def test_ollama_custom_num_ctx():
@@ -823,11 +823,11 @@ def test_ollama_custom_num_ctx():
 
 
 def test_ollama_to_langchain_default_num_ctx():
-    """Test that to_langchain uses default num_ctx (128000) when not specified."""
+    """Test that to_langchain uses default num_ctx when not specified."""
     model = OllamaLanguageModel(model_name="gemma2")
     langchain_model = model.to_langchain()
 
-    assert langchain_model.num_ctx == 128000
+    assert langchain_model.num_ctx == 8192
 
 
 def test_ollama_to_langchain_custom_num_ctx():


### PR DESCRIPTION
Fixes #107.

## Summary
- lower the default Ollama `num_ctx` from 128000 to 8192 for direct API calls
- apply the same default to the LangChain `ChatOllama` conversion path
- update existing tests and provider docs while preserving explicit `config={"num_ctx": ...}` overrides

## Validation
- `uv run pytest tests/providers/llm/test_ollama_provider.py -q`
- `uv run ruff check src/esperanto/providers/llm/ollama.py tests/providers/llm/test_ollama_provider.py`
- `uv run python -m py_compile src/esperanto/providers/llm/ollama.py tests/providers/llm/test_ollama_provider.py`
- `git diff --check`