### PR TITLE
fix: normalize base_url across providers (strip trailing slashes before composing endpoint URLs)

### DIFF
--- a/src/esperanto/providers/embedding/azure.py
+++ b/src/esperanto/providers/embedding/azure.py
@@ -39,6 +39,8 @@ class AzureEmbeddingModel(EmbeddingModel):
             os.getenv("AZURE_OPENAI_ENDPOINT_EMBEDDING") or
             os.getenv("AZURE_OPENAI_ENDPOINT")
         )
+        if self.azure_endpoint:
+            self.azure_endpoint = self.azure_endpoint.rstrip("/")
 
         self.api_version = (
             api_version or

--- a/src/esperanto/providers/embedding/google.py
+++ b/src/esperanto/providers/embedding/google.py
@@ -41,7 +41,7 @@ class GoogleEmbeddingModel(EmbeddingModel):
             raise ValueError("Google API key not found")
 
         # Set base URL
-        base_host = os.getenv("GEMINI_API_BASE_URL") or "https://generativelanguage.googleapis.com"
+        base_host = (os.getenv("GEMINI_API_BASE_URL") or "https://generativelanguage.googleapis.com").rstrip("/")
         self.base_url = f"{base_host}/v1beta"
 
         # Initialize HTTP clients with configurable timeout

--- a/src/esperanto/providers/embedding/jina.py
+++ b/src/esperanto/providers/embedding/jina.py
@@ -52,7 +52,7 @@ class JinaEmbeddingModel(EmbeddingModel):
         self.base_url = (
             self.base_url
             or "https://api.jina.ai/v1/embeddings"
-        )
+        ).rstrip("/")
 
         # Initialize HTTP clients with configurable timeout
         self._create_http_clients()

--- a/src/esperanto/providers/embedding/mistral.py
+++ b/src/esperanto/providers/embedding/mistral.py
@@ -20,7 +20,7 @@ class MistralEmbeddingModel(EmbeddingModel):
             raise ValueError("Mistral API key not found. Set MISTRAL_API_KEY environment variable.")
 
         # Set base URL
-        self.base_url = "https://api.mistral.ai/v1"
+        self.base_url = "https://api.mistral.ai/v1".rstrip("/")
 
         # Initialize HTTP clients with configurable timeout
         self._create_http_clients()

--- a/src/esperanto/providers/embedding/ollama.py
+++ b/src/esperanto/providers/embedding/ollama.py
@@ -20,7 +20,7 @@ class OllamaEmbeddingModel(EmbeddingModel):
             self.base_url
             or os.getenv("OLLAMA_BASE_URL") or os.getenv("OLLAMA_API_BASE")
             or "http://localhost:11434"
-        )
+        ).rstrip("/")
 
         # Initialize HTTP clients with configurable timeout
         self._create_http_clients()

--- a/src/esperanto/providers/embedding/openai.py
+++ b/src/esperanto/providers/embedding/openai.py
@@ -23,7 +23,7 @@ class OpenAIEmbeddingModel(EmbeddingModel):
             raise ValueError("OpenAI API key not found")
 
         # Set base URL
-        self.base_url = self.base_url or "https://api.openai.com/v1"
+        self.base_url = (self.base_url or "https://api.openai.com/v1").rstrip("/")
 
         # Update config with model_name if provided
         if "model_name" in kwargs:

--- a/src/esperanto/providers/embedding/openrouter.py
+++ b/src/esperanto/providers/embedding/openrouter.py
@@ -26,9 +26,9 @@ class OpenRouterEmbeddingModel(OpenAIEmbeddingModel):
             self.base_url = self.base_url or self.config.get("base_url")
 
         # Initialize OpenRouter-specific configuration
-        self.base_url = self.base_url or os.getenv(
+        self.base_url = (self.base_url or os.getenv(
             "OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1"
-        )
+        )).rstrip("/")
         self.api_key = self.api_key or os.getenv("OPENROUTER_API_KEY")
 
         if not self.api_key:

--- a/src/esperanto/providers/embedding/vertex.py
+++ b/src/esperanto/providers/embedding/vertex.py
@@ -25,7 +25,7 @@ class VertexEmbeddingModel(EmbeddingModel):
         super().__init__(**kwargs)
         
         # Set base URL for Vertex AI
-        self.base_url = f"https://{self.location}-aiplatform.googleapis.com/v1"
+        self.base_url = f"https://{self.location}-aiplatform.googleapis.com/v1".rstrip("/")
         
         # Initialize HTTP clients with configurable timeout
         self._create_http_clients()

--- a/src/esperanto/providers/embedding/voyage.py
+++ b/src/esperanto/providers/embedding/voyage.py
@@ -29,7 +29,7 @@ class VoyageEmbeddingModel(EmbeddingModel):
             raise ValueError("Voyage API key not found")
 
         # Set base URL
-        self.base_url = self.base_url or "https://api.voyageai.com/v1"
+        self.base_url = (self.base_url or "https://api.voyageai.com/v1").rstrip("/")
 
         # Initialize HTTP clients with configurable timeout
         self._create_http_clients()

--- a/src/esperanto/providers/llm/anthropic.py
+++ b/src/esperanto/providers/llm/anthropic.py
@@ -58,7 +58,7 @@ class AnthropicLanguageModel(LanguageModel):
             )
 
         # Set base URL
-        self.base_url = self.base_url or "https://api.anthropic.com/v1"
+        self.base_url = (self.base_url or "https://api.anthropic.com/v1").rstrip("/")
 
         # Initialize HTTP clients with configurable timeout
         self._create_http_clients()

--- a/src/esperanto/providers/llm/azure.py
+++ b/src/esperanto/providers/llm/azure.py
@@ -60,6 +60,8 @@ class AzureLanguageModel(LanguageModel):
             os.getenv("AZURE_OPENAI_ENDPOINT_LLM") or
             os.getenv("AZURE_OPENAI_ENDPOINT")
         )
+        if self.azure_endpoint:
+            self.azure_endpoint = self.azure_endpoint.rstrip("/")
 
         self.api_version = (
             self._config.get("api_version") or

--- a/src/esperanto/providers/llm/google.py
+++ b/src/esperanto/providers/llm/google.py
@@ -56,7 +56,7 @@ class GoogleLanguageModel(LanguageModel):
             )
 
         # Set base URL
-        base_host = os.getenv("GEMINI_API_BASE_URL") or "https://generativelanguage.googleapis.com"
+        base_host = (os.getenv("GEMINI_API_BASE_URL") or "https://generativelanguage.googleapis.com").rstrip("/")
         self.base_url = f"{base_host}/v1beta"
 
         # Initialize HTTP clients with configurable timeout

--- a/src/esperanto/providers/llm/groq.py
+++ b/src/esperanto/providers/llm/groq.py
@@ -51,7 +51,7 @@ class GroqLanguageModel(LanguageModel):
             raise ValueError("Groq API key not found")
 
         # Set base URL for Groq's OpenAI-compatible API
-        self.base_url = "https://api.groq.com/openai/v1"
+        self.base_url = "https://api.groq.com/openai/v1".rstrip("/")
 
         # Initialize HTTP clients with configurable timeout
         self._create_http_clients()

--- a/src/esperanto/providers/llm/mistral.py
+++ b/src/esperanto/providers/llm/mistral.py
@@ -53,7 +53,7 @@ class MistralLanguageModel(LanguageModel):
             raise ValueError("Mistral API key not found. Set MISTRAL_API_KEY environment variable.")
 
         # Set base URL
-        self.base_url = self.base_url or "https://api.mistral.ai/v1"
+        self.base_url = (self.base_url or "https://api.mistral.ai/v1").rstrip("/")
 
         # Initialize HTTP clients with configurable timeout
         self._create_http_clients()

--- a/src/esperanto/providers/llm/ollama.py
+++ b/src/esperanto/providers/llm/ollama.py
@@ -49,8 +49,8 @@ class OllamaLanguageModel(LanguageModel):
 
         # Set default base URL if not provided
         self.base_url = (
-            self.base_url or os.getenv("OLLAMA_BASE_URL")  or os.getenv("OLLAMA_API_BASE") or "http://localhost:11434"
-        )
+            self.base_url or os.getenv("OLLAMA_BASE_URL") or os.getenv("OLLAMA_API_BASE") or "http://localhost:11434"
+        ).rstrip("/")
 
         # Initialize HTTP clients with configurable timeout
         self._create_http_clients()

--- a/src/esperanto/providers/llm/openai.py
+++ b/src/esperanto/providers/llm/openai.py
@@ -51,7 +51,7 @@ class OpenAILanguageModel(LanguageModel):
             raise ValueError("OpenAI API key not found")
 
         # Set base URL
-        self.base_url = self.base_url or os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"
+        self.base_url = (self.base_url os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1").rstrip("/")
 
         # Initialize HTTP clients with configurable timeout
         self._create_http_clients()

--- a/src/esperanto/providers/llm/openai.py
+++ b/src/esperanto/providers/llm/openai.py
@@ -51,7 +51,7 @@ class OpenAILanguageModel(LanguageModel):
             raise ValueError("OpenAI API key not found")
 
         # Set base URL
-        self.base_url = (self.base_url os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1").rstrip("/")
+        self.base_url = (self.base_url or os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1").rstrip("/")
 
         # Initialize HTTP clients with configurable timeout
         self._create_http_clients()

--- a/src/esperanto/providers/llm/openrouter.py
+++ b/src/esperanto/providers/llm/openrouter.py
@@ -44,9 +44,9 @@ class OpenRouterLanguageModel(OpenAILanguageModel):
                 self.base_url = self.config["base_url"]
 
         # Initialize OpenRouter-specific configuration
-        self.base_url = self.base_url or os.getenv(
+        self.base_url = (self.base_url or os.getenv(
             "OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1"
-        )
+        )).rstrip("/")
         self.api_key = self.api_key or os.getenv("OPENROUTER_API_KEY")
 
         if not self.api_key:

--- a/src/esperanto/providers/llm/perplexity.py
+++ b/src/esperanto/providers/llm/perplexity.py
@@ -56,9 +56,9 @@ class PerplexityLanguageModel(LanguageModel):
         super().__post_init__()
 
         # Initialize Perplexity-specific configuration
-        self.base_url = self.base_url or os.getenv(
+        self.base_url = (self.base_url or os.getenv(
             "PERPLEXITY_BASE_URL", "https://api.perplexity.ai"
-        )
+        )).rstrip("/")
         self.api_key = self.api_key or os.getenv("PERPLEXITY_API_KEY")
 
         if not self.api_key:

--- a/src/esperanto/providers/llm/vertex.py
+++ b/src/esperanto/providers/llm/vertex.py
@@ -59,7 +59,7 @@ class VertexLanguageModel(LanguageModel):
             )
 
         # Set base URL for Vertex AI
-        self.base_url = f"https://{self.location}-aiplatform.googleapis.com/v1"
+        self.base_url = f"https://{self.location}-aiplatform.googleapis.com/v1".rstrip("/")
 
         # Load credentials (service account file, ADC, or None for gcloud fallback)
         self._load_credentials()

--- a/src/esperanto/providers/reranker/jina.py
+++ b/src/esperanto/providers/reranker/jina.py
@@ -29,7 +29,7 @@ class JinaRerankerModel(RerankerModel):
             )
 
         # API configuration
-        self.base_url = self.base_url or "https://api.jina.ai/v1"
+        self.base_url = (self.base_url or "https://api.jina.ai/v1").rstrip("/")
 
         # Initialize HTTP clients with configurable timeout
         self._create_http_clients()

--- a/src/esperanto/providers/reranker/voyage.py
+++ b/src/esperanto/providers/reranker/voyage.py
@@ -29,7 +29,7 @@ class VoyageRerankerModel(RerankerModel):
             )
 
         # API configuration
-        self.base_url = self.base_url or "https://api.voyageai.com/v1"
+        self.base_url = (self.base_url or "https://api.voyageai.com/v1").rstrip("/")
 
         # Initialize HTTP clients with configurable timeout
         self._create_http_clients()

--- a/src/esperanto/providers/stt/azure.py
+++ b/src/esperanto/providers/stt/azure.py
@@ -31,6 +31,8 @@ class AzureSpeechToTextModel(SpeechToTextModel):
             os.getenv("AZURE_OPENAI_ENDPOINT_STT") or
             os.getenv("AZURE_OPENAI_ENDPOINT")
         )
+        if self.azure_endpoint:
+            self.azure_endpoint = self.azure_endpoint.rstrip("/")
 
         self.api_version = (
             self._config.get("api_version") or

--- a/src/esperanto/providers/stt/elevenlabs.py
+++ b/src/esperanto/providers/stt/elevenlabs.py
@@ -29,7 +29,7 @@ class ElevenLabsSpeechToTextModel(SpeechToTextModel):
             raise ValueError("ElevenLabs API key not found")
 
         # Set base URL
-        self.base_url = self.base_url or "https://api.elevenlabs.io/v1"
+        self.base_url = (self.base_url or "https://api.elevenlabs.io/v1").rstrip("/")
 
         # Initialize HTTP clients with configurable timeout
         self._create_http_clients()

--- a/src/esperanto/providers/stt/google.py
+++ b/src/esperanto/providers/stt/google.py
@@ -35,7 +35,7 @@ class GoogleSpeechToTextModel(SpeechToTextModel):
             )
 
         # Set base URL - consistent with other Google providers
-        base_host = os.getenv("GEMINI_API_BASE_URL") or "https://generativelanguage.googleapis.com"
+        base_host = (os.getenv("GEMINI_API_BASE_URL") or "https://generativelanguage.googleapis.com").rstrip("/")
         self.base_url = f"{base_host}/v1beta"
 
         # Initialize HTTP clients with configurable timeout

--- a/src/esperanto/providers/stt/groq.py
+++ b/src/esperanto/providers/stt/groq.py
@@ -27,7 +27,7 @@ class GroqSpeechToTextModel(OpenAISpeechToTextModel):
             raise ValueError("Groq API key not found")
 
         # Set Groq's OpenAI-compatible base URL
-        self.base_url = self.base_url or "https://api.groq.com/openai/v1"
+        self.base_url = (self.base_url or "https://api.groq.com/openai/v1").rstrip("/")
 
         # Call parent's post_init (won't overwrite since values are already set)
         super().__post_init__()

--- a/src/esperanto/providers/stt/mistral.py
+++ b/src/esperanto/providers/stt/mistral.py
@@ -27,7 +27,7 @@ class MistralSpeechToTextModel(SpeechToTextModel):
                 "Mistral API key not found. Set MISTRAL_API_KEY environment variable."
             )
 
-        self.base_url = self.base_url or "https://api.mistral.ai/v1"
+        self.base_url = (self.base_url or "https://api.mistral.ai/v1").rstrip("/")
 
         self._create_http_clients()
 

--- a/src/esperanto/providers/stt/openai.py
+++ b/src/esperanto/providers/stt/openai.py
@@ -29,7 +29,7 @@ class OpenAISpeechToTextModel(SpeechToTextModel):
             raise ValueError("OpenAI API key not found")
 
         # Set base URL
-        self.base_url = self.base_url or "https://api.openai.com/v1"
+        self.base_url = (self.base_url or "https://api.openai.com/v1").rstrip("/")
 
         # Initialize HTTP clients with configurable timeout
         self._create_http_clients()

--- a/src/esperanto/providers/tts/azure.py
+++ b/src/esperanto/providers/tts/azure.py
@@ -58,6 +58,8 @@ class AzureTextToSpeechModel(TextToSpeechModel):
             os.getenv("AZURE_OPENAI_ENDPOINT_TTS") or
             os.getenv("AZURE_OPENAI_ENDPOINT")
         )
+        if self.azure_endpoint:
+            self.azure_endpoint = self.azure_endpoint.rstrip("/")
 
         self.api_version = (
             self._config.get("api_version") or

--- a/src/esperanto/providers/tts/elevenlabs.py
+++ b/src/esperanto/providers/tts/elevenlabs.py
@@ -54,6 +54,9 @@ class ElevenLabsTextToSpeechModel(TextToSpeechModel):
             base_url=base_url or "https://api.elevenlabs.io",
             config=kwargs
         )
+
+        if self.base_url:
+            self.base_url = self.base_url.rstrip("/")
         
         self.voice_settings = {
             **self.DEFAULT_VOICE_SETTINGS,

--- a/src/esperanto/providers/tts/google.py
+++ b/src/esperanto/providers/tts/google.py
@@ -47,7 +47,7 @@ class GoogleTextToSpeechModel(TextToSpeechModel):
             )
 
         # Set base URL
-        base_host = os.getenv("GEMINI_API_BASE_URL") or "https://generativelanguage.googleapis.com"
+        base_host = (os.getenv("GEMINI_API_BASE_URL") or "https://generativelanguage.googleapis.com").rstrip("/")
         self.base_url = f"{base_host}/v1beta"
 
         # Initialize HTTP clients with configurable timeout

--- a/src/esperanto/providers/tts/mistral.py
+++ b/src/esperanto/providers/tts/mistral.py
@@ -27,7 +27,7 @@ class MistralTextToSpeechModel(TextToSpeechModel):
             raise ValueError(
                 "Mistral API key not found. Set MISTRAL_API_KEY environment variable."
             )
-        self.base_url = self.base_url or "https://api.mistral.ai/v1"
+        self.base_url = (self.base_url or "https://api.mistral.ai/v1").rstrip("/")
         self.model_name = self.model_name or self._get_default_model()
         self._voices_cache: Optional[Dict[str, Voice]] = None
         self._create_http_clients()

--- a/src/esperanto/providers/tts/openai.py
+++ b/src/esperanto/providers/tts/openai.py
@@ -52,7 +52,7 @@ class OpenAITextToSpeechModel(TextToSpeechModel):
         )
         
         # Set base URL
-        self.base_url = self.base_url or "https://api.openai.com/v1"
+        self.base_url = (self.base_url or "https://api.openai.com/v1").rstrip("/")
         
         # Initialize HTTP clients with configurable timeout
         self._create_http_clients()

--- a/src/esperanto/providers/tts/vertex.py
+++ b/src/esperanto/providers/tts/vertex.py
@@ -47,7 +47,7 @@ class VertexTextToSpeechModel(TextToSpeechModel):
             )
 
         # Set base URL for Cloud Text-to-Speech API
-        self.base_url = "https://texttospeech.googleapis.com/v1"
+        self.base_url = "https://texttospeech.googleapis.com/v1".rstrip("/")
 
         # Initialize HTTP clients with configurable timeout
         self._create_http_clients()

--- a/src/esperanto/providers/tts/xai.py
+++ b/src/esperanto/providers/tts/xai.py
@@ -64,7 +64,7 @@ class XAITextToSpeechModel(TextToSpeechModel):
             self._config.get("base_url") or
             os.getenv("XAI_BASE_URL") or
             self.DEFAULT_BASE_URL
-        )
+        ).rstrip("/")
 
         # Validate required parameters
         if not self.api_key:

--- a/tests/providers/llm/test_azure_provider.py
+++ b/tests/providers/llm/test_azure_provider.py
@@ -72,7 +72,7 @@ def test_initialization_success(mock_env_vars):
     """Test successful initialization with environment variables."""
     model = AzureLanguageModel(model_name="test-deployment")
     assert model.api_key == "test_azure_api_key"
-    assert model.azure_endpoint == "https://test-endpoint.openai.azure.com/"
+    assert model.azure_endpoint == "https://test-endpoint.openai.azure.com"
     assert model.api_version == "2023-12-01-preview"
     assert model.model_name == "test-deployment" # Deployment name
     assert model.client is not None
@@ -89,7 +89,7 @@ def test_initialization_with_direct_params():
         }
     )
     assert model.api_key == "direct_key"
-    assert model.azure_endpoint == "https://direct-endpoint.com/"
+    assert model.azure_endpoint == "https://direct-endpoint.com"
     assert model.api_version == "2024-01-01"
     assert model.model_name == "direct-deployment"
 
@@ -282,7 +282,7 @@ def test_to_langchain(MockAzureChatOpenAI, azure_model, mock_env_vars):
 
     assert call_kwargs["azure_deployment"] == "test-deployment"
     assert call_kwargs["api_key"].get_secret_value() == "test_azure_api_key"
-    assert call_kwargs["azure_endpoint"] == "https://test-endpoint.openai.azure.com/"
+    assert call_kwargs["azure_endpoint"] == "https://test-endpoint.openai.azure.com"
     assert call_kwargs["api_version"] == "2023-12-01-preview"
     assert call_kwargs["temperature"] == 0.8
     assert call_kwargs["max_tokens"] == 150

--- a/tests/providers/test_base_url_normalization.py
+++ b/tests/providers/test_base_url_normalization.py
@@ -342,3 +342,59 @@ def test_xai_tts_base_url_env_var_trailing_slash_stripped(monkeypatch):
 
     model = XAITextToSpeechModel()
     assert model.base_url == "https://xai.example.com/v1"
+
+
+def _azure_env(monkeypatch, modality_suffix: str) -> None:
+    """Set common Azure env vars with trailing slash on the endpoint."""
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv(
+        "AZURE_OPENAI_ENDPOINT",
+        "https://test-endpoint.openai.azure.com/",
+    )
+    monkeypatch.setenv("AZURE_OPENAI_API_VERSION", f"2024-{modality_suffix}-01")
+
+
+def test_azure_llm_endpoint_trailing_slash_stripped(monkeypatch):
+    _azure_env(monkeypatch, "01")
+    monkeypatch.setenv("OPENAI_API_VERSION", "2024-01-01")
+    from esperanto.providers.llm.azure import AzureLanguageModel
+
+    model = AzureLanguageModel(model_name="test-deployment")
+    assert model.azure_endpoint == "https://test-endpoint.openai.azure.com"
+
+
+def test_azure_llm_endpoint_via_base_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.delenv("AZURE_OPENAI_ENDPOINT", raising=False)
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-01-01")
+    from esperanto.providers.llm.azure import AzureLanguageModel
+
+    model = AzureLanguageModel(
+        model_name="test-deployment",
+        base_url="https://direct-endpoint.com/",
+    )
+    assert model.azure_endpoint == "https://direct-endpoint.com"
+
+
+def test_azure_embedding_endpoint_trailing_slash_stripped(monkeypatch):
+    _azure_env(monkeypatch, "02")
+    from esperanto.providers.embedding.azure import AzureEmbeddingModel
+
+    model = AzureEmbeddingModel(model_name="test-deployment")
+    assert model.azure_endpoint == "https://test-endpoint.openai.azure.com"
+
+
+def test_azure_stt_endpoint_trailing_slash_stripped(monkeypatch):
+    _azure_env(monkeypatch, "03")
+    from esperanto.providers.stt.azure import AzureSpeechToTextModel
+
+    model = AzureSpeechToTextModel(model_name="test-deployment")
+    assert model.azure_endpoint == "https://test-endpoint.openai.azure.com"
+
+
+def test_azure_tts_endpoint_trailing_slash_stripped(monkeypatch):
+    _azure_env(monkeypatch, "04")
+    from esperanto.providers.tts.azure import AzureTextToSpeechModel
+
+    model = AzureTextToSpeechModel(model_name="test-deployment")
+    assert model.azure_endpoint == "https://test-endpoint.openai.azure.com"

--- a/tests/providers/test_base_url_normalization.py
+++ b/tests/providers/test_base_url_normalization.py
@@ -264,6 +264,14 @@ def test_groq_stt_base_url_trailing_slash_stripped(monkeypatch):
     assert model.base_url == "https://api.groq.com/openai/v1"
 
 
+def test_mistral_stt_base_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
+    from esperanto.providers.stt.mistral import MistralSpeechToTextModel
+
+    model = MistralSpeechToTextModel(base_url="https://api.mistral.ai/v1/")
+    assert model.base_url == "https://api.mistral.ai/v1"
+
+
 def test_openai_stt_base_url_trailing_slash_stripped(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     from esperanto.providers.stt.openai import OpenAISpeechToTextModel

--- a/tests/providers/test_base_url_normalization.py
+++ b/tests/providers/test_base_url_normalization.py
@@ -1,0 +1,336 @@
+"""Tests for base URL trailing slash normalization across providers (issue #149).
+
+Every provider that composes endpoint URLs from ``self.base_url`` must strip
+trailing slashes to avoid accidental double-slashes in the composed URL when a
+user (or environment variable) supplies a ``base_url`` that ends with ``/``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _assert_no_trailing_slash(base_url: str) -> None:
+    """Assert that a base_url does not end with a slash."""
+    assert base_url, "base_url must be set"
+    assert not base_url.endswith("/"), f"base_url should not end with '/': {base_url!r}"
+
+
+# ---------------------------------------------------------------------------
+# LLM providers
+# ---------------------------------------------------------------------------
+
+
+def test_anthropic_llm_base_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    from esperanto.providers.llm.anthropic import AnthropicLanguageModel
+
+    model = AnthropicLanguageModel(base_url="https://api.anthropic.com/v1/")
+    assert model.base_url == "https://api.anthropic.com/v1"
+
+
+def test_anthropic_llm_base_url_default_has_no_trailing_slash(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    from esperanto.providers.llm.anthropic import AnthropicLanguageModel
+
+    model = AnthropicLanguageModel()
+    _assert_no_trailing_slash(model.base_url)
+
+
+def test_google_llm_base_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+    monkeypatch.setenv("GEMINI_API_BASE_URL", "https://gemini.example.com/")
+    from esperanto.providers.llm.google import GoogleLanguageModel
+
+    model = GoogleLanguageModel()
+    assert model.base_url == "https://gemini.example.com/v1beta"
+
+
+def test_google_llm_base_url_default_has_no_trailing_slash(monkeypatch):
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+    monkeypatch.delenv("GEMINI_API_BASE_URL", raising=False)
+    from esperanto.providers.llm.google import GoogleLanguageModel
+
+    model = GoogleLanguageModel()
+    _assert_no_trailing_slash(model.base_url)
+
+
+def test_groq_llm_base_url_default_has_no_trailing_slash(monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    from esperanto.providers.llm.groq import GroqLanguageModel
+
+    # Groq LLM hardcodes its base_url; this still asserts the invariant holds.
+    model = GroqLanguageModel()
+    _assert_no_trailing_slash(model.base_url)
+
+
+def test_mistral_llm_base_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
+    from esperanto.providers.llm.mistral import MistralLanguageModel
+
+    model = MistralLanguageModel(base_url="https://api.mistral.ai/v1/")
+    assert model.base_url == "https://api.mistral.ai/v1"
+
+
+def test_openai_llm_base_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    from esperanto.providers.llm.openai import OpenAILanguageModel
+
+    model = OpenAILanguageModel(base_url="https://api.openai.com/v1/")
+    assert model.base_url == "https://api.openai.com/v1"
+
+
+def test_openai_llm_base_url_multiple_trailing_slashes_stripped(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    from esperanto.providers.llm.openai import OpenAILanguageModel
+
+    model = OpenAILanguageModel(base_url="https://api.openai.com/v1///")
+    assert model.base_url == "https://api.openai.com/v1"
+
+
+def test_openrouter_llm_base_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    from esperanto.providers.llm.openrouter import OpenRouterLanguageModel
+
+    model = OpenRouterLanguageModel(base_url="https://openrouter.ai/api/v1/")
+    assert model.base_url == "https://openrouter.ai/api/v1"
+
+
+def test_openrouter_llm_base_url_env_var_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.setenv("OPENROUTER_BASE_URL", "https://router.example.com/api/v1/")
+    from esperanto.providers.llm.openrouter import OpenRouterLanguageModel
+
+    model = OpenRouterLanguageModel()
+    assert model.base_url == "https://router.example.com/api/v1"
+
+
+def test_perplexity_llm_base_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "test-key")
+    monkeypatch.delenv("PERPLEXITY_BASE_URL", raising=False)
+    from esperanto.providers.llm.perplexity import PerplexityLanguageModel
+
+    model = PerplexityLanguageModel(base_url="https://api.perplexity.ai/")
+    assert model.base_url == "https://api.perplexity.ai"
+
+
+def test_vertex_llm_base_url_default_has_no_trailing_slash(monkeypatch):
+    monkeypatch.setenv("VERTEX_PROJECT", "test-project")
+    monkeypatch.setenv("VERTEX_LOCATION", "us-central1")
+    # Mock google.auth.default to avoid real ADC pickup
+    with patch("google.auth.default") as mock_default:
+        mock_creds = MagicMock()
+        mock_creds.valid = True
+        mock_creds.token = "mock-token"
+        mock_default.return_value = (mock_creds, "test-project")
+        from esperanto.providers.llm.vertex import VertexLanguageModel
+
+        model = VertexLanguageModel(model_name="gemini-2.0-flash")
+        _assert_no_trailing_slash(model.base_url)
+
+
+# ---------------------------------------------------------------------------
+# Embedding providers
+# ---------------------------------------------------------------------------
+
+
+def test_google_embedding_base_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+    monkeypatch.setenv("GEMINI_API_BASE_URL", "https://gemini.example.com/")
+    from esperanto.providers.embedding.google import GoogleEmbeddingModel
+
+    model = GoogleEmbeddingModel()
+    assert model.base_url == "https://gemini.example.com/v1beta"
+
+
+def test_jina_embedding_base_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("JINA_API_KEY", "test-key")
+    from esperanto.providers.embedding.jina import JinaEmbeddingModel
+
+    model = JinaEmbeddingModel(base_url="https://api.jina.ai/v1/embeddings/")
+    assert model.base_url == "https://api.jina.ai/v1/embeddings"
+
+
+def test_mistral_embedding_base_url_default_has_no_trailing_slash(monkeypatch):
+    monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
+    from esperanto.providers.embedding.mistral import MistralEmbeddingModel
+
+    model = MistralEmbeddingModel()
+    _assert_no_trailing_slash(model.base_url)
+
+
+def test_ollama_embedding_base_url_trailing_slash_stripped():
+    from esperanto.providers.embedding.ollama import OllamaEmbeddingModel
+
+    model = OllamaEmbeddingModel(base_url="http://localhost:11434/")
+    assert model.base_url == "http://localhost:11434"
+
+
+def test_ollama_embedding_base_url_env_var_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://env:11434/")
+    from esperanto.providers.embedding.ollama import OllamaEmbeddingModel
+
+    model = OllamaEmbeddingModel()
+    assert model.base_url == "http://env:11434"
+
+
+def test_openai_embedding_base_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    from esperanto.providers.embedding.openai import OpenAIEmbeddingModel
+
+    model = OpenAIEmbeddingModel(base_url="https://api.openai.com/v1/")
+    assert model.base_url == "https://api.openai.com/v1"
+
+
+def test_openrouter_embedding_base_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    from esperanto.providers.embedding.openrouter import OpenRouterEmbeddingModel
+
+    model = OpenRouterEmbeddingModel(base_url="https://openrouter.ai/api/v1/")
+    assert model.base_url == "https://openrouter.ai/api/v1"
+
+
+def test_vertex_embedding_base_url_default_has_no_trailing_slash(monkeypatch):
+    monkeypatch.setenv("VERTEX_PROJECT", "test-project")
+    monkeypatch.setenv("VERTEX_LOCATION", "us-central1")
+    from esperanto.providers.embedding.vertex import VertexEmbeddingModel
+
+    model = VertexEmbeddingModel()
+    _assert_no_trailing_slash(model.base_url)
+
+
+def test_voyage_embedding_base_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("VOYAGE_API_KEY", "test-key")
+    from esperanto.providers.embedding.voyage import VoyageEmbeddingModel
+
+    model = VoyageEmbeddingModel(base_url="https://api.voyageai.com/v1/")
+    assert model.base_url == "https://api.voyageai.com/v1"
+
+
+# ---------------------------------------------------------------------------
+# Reranker providers
+# ---------------------------------------------------------------------------
+
+
+def test_jina_reranker_base_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("JINA_API_KEY", "test-key")
+    from esperanto.providers.reranker.jina import JinaRerankerModel
+
+    model = JinaRerankerModel(base_url="https://api.jina.ai/v1/")
+    assert model.base_url == "https://api.jina.ai/v1"
+
+
+def test_voyage_reranker_base_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("VOYAGE_API_KEY", "test-key")
+    from esperanto.providers.reranker.voyage import VoyageRerankerModel
+
+    model = VoyageRerankerModel(base_url="https://api.voyageai.com/v1/")
+    assert model.base_url == "https://api.voyageai.com/v1"
+
+
+# ---------------------------------------------------------------------------
+# Speech-to-Text providers
+# ---------------------------------------------------------------------------
+
+
+def test_elevenlabs_stt_base_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("ELEVENLABS_API_KEY", "test-key")
+    from esperanto.providers.stt.elevenlabs import ElevenLabsSpeechToTextModel
+
+    model = ElevenLabsSpeechToTextModel(base_url="https://api.elevenlabs.io/v1/")
+    assert model.base_url == "https://api.elevenlabs.io/v1"
+
+
+def test_google_stt_base_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+    monkeypatch.setenv("GEMINI_API_BASE_URL", "https://gemini.example.com/")
+    from esperanto.providers.stt.google import GoogleSpeechToTextModel
+
+    model = GoogleSpeechToTextModel()
+    assert model.base_url == "https://gemini.example.com/v1beta"
+
+
+def test_groq_stt_base_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    from esperanto.providers.stt.groq import GroqSpeechToTextModel
+
+    model = GroqSpeechToTextModel(base_url="https://api.groq.com/openai/v1/")
+    assert model.base_url == "https://api.groq.com/openai/v1"
+
+
+def test_openai_stt_base_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    from esperanto.providers.stt.openai import OpenAISpeechToTextModel
+
+    model = OpenAISpeechToTextModel(base_url="https://api.openai.com/v1/")
+    assert model.base_url == "https://api.openai.com/v1"
+
+
+# ---------------------------------------------------------------------------
+# Text-to-Speech providers
+# ---------------------------------------------------------------------------
+
+
+def test_elevenlabs_tts_base_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("ELEVENLABS_API_KEY", "test-key")
+    from esperanto.providers.tts.elevenlabs import ElevenLabsTextToSpeechModel
+
+    model = ElevenLabsTextToSpeechModel(base_url="https://api.elevenlabs.io/")
+    assert model.base_url == "https://api.elevenlabs.io"
+
+
+def test_google_tts_base_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+    monkeypatch.setenv("GEMINI_API_BASE_URL", "https://gemini.example.com/")
+    from esperanto.providers.tts.google import GoogleTextToSpeechModel
+
+    model = GoogleTextToSpeechModel()
+    assert model.base_url == "https://gemini.example.com/v1beta"
+
+
+def test_mistral_tts_base_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
+    from esperanto.providers.tts.mistral import MistralTextToSpeechModel
+
+    model = MistralTextToSpeechModel(base_url="https://api.mistral.ai/v1/")
+    assert model.base_url == "https://api.mistral.ai/v1"
+
+
+def test_openai_tts_base_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    from esperanto.providers.tts.openai import OpenAITextToSpeechModel
+
+    model = OpenAITextToSpeechModel(base_url="https://api.openai.com/v1/")
+    assert model.base_url == "https://api.openai.com/v1"
+
+
+def test_vertex_tts_base_url_default_has_no_trailing_slash(monkeypatch):
+    monkeypatch.setenv("VERTEX_PROJECT", "test-project")
+    from esperanto.providers.tts.vertex import VertexTextToSpeechModel
+
+    model = VertexTextToSpeechModel()
+    _assert_no_trailing_slash(model.base_url)
+
+
+def test_xai_tts_base_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("XAI_API_KEY", "test-key")
+    monkeypatch.delenv("XAI_BASE_URL", raising=False)
+    from esperanto.providers.tts.xai import XAITextToSpeechModel
+
+    model = XAITextToSpeechModel(base_url="https://api.x.ai/")
+    assert model.base_url == "https://api.x.ai"
+
+
+def test_xai_tts_base_url_env_var_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("XAI_API_KEY", "test-key")
+    monkeypatch.setenv("XAI_BASE_URL", "https://xai.example.com/v1/")
+    from esperanto.providers.tts.xai import XAITextToSpeechModel
+
+    model = XAITextToSpeechModel()
+    assert model.base_url == "https://xai.example.com/v1"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes: https://github.com/lfnovo/esperanto/issues/149

#### What does this implement/fix? Explain your changes.
This is a very small change to remove trailing '/' from base url values for providers.

#### Any other comments?
Unit test added for the same across.

<!--
Thanks for contributing!
-->