### PR TITLE
fix(llm/ollama): lower default num_ctx from 128000 to 8192 (closes #107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Ollama `num_ctx` default lowered from 128,000 to 8,192.** The previous 128K default caused out-of-memory errors on consumer GPUs with 8 GB VRAM. 8,192 tokens works reliably on common hardware while still being large enough for typical chat workloads. Override with `config={"num_ctx": N}` when you need a larger context window. (#107)
 - **Lint and type-check the codebase clean.** Ruff (`ruff check .`) and mypy (`mypy src/esperanto`) now report zero errors. Most fixes are type-only and do not change runtime behavior. Notable structural changes:
   - `HttpConnectionMixin` now declares `client: httpx.Client` and `async_client: httpx.AsyncClient` as non-Optional. The `Optional[Client] = None` dataclass fields previously redeclared on every provider base class have been removed; clients are still assigned by `_create_http_clients()` during `__post_init__`, so the runtime contract is unchanged.
   - Removed a duplicate `_get_default_model` definition in the Mistral provider (returned the same value as the original).

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -119,23 +119,26 @@ model = AIFactory.create_language(
 
 **Context Window (`num_ctx`):**
 
-Esperanto uses a default context window of **128,000 tokens** for Ollama models, which is much larger than Ollama's built-in default of 2,048 tokens. This ensures that large documents and long conversations work out of the box.
+Esperanto uses a default context window of **8,192 tokens** for Ollama models. This default was chosen to work reliably on hardware with 8 GB VRAM — Ollama's built-in default of 2,048 tokens is too small for typical chat workloads, while a 128K default causes out-of-memory errors on common consumer GPUs. 8,192 strikes a balance that works out of the box on most hardware.
 
-You can customize this value if needed:
+Override via `config` whenever you need more (or less) context:
 
 ```python
-# Use a smaller context window for memory efficiency
+# Default — 8192 tokens, safe for 8 GB VRAM hardware
+model = AIFactory.create_language("ollama", "llama3.1")
+
+# Increase for longer conversations or documents
 model = AIFactory.create_language(
     "ollama",
     "llama3.1",
-    config={"num_ctx": 8192}
+    config={"num_ctx": 32768}
 )
 
-# Use a larger context window for very long documents
+# Use a very large context window if your hardware supports it
 model = AIFactory.create_language(
     "ollama",
     "llama3.1",
-    config={"num_ctx": 131072}  # 128K tokens
+    config={"num_ctx": 131072}  # 128K tokens — needs 24 GB+ VRAM
 )
 ```
 
@@ -489,7 +492,7 @@ Error: Out of memory
 Issue: Model gives generic answers ignoring provided context
 ```
 **Solution:**
-This usually means the context window is too small and your input is being truncated. Esperanto defaults to 128K tokens, but if you're overriding `num_ctx` with a smaller value, increase it:
+This usually means the context window is too small and your input is being truncated. Esperanto defaults to 8,192 tokens. If your conversation or document is longer, increase `num_ctx`:
 ```python
 model = AIFactory.create_language(
     "ollama",

--- a/src/esperanto/providers/llm/ollama.py
+++ b/src/esperanto/providers/llm/ollama.py
@@ -97,8 +97,8 @@ class OllamaLanguageModel(LanguageModel):
                     kwargs[key] = value
 
         # Handle Ollama-specific options from _config (num_ctx for context window)
-        # Default to 128000 tokens if not specified (Ollama's default of 2048 is too small)
-        options["num_ctx"] = self._config.get("num_ctx", 128000)
+        # Default to 8192 to avoid OOM on 8 GB VRAM hardware; override via config={"num_ctx": N}
+        options["num_ctx"] = self._config.get("num_ctx", 8192)
 
         # Handle keep_alive (top-level parameter, not in options)
         # Only set if explicitly provided - don't force memory usage on users
@@ -578,7 +578,7 @@ class OllamaLanguageModel(LanguageModel):
             "temperature": self.temperature,
             "top_p": self.top_p,
             "num_predict": self.max_tokens,
-            "num_ctx": self._config.get("num_ctx", 128000),
+            "num_ctx": self._config.get("num_ctx", 8192),
             "base_url": self.base_url,
         }
 

--- a/tests/providers/llm/test_ollama_provider.py
+++ b/tests/providers/llm/test_ollama_provider.py
@@ -805,12 +805,12 @@ def test_ollama_base_url_env_var_trailing_slash_stripped():
 
 
 def test_ollama_default_num_ctx():
-    """Test that default num_ctx (128000) is applied when not specified."""
+    """Test that default num_ctx (8192) is applied when not specified."""
     model = OllamaLanguageModel(model_name="gemma2")
     api_kwargs = model._get_api_kwargs()
 
     assert "options" in api_kwargs
-    assert api_kwargs["options"]["num_ctx"] == 128000
+    assert api_kwargs["options"]["num_ctx"] == 8192
 
 
 def test_ollama_custom_num_ctx():
@@ -823,11 +823,11 @@ def test_ollama_custom_num_ctx():
 
 
 def test_ollama_to_langchain_default_num_ctx():
-    """Test that to_langchain uses default num_ctx (128000) when not specified."""
+    """Test that to_langchain uses default num_ctx (8192) when not specified."""
     model = OllamaLanguageModel(model_name="gemma2")
     langchain_model = model.to_langchain()
 
-    assert langchain_model.num_ctx == 128000
+    assert langchain_model.num_ctx == 8192
 
 
 def test_ollama_to_langchain_custom_num_ctx():


### PR DESCRIPTION
## Summary

Applies the **Hot-Swap-First Defaults** principle (ARCHITECTURE.md) to Ollama's \`num_ctx\` default. The previous 128,000 default forced a 128k-token KV cache regardless of model size, OOM-crashing Ollama on consumer GPUs (e.g. Llama 3.2 3B on 8 GB VRAM).

New default: **8,192**. Big enough that typical chat workloads succeed when hot-swapping from cloud providers; small enough to fit common 3B–7B models on 8 GB VRAM.

Override semantics unchanged: \`AIFactory.create_language(\"ollama\", \"...\", config={\"num_ctx\": 32768})\` still works for users who need larger context.

## Why

The original issue framed this as discovery feeding runtime; the real culprit is the hardcoded default itself. \`max_context_length\` from \`/api/tags\` (model_discovery.py:309) is informational metadata only and does not feed the request path.

## Diff shape

\`\`\`
CHANGELOG.md                                |  1 +
docs/providers/ollama.md                    | 17 ++++++++++-------
src/esperanto/providers/llm/ollama.py       |  6 +++---
tests/providers/llm/test_ollama_provider.py |  8 ++++----
4 files changed, 18 insertions(+), 14 deletions(-)
\`\`\`

## Test plan

- [x] \`test_ollama_default_num_ctx\`: outgoing request \`api_kwargs['options']['num_ctx']\` is 8192 when no config given
- [x] \`test_ollama_custom_num_ctx\`: \`config={'num_ctx': 32768}\` still produces 32768 (override preserved)
- [x] \`test_ollama_to_langchain_default_num_ctx\`: LangChain integration also picks up 8192 default
- [x] \`uv run pytest tests/providers tests/unit tests/common_types tests/test_deprecation_warnings.py -q --no-cov\` exits 0 (944 passed; 1 unrelated pre-existing transformers/HF network error)
- [x] \`uv run ruff check .\` clean
- [x] \`uv run mypy src/esperanto\` clean
- [x] \`docs/providers/ollama.md\` updated with new default + override example

## Out of scope

Per the issue body:
- Reading the model's actual context window from \`/api/show\` and using it as a smarter per-model default — separate design (per-host VRAM concerns).
- Per-call \`num_ctx\` override on \`chat_complete\` — \`num_ctx\` stays in instance config (Group C, Q4 decision, 2026-05-01).

Closes #107.