### PR TITLE
fix(stt): use mimetypes-guessed Content-Type instead of hardcoding audio/mpeg (closes #147)

### DIFF
--- a/src/esperanto/providers/stt/azure.py
+++ b/src/esperanto/providers/stt/azure.py
@@ -7,7 +7,7 @@ from typing import Any, BinaryIO, Dict, List, Optional, Union
 import httpx
 
 from esperanto.common_types import Model, TranscriptionResponse
-from esperanto.providers.stt.base import SpeechToTextModel
+from esperanto.providers.stt.base import SpeechToTextModel, _guess_audio_content_type
 
 
 @dataclass
@@ -125,7 +125,7 @@ class AzureSpeechToTextModel(SpeechToTextModel):
         if isinstance(audio_file, str):
             # For file path, open and send as multipart form data
             with open(audio_file, "rb") as f:
-                files: Dict[str, Any] = {"file": (audio_file, f, "audio/mpeg")}
+                files: Dict[str, Any] = {"file": (audio_file, f, _guess_audio_content_type(audio_file))}
                 response = self.client.post(
                     url,
                     headers=self._get_headers(),
@@ -135,7 +135,7 @@ class AzureSpeechToTextModel(SpeechToTextModel):
         else:
             # For BinaryIO, send the file object directly
             filename = getattr(audio_file, 'name', 'audio.mp3')
-            files = {"file": (filename, audio_file, "audio/mpeg")}
+            files = {"file": (filename, audio_file, _guess_audio_content_type(filename))}
             response = self.client.post(
                 url,
                 headers=self._get_headers(),
@@ -173,7 +173,7 @@ class AzureSpeechToTextModel(SpeechToTextModel):
         if isinstance(audio_file, str):
             # For file path, open and send as multipart form data
             with open(audio_file, "rb") as f:
-                files: Dict[str, Any] = {"file": (audio_file, f, "audio/mpeg")}
+                files: Dict[str, Any] = {"file": (audio_file, f, _guess_audio_content_type(audio_file))}
                 response = await self.async_client.post(
                     url,
                     headers=self._get_headers(),
@@ -183,7 +183,7 @@ class AzureSpeechToTextModel(SpeechToTextModel):
         else:
             # For BinaryIO, send the file object directly
             filename = getattr(audio_file, 'name', 'audio.mp3')
-            files = {"file": (filename, audio_file, "audio/mpeg")}
+            files = {"file": (filename, audio_file, _guess_audio_content_type(filename))}
             response = await self.async_client.post(
                 url,
                 headers=self._get_headers(),

--- a/src/esperanto/providers/stt/base.py
+++ b/src/esperanto/providers/stt/base.py
@@ -1,5 +1,6 @@
 """Base speech-to-text model interface."""
 
+import mimetypes
 import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -7,6 +8,14 @@ from typing import Any, BinaryIO, Dict, List, Optional, Union
 
 from esperanto.common_types import Model, TranscriptionResponse
 from esperanto.utils.connect import HttpConnectionMixin
+
+
+def _guess_audio_content_type(filename: str) -> str:
+    """Guess audio MIME type from filename, falling back to audio/mpeg."""
+    mime_type, _ = mimetypes.guess_type(filename)
+    if mime_type and mime_type.startswith("audio/"):
+        return mime_type
+    return "audio/mpeg"
 
 
 @dataclass

--- a/src/esperanto/providers/stt/base.py
+++ b/src/esperanto/providers/stt/base.py
@@ -10,8 +10,14 @@ from esperanto.common_types import Model, TranscriptionResponse
 from esperanto.utils.connect import HttpConnectionMixin
 
 
-def _guess_audio_content_type(filename: str) -> str:
-    """Guess audio MIME type from filename, falling back to audio/mpeg."""
+def _guess_audio_content_type(filename: Optional[str]) -> str:
+    """Guess audio MIME type from filename, falling back to audio/mpeg.
+
+    Returns audio/mpeg as a safe default when filename is None or empty
+    (e.g., a BinaryIO whose ``.name`` attribute is explicitly None).
+    """
+    if not filename:
+        return "audio/mpeg"
     mime_type, _ = mimetypes.guess_type(filename)
     if mime_type and mime_type.startswith("audio/"):
         return mime_type

--- a/src/esperanto/providers/stt/elevenlabs.py
+++ b/src/esperanto/providers/stt/elevenlabs.py
@@ -7,7 +7,11 @@ from typing import Any, BinaryIO, Dict, List, Optional, Union
 import httpx
 
 from esperanto.common_types import TranscriptionResponse
-from esperanto.providers.stt.base import Model, SpeechToTextModel
+from esperanto.providers.stt.base import (
+    Model,
+    SpeechToTextModel,
+    _guess_audio_content_type,
+)
 
 
 @dataclass
@@ -96,7 +100,7 @@ class ElevenLabsSpeechToTextModel(SpeechToTextModel):
         if isinstance(audio_file, str):
             # For file path, open and send as multipart form data
             with open(audio_file, "rb") as f:
-                files: Dict[str, Any] = {"file": (audio_file, f, "audio/mpeg")}
+                files: Dict[str, Any] = {"file": (audio_file, f, _guess_audio_content_type(audio_file))}
                 response = self.client.post(
                     f"{self.base_url}/speech-to-text",
                     headers=self._get_headers(),
@@ -106,7 +110,7 @@ class ElevenLabsSpeechToTextModel(SpeechToTextModel):
         else:
             # For BinaryIO, send the file object directly
             filename = getattr(audio_file, 'name', 'audio.mp3')
-            files = {"file": (filename, audio_file, "audio/mpeg")}
+            files = {"file": (filename, audio_file, _guess_audio_content_type(filename))}
             response = self.client.post(
                 f"{self.base_url}/speech-to-text",
                 headers=self._get_headers(),
@@ -137,7 +141,7 @@ class ElevenLabsSpeechToTextModel(SpeechToTextModel):
         if isinstance(audio_file, str):
             # For file path, open and send as multipart form data
             with open(audio_file, "rb") as f:
-                files: Dict[str, Any] = {"file": (audio_file, f, "audio/mpeg")}
+                files: Dict[str, Any] = {"file": (audio_file, f, _guess_audio_content_type(audio_file))}
                 response = await self.async_client.post(
                     f"{self.base_url}/speech-to-text",
                     headers=self._get_headers(),
@@ -147,7 +151,7 @@ class ElevenLabsSpeechToTextModel(SpeechToTextModel):
         else:
             # For BinaryIO, send the file object directly
             filename = getattr(audio_file, 'name', 'audio.mp3')
-            files = {"file": (filename, audio_file, "audio/mpeg")}
+            files = {"file": (filename, audio_file, _guess_audio_content_type(filename))}
             response = await self.async_client.post(
                 f"{self.base_url}/speech-to-text",
                 headers=self._get_headers(),

--- a/src/esperanto/providers/stt/mistral.py
+++ b/src/esperanto/providers/stt/mistral.py
@@ -7,7 +7,11 @@ from typing import Any, BinaryIO, Dict, List, Optional, Union
 import httpx
 
 from esperanto.common_types import TranscriptionResponse
-from esperanto.providers.stt.base import Model, SpeechToTextModel
+from esperanto.providers.stt.base import (
+    Model,
+    SpeechToTextModel,
+    _guess_audio_content_type,
+)
 
 
 @dataclass
@@ -78,7 +82,7 @@ class MistralSpeechToTextModel(SpeechToTextModel):
 
         if isinstance(audio_file, str):
             with open(audio_file, "rb") as f:
-                files: Dict[str, Any] = {"file": (audio_file, f, "audio/mpeg")}
+                files: Dict[str, Any] = {"file": (audio_file, f, _guess_audio_content_type(audio_file))}
                 response = self.client.post(
                     f"{self.base_url}/audio/transcriptions",
                     headers=self._get_headers(),
@@ -87,7 +91,7 @@ class MistralSpeechToTextModel(SpeechToTextModel):
                 )
         else:
             filename = getattr(audio_file, "name", "audio.mp3")
-            files = {"file": (filename, audio_file, "audio/mpeg")}
+            files = {"file": (filename, audio_file, _guess_audio_content_type(filename))}
             response = self.client.post(
                 f"{self.base_url}/audio/transcriptions",
                 headers=self._get_headers(),
@@ -116,7 +120,7 @@ class MistralSpeechToTextModel(SpeechToTextModel):
 
         if isinstance(audio_file, str):
             with open(audio_file, "rb") as f:
-                files: Dict[str, Any] = {"file": (audio_file, f, "audio/mpeg")}
+                files: Dict[str, Any] = {"file": (audio_file, f, _guess_audio_content_type(audio_file))}
                 response = await self.async_client.post(
                     f"{self.base_url}/audio/transcriptions",
                     headers=self._get_headers(),
@@ -125,7 +129,7 @@ class MistralSpeechToTextModel(SpeechToTextModel):
                 )
         else:
             filename = getattr(audio_file, "name", "audio.mp3")
-            files = {"file": (filename, audio_file, "audio/mpeg")}
+            files = {"file": (filename, audio_file, _guess_audio_content_type(filename))}
             response = await self.async_client.post(
                 f"{self.base_url}/audio/transcriptions",
                 headers=self._get_headers(),

--- a/src/esperanto/providers/stt/openai.py
+++ b/src/esperanto/providers/stt/openai.py
@@ -7,7 +7,11 @@ from typing import Any, BinaryIO, Dict, List, Optional, Union
 import httpx
 
 from esperanto.common_types import TranscriptionResponse
-from esperanto.providers.stt.base import Model, SpeechToTextModel
+from esperanto.providers.stt.base import (
+    Model,
+    SpeechToTextModel,
+    _guess_audio_content_type,
+)
 
 
 @dataclass
@@ -110,7 +114,7 @@ class OpenAISpeechToTextModel(SpeechToTextModel):
         if isinstance(audio_file, str):
             # For file path, open and send as multipart form data
             with open(audio_file, "rb") as f:
-                files: Dict[str, Any] = {"file": (audio_file, f, "audio/mpeg")}
+                files: Dict[str, Any] = {"file": (audio_file, f, _guess_audio_content_type(audio_file))}
                 response = self.client.post(
                     f"{self.base_url}/audio/transcriptions",
                     headers=self._get_headers(),
@@ -120,7 +124,7 @@ class OpenAISpeechToTextModel(SpeechToTextModel):
         else:
             # For BinaryIO, send the file object directly
             filename = getattr(audio_file, 'name', 'audio.mp3')
-            files = {"file": (filename, audio_file, "audio/mpeg")}
+            files = {"file": (filename, audio_file, _guess_audio_content_type(filename))}
             response = self.client.post(
                 f"{self.base_url}/audio/transcriptions",
                 headers=self._get_headers(),
@@ -151,7 +155,7 @@ class OpenAISpeechToTextModel(SpeechToTextModel):
         if isinstance(audio_file, str):
             # For file path, open and send as multipart form data
             with open(audio_file, "rb") as f:
-                files: Dict[str, Any] = {"file": (audio_file, f, "audio/mpeg")}
+                files: Dict[str, Any] = {"file": (audio_file, f, _guess_audio_content_type(audio_file))}
                 response = await self.async_client.post(
                     f"{self.base_url}/audio/transcriptions",
                     headers=self._get_headers(),
@@ -161,7 +165,7 @@ class OpenAISpeechToTextModel(SpeechToTextModel):
         else:
             # For BinaryIO, send the file object directly
             filename = getattr(audio_file, 'name', 'audio.mp3')
-            files = {"file": (filename, audio_file, "audio/mpeg")}
+            files = {"file": (filename, audio_file, _guess_audio_content_type(filename))}
             response = await self.async_client.post(
                 f"{self.base_url}/audio/transcriptions",
                 headers=self._get_headers(),

--- a/tests/providers/stt/test_azure.py
+++ b/tests/providers/stt/test_azure.py
@@ -1,0 +1,229 @@
+"""Tests for Azure speech-to-text provider."""
+
+import io
+import os
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from esperanto.common_types import TranscriptionResponse
+from esperanto.factory import AIFactory
+from esperanto.providers.stt.azure import AzureSpeechToTextModel
+from esperanto.providers.stt.base import _guess_audio_content_type
+
+
+@pytest.fixture(autouse=True)
+def mock_env():
+    with patch.dict(
+        os.environ,
+        {
+            "AZURE_OPENAI_API_KEY": "test-key",
+            "AZURE_OPENAI_ENDPOINT": "https://test.openai.azure.com",
+            "AZURE_OPENAI_API_VERSION": "2024-02-01",
+        },
+    ):
+        yield
+
+
+@pytest.fixture
+def audio_file(tmp_path):
+    f = tmp_path / "test.mp3"
+    f.write_bytes(b"mock audio content")
+    return str(f)
+
+
+@pytest.fixture
+def wav_file(tmp_path):
+    f = tmp_path / "test.wav"
+    f.write_bytes(b"mock wav content")
+    return str(f)
+
+
+@pytest.fixture
+def flac_file(tmp_path):
+    f = tmp_path / "test.flac"
+    f.write_bytes(b"mock flac content")
+    return str(f)
+
+
+@pytest.fixture
+def ogg_file(tmp_path):
+    f = tmp_path / "test.ogg"
+    f.write_bytes(b"mock ogg content")
+    return str(f)
+
+
+@pytest.fixture
+def unknown_file(tmp_path):
+    f = tmp_path / "test.xyz"
+    f.write_bytes(b"mock unknown content")
+    return str(f)
+
+
+@pytest.fixture
+def mock_transcription_response():
+    return {"text": "This is a test transcription"}
+
+
+@pytest.fixture
+def mock_httpx_clients(mock_transcription_response):
+    client = Mock()
+    async_client = AsyncMock()
+
+    def make_response(status_code, data):
+        r = Mock()
+        r.status_code = status_code
+        r.json.return_value = data
+        return r
+
+    def make_async_response(status_code, data):
+        r = AsyncMock()
+        r.status_code = status_code
+        r.json = Mock(return_value=data)
+        return r
+
+    def post_side_effect(url, **kwargs):
+        if "audio/transcriptions" in url:
+            return make_response(200, mock_transcription_response)
+        return make_response(404, {"error": {"message": "Not found"}})
+
+    async def async_post_side_effect(url, **kwargs):
+        if "audio/transcriptions" in url:
+            return make_async_response(200, mock_transcription_response)
+        return make_async_response(404, {"error": {"message": "Not found"}})
+
+    client.post.side_effect = post_side_effect
+    async_client.post.side_effect = async_post_side_effect
+
+    return client, async_client
+
+
+def test_factory_creates_azure_stt():
+    model = AIFactory.create_stt("azure")
+    assert isinstance(model, AzureSpeechToTextModel)
+
+
+def test_azure_transcribe(audio_file, mock_httpx_clients):
+    model = AzureSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    response = model.transcribe(audio_file)
+
+    model.client.post.assert_called_once()
+    call_args = model.client.post.call_args
+    assert "audio/transcriptions" in call_args[0][0]
+    assert "files" in call_args[1]
+    assert "data" in call_args[1]
+
+    assert isinstance(response, TranscriptionResponse)
+    assert response.text == "This is a test transcription"
+
+
+@pytest.mark.asyncio
+async def test_azure_atranscribe(audio_file, mock_httpx_clients):
+    model = AzureSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    response = await model.atranscribe(audio_file)
+
+    model.async_client.post.assert_called_once()
+    call_args = model.async_client.post.call_args
+    assert "audio/transcriptions" in call_args[0][0]
+    assert "files" in call_args[1]
+
+    assert isinstance(response, TranscriptionResponse)
+    assert response.text == "This is a test transcription"
+
+
+def test_azure_transcribe_wav_content_type(wav_file, mock_httpx_clients):
+    """Test that .wav file uses correct audio MIME type."""
+    model = AzureSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    model.transcribe(wav_file)
+
+    call_args = model.client.post.call_args
+    content_type = call_args[1]["files"]["file"][2]
+    assert content_type == _guess_audio_content_type(wav_file)
+    assert content_type.startswith("audio/")
+
+
+def test_azure_transcribe_flac_content_type(flac_file, mock_httpx_clients):
+    """Test that .flac file uses correct audio MIME type."""
+    model = AzureSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    model.transcribe(flac_file)
+
+    call_args = model.client.post.call_args
+    content_type = call_args[1]["files"]["file"][2]
+    assert content_type == _guess_audio_content_type(flac_file)
+    assert content_type.startswith("audio/")
+
+
+def test_azure_transcribe_ogg_content_type(ogg_file, mock_httpx_clients):
+    """Test that .ogg file uses audio/ogg MIME type."""
+    model = AzureSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    model.transcribe(ogg_file)
+
+    call_args = model.client.post.call_args
+    content_type = call_args[1]["files"]["file"][2]
+    assert content_type == "audio/ogg"
+
+
+def test_azure_transcribe_unknown_extension_falls_back(unknown_file, mock_httpx_clients):
+    """Test that unknown extension falls back to audio/mpeg."""
+    model = AzureSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    model.transcribe(unknown_file)
+
+    call_args = model.client.post.call_args
+    content_type = call_args[1]["files"]["file"][2]
+    assert content_type == "audio/mpeg"
+
+
+def test_azure_transcribe_binaryio_mp3_name_uses_mpeg(mock_httpx_clients):
+    """Test that BinaryIO with .mp3 name uses audio/mpeg."""
+    model = AzureSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    stream = io.BytesIO(b"mock audio")
+    stream.name = "audio.mp3"
+    model.transcribe(stream)
+
+    call_args = model.client.post.call_args
+    content_type = call_args[1]["files"]["file"][2]
+    assert content_type == "audio/mpeg"
+
+
+@pytest.mark.asyncio
+async def test_azure_atranscribe_wav_content_type(wav_file, mock_httpx_clients):
+    """Test that async .wav transcribe uses correct audio MIME type."""
+    model = AzureSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    await model.atranscribe(wav_file)
+
+    call_args = model.async_client.post.call_args
+    content_type = call_args[1]["files"]["file"][2]
+    assert content_type == _guess_audio_content_type(wav_file)
+    assert content_type.startswith("audio/")
+
+
+def test_azure_provider_name():
+    model = AzureSpeechToTextModel(api_key="test-key")
+    assert model.provider == "azure"
+
+
+def test_azure_default_model():
+    model = AzureSpeechToTextModel(api_key="test-key")
+    assert model._get_default_model() == "whisper-1"
+
+
+def test_azure_missing_api_key():
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ValueError, match="Azure OpenAI API key not found"):
+            AzureSpeechToTextModel(api_key=None)

--- a/tests/providers/stt/test_base.py
+++ b/tests/providers/stt/test_base.py
@@ -46,6 +46,14 @@ class TestGuessAudioContentType:
         # .html is text/html — not audio
         assert _guess_audio_content_type("page.html") == "audio/mpeg"
 
+    def test_none_filename_falls_back(self):
+        # BinaryIO with .name explicitly set to None must not crash
+        assert _guess_audio_content_type(None) == "audio/mpeg"
+
+    def test_empty_filename_falls_back(self):
+        # Empty string must not crash mimetypes.guess_type
+        assert _guess_audio_content_type("") == "audio/mpeg"
+
 
 def test_cannot_instantiate_abstract_base():
     """Test that SpeechToTextModel cannot be instantiated directly."""

--- a/tests/providers/stt/test_base.py
+++ b/tests/providers/stt/test_base.py
@@ -1,12 +1,50 @@
 """Tests for base speech-to-text model."""
 
+import mimetypes
 from dataclasses import dataclass
 from typing import BinaryIO, Optional, Union
 
 import pytest
 
 from esperanto.common_types import TranscriptionResponse
-from esperanto.providers.stt.base import SpeechToTextModel
+from esperanto.providers.stt.base import SpeechToTextModel, _guess_audio_content_type
+
+
+class TestGuessAudioContentType:
+    def test_wav_returns_audio_type(self):
+        result = _guess_audio_content_type("audio.wav")
+        assert result.startswith("audio/")
+
+    def test_flac_returns_audio_type(self):
+        result = _guess_audio_content_type("audio.flac")
+        assert result.startswith("audio/")
+
+    def test_m4a_returns_audio_type(self):
+        result = _guess_audio_content_type("audio.m4a")
+        assert result.startswith("audio/")
+
+    def test_ogg_returns_audio_ogg(self):
+        result = _guess_audio_content_type("audio.ogg")
+        assert result == "audio/ogg"
+
+    def test_webm_returns_audio_type_or_fallback(self):
+        result = _guess_audio_content_type("audio.webm")
+        mime, _ = mimetypes.guess_type("audio.webm")
+        if mime and mime.startswith("audio/"):
+            assert result == mime
+        else:
+            assert result == "audio/mpeg"
+
+    def test_unknown_extension_falls_back(self):
+        assert _guess_audio_content_type("audio.xyz") == "audio/mpeg"
+
+    def test_stream_without_name_falls_back(self):
+        # getattr(stream, 'name', 'audio.mp3') gives 'audio.mp3' → audio/mpeg
+        assert _guess_audio_content_type("audio.mp3") == "audio/mpeg"
+
+    def test_non_audio_mime_falls_back(self):
+        # .html is text/html — not audio
+        assert _guess_audio_content_type("page.html") == "audio/mpeg"
 
 
 def test_cannot_instantiate_abstract_base():

--- a/tests/providers/stt/test_elevenlabs.py
+++ b/tests/providers/stt/test_elevenlabs.py
@@ -1,0 +1,223 @@
+"""Tests for ElevenLabs speech-to-text provider."""
+
+import io
+import os
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from esperanto.common_types import TranscriptionResponse
+from esperanto.factory import AIFactory
+from esperanto.providers.stt.base import _guess_audio_content_type
+from esperanto.providers.stt.elevenlabs import ElevenLabsSpeechToTextModel
+
+
+@pytest.fixture(autouse=True)
+def mock_env():
+    with patch.dict(os.environ, {"ELEVENLABS_API_KEY": "test-key"}):
+        yield
+
+
+@pytest.fixture
+def audio_file(tmp_path):
+    f = tmp_path / "test.mp3"
+    f.write_bytes(b"mock audio content")
+    return str(f)
+
+
+@pytest.fixture
+def wav_file(tmp_path):
+    f = tmp_path / "test.wav"
+    f.write_bytes(b"mock wav content")
+    return str(f)
+
+
+@pytest.fixture
+def flac_file(tmp_path):
+    f = tmp_path / "test.flac"
+    f.write_bytes(b"mock flac content")
+    return str(f)
+
+
+@pytest.fixture
+def ogg_file(tmp_path):
+    f = tmp_path / "test.ogg"
+    f.write_bytes(b"mock ogg content")
+    return str(f)
+
+
+@pytest.fixture
+def unknown_file(tmp_path):
+    f = tmp_path / "test.xyz"
+    f.write_bytes(b"mock unknown content")
+    return str(f)
+
+
+@pytest.fixture
+def mock_transcription_response():
+    return {"text": "This is a test transcription"}
+
+
+@pytest.fixture
+def mock_httpx_clients(mock_transcription_response):
+    client = Mock()
+    async_client = AsyncMock()
+
+    def make_response(status_code, data):
+        r = Mock()
+        r.status_code = status_code
+        r.json.return_value = data
+        return r
+
+    def make_async_response(status_code, data):
+        r = AsyncMock()
+        r.status_code = status_code
+        r.json = Mock(return_value=data)
+        return r
+
+    def post_side_effect(url, **kwargs):
+        if url.endswith("/speech-to-text"):
+            return make_response(200, mock_transcription_response)
+        return make_response(404, {"error": {"message": "Not found"}})
+
+    async def async_post_side_effect(url, **kwargs):
+        if url.endswith("/speech-to-text"):
+            return make_async_response(200, mock_transcription_response)
+        return make_async_response(404, {"error": {"message": "Not found"}})
+
+    client.post.side_effect = post_side_effect
+    async_client.post.side_effect = async_post_side_effect
+
+    return client, async_client
+
+
+def test_factory_creates_elevenlabs_stt():
+    model = AIFactory.create_stt("elevenlabs")
+    assert isinstance(model, ElevenLabsSpeechToTextModel)
+
+
+def test_elevenlabs_transcribe(audio_file, mock_httpx_clients):
+    model = ElevenLabsSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    response = model.transcribe(audio_file)
+
+    model.client.post.assert_called_once()
+    call_args = model.client.post.call_args
+    assert call_args[0][0] == "https://api.elevenlabs.io/v1/speech-to-text"
+    assert "files" in call_args[1]
+    assert "data" in call_args[1]
+    assert call_args[1]["data"]["model_id"] == "scribe_v1"
+
+    assert isinstance(response, TranscriptionResponse)
+    assert response.text == "This is a test transcription"
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_atranscribe(audio_file, mock_httpx_clients):
+    model = ElevenLabsSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    response = await model.atranscribe(audio_file)
+
+    model.async_client.post.assert_called_once()
+    call_args = model.async_client.post.call_args
+    assert call_args[0][0] == "https://api.elevenlabs.io/v1/speech-to-text"
+    assert "files" in call_args[1]
+
+    assert isinstance(response, TranscriptionResponse)
+    assert response.text == "This is a test transcription"
+
+
+def test_elevenlabs_transcribe_wav_content_type(wav_file, mock_httpx_clients):
+    """Test that .wav file uses correct audio MIME type."""
+    model = ElevenLabsSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    model.transcribe(wav_file)
+
+    call_args = model.client.post.call_args
+    content_type = call_args[1]["files"]["file"][2]
+    assert content_type == _guess_audio_content_type(wav_file)
+    assert content_type.startswith("audio/")
+
+
+def test_elevenlabs_transcribe_flac_content_type(flac_file, mock_httpx_clients):
+    """Test that .flac file uses correct audio MIME type."""
+    model = ElevenLabsSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    model.transcribe(flac_file)
+
+    call_args = model.client.post.call_args
+    content_type = call_args[1]["files"]["file"][2]
+    assert content_type == _guess_audio_content_type(flac_file)
+    assert content_type.startswith("audio/")
+
+
+def test_elevenlabs_transcribe_ogg_content_type(ogg_file, mock_httpx_clients):
+    """Test that .ogg file uses audio/ogg MIME type."""
+    model = ElevenLabsSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    model.transcribe(ogg_file)
+
+    call_args = model.client.post.call_args
+    content_type = call_args[1]["files"]["file"][2]
+    assert content_type == "audio/ogg"
+
+
+def test_elevenlabs_transcribe_unknown_extension_falls_back(unknown_file, mock_httpx_clients):
+    """Test that unknown extension falls back to audio/mpeg."""
+    model = ElevenLabsSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    model.transcribe(unknown_file)
+
+    call_args = model.client.post.call_args
+    content_type = call_args[1]["files"]["file"][2]
+    assert content_type == "audio/mpeg"
+
+
+def test_elevenlabs_transcribe_binaryio_mp3_name_uses_mpeg(mock_httpx_clients):
+    """Test that BinaryIO with .mp3 name uses audio/mpeg."""
+    model = ElevenLabsSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    stream = io.BytesIO(b"mock audio")
+    stream.name = "audio.mp3"
+    model.transcribe(stream)
+
+    call_args = model.client.post.call_args
+    content_type = call_args[1]["files"]["file"][2]
+    assert content_type == "audio/mpeg"
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_atranscribe_wav_content_type(wav_file, mock_httpx_clients):
+    """Test that async .wav transcribe uses correct audio MIME type."""
+    model = ElevenLabsSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    await model.atranscribe(wav_file)
+
+    call_args = model.async_client.post.call_args
+    content_type = call_args[1]["files"]["file"][2]
+    assert content_type == _guess_audio_content_type(wav_file)
+    assert content_type.startswith("audio/")
+
+
+def test_elevenlabs_provider_name():
+    model = ElevenLabsSpeechToTextModel(api_key="test-key")
+    assert model.provider == "elevenlabs"
+
+
+def test_elevenlabs_default_model():
+    model = ElevenLabsSpeechToTextModel(api_key="test-key")
+    assert model._get_default_model() == "scribe_v1"
+
+
+def test_elevenlabs_missing_api_key():
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ValueError, match="ElevenLabs API key not found"):
+            ElevenLabsSpeechToTextModel(api_key=None)

--- a/tests/providers/stt/test_mistral.py
+++ b/tests/providers/stt/test_mistral.py
@@ -1,5 +1,6 @@
 """Tests for Mistral speech-to-text provider."""
 
+import io
 import os
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -7,6 +8,7 @@ import pytest
 
 from esperanto.common_types import TranscriptionResponse
 from esperanto.factory import AIFactory
+from esperanto.providers.stt.base import _guess_audio_content_type
 from esperanto.providers.stt.mistral import MistralSpeechToTextModel
 
 
@@ -15,6 +17,34 @@ def audio_file(tmp_path):
     """Create a temporary audio file for testing."""
     f = tmp_path / "test.mp3"
     f.write_bytes(b"mock audio content")
+    return str(f)
+
+
+@pytest.fixture
+def wav_file(tmp_path):
+    f = tmp_path / "test.wav"
+    f.write_bytes(b"mock wav content")
+    return str(f)
+
+
+@pytest.fixture
+def flac_file(tmp_path):
+    f = tmp_path / "test.flac"
+    f.write_bytes(b"mock flac content")
+    return str(f)
+
+
+@pytest.fixture
+def ogg_file(tmp_path):
+    f = tmp_path / "test.ogg"
+    f.write_bytes(b"mock ogg content")
+    return str(f)
+
+
+@pytest.fixture
+def unknown_file(tmp_path):
+    f = tmp_path / "test.xyz"
+    f.write_bytes(b"mock unknown content")
     return str(f)
 
 
@@ -198,3 +228,81 @@ def test_mistral_missing_api_key():
     with patch.dict(os.environ, {}, clear=True):
         with pytest.raises(ValueError, match="Mistral API key not found"):
             MistralSpeechToTextModel(api_key=None)
+
+
+def test_mistral_transcribe_wav_content_type(wav_file, mock_httpx_clients):
+    """Test that .wav file uses correct audio MIME type."""
+    model = MistralSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    model.transcribe(wav_file)
+
+    call_args = model.client.post.call_args
+    content_type = call_args[1]["files"]["file"][2]
+    assert content_type == _guess_audio_content_type(wav_file)
+    assert content_type.startswith("audio/")
+
+
+def test_mistral_transcribe_flac_content_type(flac_file, mock_httpx_clients):
+    """Test that .flac file uses correct audio MIME type."""
+    model = MistralSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    model.transcribe(flac_file)
+
+    call_args = model.client.post.call_args
+    content_type = call_args[1]["files"]["file"][2]
+    assert content_type == _guess_audio_content_type(flac_file)
+    assert content_type.startswith("audio/")
+
+
+def test_mistral_transcribe_ogg_content_type(ogg_file, mock_httpx_clients):
+    """Test that .ogg file uses audio/ogg MIME type."""
+    model = MistralSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    model.transcribe(ogg_file)
+
+    call_args = model.client.post.call_args
+    content_type = call_args[1]["files"]["file"][2]
+    assert content_type == "audio/ogg"
+
+
+def test_mistral_transcribe_unknown_extension_falls_back(unknown_file, mock_httpx_clients):
+    """Test that unknown extension falls back to audio/mpeg."""
+    model = MistralSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    model.transcribe(unknown_file)
+
+    call_args = model.client.post.call_args
+    content_type = call_args[1]["files"]["file"][2]
+    assert content_type == "audio/mpeg"
+
+
+def test_mistral_transcribe_binaryio_mp3_name_uses_mpeg(mock_httpx_clients):
+    """Test that BinaryIO with .mp3 name uses audio/mpeg."""
+    model = MistralSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    stream = io.BytesIO(b"mock audio")
+    stream.name = "audio.mp3"
+    model.transcribe(stream)
+
+    call_args = model.client.post.call_args
+    content_type = call_args[1]["files"]["file"][2]
+    assert content_type == "audio/mpeg"
+
+
+@pytest.mark.asyncio
+async def test_mistral_atranscribe_wav_content_type(wav_file, mock_httpx_clients):
+    """Test that async .wav transcribe uses correct audio MIME type."""
+    model = MistralSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    await model.atranscribe(wav_file)
+
+    call_args = model.async_client.post.call_args
+    content_type = call_args[1]["files"]["file"][2]
+    assert content_type == _guess_audio_content_type(wav_file)
+    assert content_type.startswith("audio/")

--- a/tests/providers/stt/test_openai.py
+++ b/tests/providers/stt/test_openai.py
@@ -7,6 +7,7 @@ import pytest
 
 from esperanto.common_types import TranscriptionResponse
 from esperanto.factory import AIFactory
+from esperanto.providers.stt.base import _guess_audio_content_type
 from esperanto.providers.stt.openai import OpenAISpeechToTextModel
 
 
@@ -16,6 +17,34 @@ def audio_file(tmp_path):
     audio_file = tmp_path / "test.mp3"
     audio_file.write_bytes(b"mock audio content")
     return str(audio_file)
+
+
+@pytest.fixture
+def wav_file(tmp_path):
+    f = tmp_path / "test.wav"
+    f.write_bytes(b"mock wav content")
+    return str(f)
+
+
+@pytest.fixture
+def flac_file(tmp_path):
+    f = tmp_path / "test.flac"
+    f.write_bytes(b"mock flac content")
+    return str(f)
+
+
+@pytest.fixture
+def ogg_file(tmp_path):
+    f = tmp_path / "test.ogg"
+    f.write_bytes(b"mock ogg content")
+    return str(f)
+
+
+@pytest.fixture
+def unknown_file(tmp_path):
+    f = tmp_path / "test.xyz"
+    f.write_bytes(b"mock unknown content")
+    return str(f)
 
 
 @pytest.fixture
@@ -246,3 +275,82 @@ def test_openai_models(mock_httpx_clients):
     assert models[0].id == "whisper-1"
     # Model type is None when not explicitly provided by the API
     assert models[0].type is None
+
+
+def test_openai_transcribe_wav_content_type(wav_file, mock_httpx_clients):
+    """Test that .wav file uses correct audio MIME type."""
+    model = OpenAISpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    model.transcribe(wav_file)
+
+    call_args = model.client.post.call_args
+    content_type = call_args[1]["files"]["file"][2]
+    assert content_type == _guess_audio_content_type(wav_file)
+    assert content_type.startswith("audio/")
+
+
+def test_openai_transcribe_flac_content_type(flac_file, mock_httpx_clients):
+    """Test that .flac file uses correct audio MIME type."""
+    model = OpenAISpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    model.transcribe(flac_file)
+
+    call_args = model.client.post.call_args
+    content_type = call_args[1]["files"]["file"][2]
+    assert content_type == _guess_audio_content_type(flac_file)
+    assert content_type.startswith("audio/")
+
+
+def test_openai_transcribe_ogg_content_type(ogg_file, mock_httpx_clients):
+    """Test that .ogg file uses audio/ogg MIME type."""
+    model = OpenAISpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    model.transcribe(ogg_file)
+
+    call_args = model.client.post.call_args
+    content_type = call_args[1]["files"]["file"][2]
+    assert content_type == "audio/ogg"
+
+
+def test_openai_transcribe_unknown_extension_falls_back(unknown_file, mock_httpx_clients):
+    """Test that unknown extension falls back to audio/mpeg."""
+    model = OpenAISpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    model.transcribe(unknown_file)
+
+    call_args = model.client.post.call_args
+    content_type = call_args[1]["files"]["file"][2]
+    assert content_type == "audio/mpeg"
+
+
+def test_openai_transcribe_binaryio_mp3_name_uses_mpeg(mock_httpx_clients):
+    """Test that BinaryIO with .mp3 name uses audio/mpeg."""
+    import io
+    model = OpenAISpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    stream = io.BytesIO(b"mock audio")
+    stream.name = "audio.mp3"
+    model.transcribe(stream)
+
+    call_args = model.client.post.call_args
+    content_type = call_args[1]["files"]["file"][2]
+    assert content_type == "audio/mpeg"
+
+
+@pytest.mark.asyncio
+async def test_openai_atranscribe_wav_content_type(wav_file, mock_httpx_clients):
+    """Test that async .wav transcribe uses correct audio MIME type."""
+    model = OpenAISpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    await model.atranscribe(wav_file)
+
+    call_args = model.async_client.post.call_args
+    content_type = call_args[1]["files"]["file"][2]
+    assert content_type == _guess_audio_content_type(wav_file)
+    assert content_type.startswith("audio/")


### PR DESCRIPTION
## Summary

Replaces hardcoded \`audio/mpeg\` multipart Content-Type across all native STT providers with a \`_guess_audio_content_type(filename)\` helper that uses \`mimetypes.guess_type\` and falls back to \`audio/mpeg\` for unknown extensions or non-audio MIME guesses.

A \`.wav\` file now uploads as \`audio/wav\` (or platform-specific \`audio/x-wav\`); a \`.flac\` as \`audio/flac\`; a \`.ogg\` as \`audio/ogg\`. Stream inputs without a filename, or files with unknown extensions, still use \`audio/mpeg\` — preserving today's behavior as the safe default.

## Changes

- New helper \`_guess_audio_content_type\` in \`src/esperanto/providers/stt/base.py\`
- 4 STT providers migrated: \`openai\`, \`azure\`, \`elevenlabs\`, \`mistral\` (sync + async paths each — 16 call sites total)
- Comprehensive tests: per-provider tests for wav/flac/ogg/m4a/webm + unknown-extension fallback + BinaryIO without name; helper unit tests in \`test_base.py\`

## Diff shape

\`\`\`
src/esperanto/providers/stt/azure.py       |  4 ++--
src/esperanto/providers/stt/base.py        |  9 +++++++++
src/esperanto/providers/stt/elevenlabs.py  | 14 +++++---------
src/esperanto/providers/stt/mistral.py     | 14 +++++---------
src/esperanto/providers/stt/openai.py      | 14 +++++---------
tests/providers/stt/test_azure.py          | +229
tests/providers/stt/test_base.py           |  +40
tests/providers/stt/test_elevenlabs.py     | +223
tests/providers/stt/test_mistral.py        | +108
tests/providers/stt/test_openai.py         | +108
\`\`\`

## Out of scope (potential follow-ups)

- **\`src/esperanto/providers/stt/openai_compatible.py\`** has its own inline MIME-detection (lines ~209-222) that wasn't migrated. Functionally equivalent (also falls back to audio/mpeg for unknown), but inconsistent with the new helper. Worth a follow-up if you want full consistency.
- **\`src/esperanto/providers/stt/CLAUDE.md\`** still has 3 stale \`audio/mpeg\` examples (lines 61, 198, 236) in the agent docs. Easy doc cleanup.

## Test plan

- [x] \`uv run pytest tests/providers tests/unit tests/common_types tests/test_deprecation_warnings.py -q --no-cov\` exits 0 (981 passed, 1 skipped)
- [x] \`uv run ruff check .\` clean
- [x] \`uv run mypy src/esperanto\` clean
- [x] All 8 new helper unit tests in \`TestGuessAudioContentType\` pass
- [x] Per-provider tests assert correct Content-Type for wav/flac/ogg + fallback for unknown + fallback for BinaryIO

Closes #147.