### PR TITLE
feat(llm): add per-call max_tokens, temperature, top_p overrides to all providers (closes #102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Per-call `max_tokens`, `temperature`, `top_p` overrides** — `chat_complete()` and `achat_complete()` now accept `max_tokens`, `temperature`, and `top_p` keyword arguments that override the instance-level values for a single request. Supported by all LLM providers. For Anthropic, `top_p` is silently dropped when `temperature` is also set, consistent with the mutual-exclusivity rule enforced by that provider's API.
 - **Mistral TTS provider** — `MistralTextToSpeechModel` using the Voxtral (`voxtral-mini-tts-2603`) model. Supports `pcm`, `wav`, `mp3`, `flac`, and `opus` response formats. Reuses the existing `MISTRAL_API_KEY` environment variable. Voice discovery via `available_voices` calls `GET /v1/audio/voices`.
 - **Mistral Speech-to-Text provider** — new `MistralSpeechToTextModel` supporting `voxtral-mini-latest` (default) and `voxtral-small-latest`. Unlike OpenAI Whisper, Mistral returns the detected language in the response body, which is surfaced as `TranscriptionResponse.language`. Accessible via `AIFactory.create_stt("mistral")`.
 - **Mistral Speech-to-Text provider** — new `MistralSpeechToTextModel` supporting `voxtral-mini-latest` (default) and `voxtral-small-latest`. Unlike OpenAI Whisper, Mistral returns the detected language in the response body, which is surfaced as `TranscriptionResponse.language`. Accessible via `AIFactory.create_speech_to_text("mistral")`.

--- a/src/esperanto/providers/llm/anthropic.py
+++ b/src/esperanto/providers/llm/anthropic.py
@@ -656,6 +656,14 @@ class AnthropicLanguageModel(LanguageModel):
             temperature: Per-call override for temperature. If None, uses instance value.
             top_p: Per-call override for top_p. If None, uses instance value.
 
+                Note: Anthropic rejects API requests where both ``temperature``
+                and ``top_p`` are set (see issue #100). When the resolved
+                payload contains both, ``top_p`` is silently dropped (with a
+                DEBUG log) regardless of which side (instance or per-call)
+                supplied each value. To force a per-call ``top_p`` to win,
+                pass ``temperature=None`` explicitly on the call to disable
+                the instance-level temperature for that request.
+
         Returns:
             Either a ChatCompletion or a Generator yielding ChatCompletionChunks
             if streaming. When the model calls tools, the response message will
@@ -748,6 +756,14 @@ class AnthropicLanguageModel(LanguageModel):
             max_tokens: Per-call override for max_tokens. If None, uses instance value.
             temperature: Per-call override for temperature. If None, uses instance value.
             top_p: Per-call override for top_p. If None, uses instance value.
+
+                Note: Anthropic rejects API requests where both ``temperature``
+                and ``top_p`` are set (see issue #100). When the resolved
+                payload contains both, ``top_p`` is silently dropped (with a
+                DEBUG log) regardless of which side (instance or per-call)
+                supplied each value. To force a per-call ``top_p`` to win,
+                pass ``temperature=None`` explicitly on the call to disable
+                the instance-level temperature for that request.
 
         Returns:
             Either a ChatCompletion or an AsyncGenerator yielding ChatCompletionChunks

--- a/src/esperanto/providers/llm/anthropic.py
+++ b/src/esperanto/providers/llm/anthropic.py
@@ -560,6 +560,9 @@ class AnthropicLanguageModel(LanguageModel):
         tools: Optional[List[Tool]] = None,
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Dict[str, Any]:
         """Create request payload for Anthropic API.
 
@@ -569,16 +572,23 @@ class AnthropicLanguageModel(LanguageModel):
             tools: List of tools the model can call.
             tool_choice: Controls tool usage.
             parallel_tool_calls: Whether to allow parallel tool calls.
+            max_tokens: Per-call override for max_tokens.
+            temperature: Per-call override for temperature.
+            top_p: Per-call override for top_p.
 
         Returns:
             Request payload dict for Anthropic API.
         """
         system_message, formatted_messages = self._prepare_messages(messages)
 
+        effective_max_tokens = max_tokens if max_tokens is not None else self.max_tokens
+        effective_temperature = temperature if temperature is not None else self.temperature
+        effective_top_p = top_p if top_p is not None else self.top_p
+
         payload: Dict[str, Any] = {
             "model": self.get_model_name(),
             "messages": formatted_messages,
-            "max_tokens": self.max_tokens or 1024,
+            "max_tokens": effective_max_tokens or 1024,
         }
 
         if system_message:
@@ -586,14 +596,14 @@ class AnthropicLanguageModel(LanguageModel):
 
         # Anthropic does not allow both temperature and top_p to be set
         # Prioritize temperature if both are provided
-        if self.temperature is not None:
-            if self.top_p is not None:
+        if effective_temperature is not None:
+            if effective_top_p is not None:
                 logger.debug(
                     "Dropping top_p — Anthropic recommends setting only temperature OR top_p, not both."
                 )
-            payload["temperature"] = max(0.0, min(1.0, float(self.temperature)))
-        elif self.top_p is not None:
-            payload["top_p"] = float(self.top_p)
+            payload["temperature"] = max(0.0, min(1.0, float(effective_temperature)))
+        elif effective_top_p is not None:
+            payload["top_p"] = float(effective_top_p)
 
         if stream:
             payload["stream"] = True
@@ -619,6 +629,9 @@ class AnthropicLanguageModel(LanguageModel):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
         validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Union[ChatCompletion, Generator[ChatCompletionChunk, None, None]]:
         """Send a chat completion request.
 
@@ -639,6 +652,9 @@ class AnthropicLanguageModel(LanguageModel):
             validate_tool_calls: If True, validate tool call arguments against the
                 tool's JSON schema. Raises ToolCallValidationError on validation
                 failure. Requires jsonschema package.
+            max_tokens: Per-call override for max_tokens. If None, uses instance value.
+            temperature: Per-call override for temperature. If None, uses instance value.
+            top_p: Per-call override for top_p. If None, uses instance value.
 
         Returns:
             Either a ChatCompletion or a Generator yielding ChatCompletionChunks
@@ -649,6 +665,11 @@ class AnthropicLanguageModel(LanguageModel):
         self._warn_if_validate_with_streaming(validate_tool_calls, stream)
 
         should_stream = stream if stream is not None else self.streaming
+
+        # Resolve per-call overrides
+        effective_max_tokens = self._resolve_max_tokens(max_tokens)
+        effective_temperature = self._resolve_temperature(temperature)
+        effective_top_p = self._resolve_top_p(top_p)
 
         # Resolve tool configuration
         resolved_tools = self._resolve_tools(tools)
@@ -661,6 +682,9 @@ class AnthropicLanguageModel(LanguageModel):
             tools=resolved_tools,
             tool_choice=resolved_tool_choice,
             parallel_tool_calls=resolved_parallel,
+            max_tokens=effective_max_tokens,
+            temperature=effective_temperature,
+            top_p=effective_top_p,
         )
 
         # Make HTTP request
@@ -698,6 +722,9 @@ class AnthropicLanguageModel(LanguageModel):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
         validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Union[ChatCompletion, AsyncGenerator[ChatCompletionChunk, None]]:
         """Send an async chat completion request.
 
@@ -718,6 +745,9 @@ class AnthropicLanguageModel(LanguageModel):
             validate_tool_calls: If True, validate tool call arguments against the
                 tool's JSON schema. Raises ToolCallValidationError on validation
                 failure. Requires jsonschema package.
+            max_tokens: Per-call override for max_tokens. If None, uses instance value.
+            temperature: Per-call override for temperature. If None, uses instance value.
+            top_p: Per-call override for top_p. If None, uses instance value.
 
         Returns:
             Either a ChatCompletion or an AsyncGenerator yielding ChatCompletionChunks
@@ -728,6 +758,11 @@ class AnthropicLanguageModel(LanguageModel):
         self._warn_if_validate_with_streaming(validate_tool_calls, stream)
 
         should_stream = stream if stream is not None else self.streaming
+
+        # Resolve per-call overrides
+        effective_max_tokens = self._resolve_max_tokens(max_tokens)
+        effective_temperature = self._resolve_temperature(temperature)
+        effective_top_p = self._resolve_top_p(top_p)
 
         # Resolve tool configuration
         resolved_tools = self._resolve_tools(tools)
@@ -740,6 +775,9 @@ class AnthropicLanguageModel(LanguageModel):
             tools=resolved_tools,
             tool_choice=resolved_tool_choice,
             parallel_tool_calls=resolved_parallel,
+            max_tokens=effective_max_tokens,
+            temperature=effective_temperature,
+            top_p=effective_top_p,
         )
 
         # Make async HTTP request

--- a/src/esperanto/providers/llm/anthropic.py
+++ b/src/esperanto/providers/llm/anthropic.py
@@ -659,10 +659,12 @@ class AnthropicLanguageModel(LanguageModel):
                 Note: Anthropic rejects API requests where both ``temperature``
                 and ``top_p`` are set (see issue #100). When the resolved
                 payload contains both, ``top_p`` is silently dropped (with a
-                DEBUG log) regardless of which side (instance or per-call)
-                supplied each value. To force a per-call ``top_p`` to win,
-                pass ``temperature=None`` explicitly on the call to disable
-                the instance-level temperature for that request.
+                DEBUG log). Per-call values participate in the conflict on
+                the same footing as instance values — there is no per-call
+                way to disable an instance-level ``temperature``. If you need
+                to use ``top_p`` exclusively, construct the model without
+                ``temperature`` (or set ``model.temperature = None``) before
+                calling chat_complete.
 
         Returns:
             Either a ChatCompletion or a Generator yielding ChatCompletionChunks
@@ -760,10 +762,12 @@ class AnthropicLanguageModel(LanguageModel):
                 Note: Anthropic rejects API requests where both ``temperature``
                 and ``top_p`` are set (see issue #100). When the resolved
                 payload contains both, ``top_p`` is silently dropped (with a
-                DEBUG log) regardless of which side (instance or per-call)
-                supplied each value. To force a per-call ``top_p`` to win,
-                pass ``temperature=None`` explicitly on the call to disable
-                the instance-level temperature for that request.
+                DEBUG log). Per-call values participate in the conflict on
+                the same footing as instance values — there is no per-call
+                way to disable an instance-level ``temperature``. If you need
+                to use ``top_p`` exclusively, construct the model without
+                ``temperature`` (or set ``model.temperature = None``) before
+                calling chat_complete.
 
         Returns:
             Either a ChatCompletion or an AsyncGenerator yielding ChatCompletionChunks

--- a/src/esperanto/providers/llm/azure.py
+++ b/src/esperanto/providers/llm/azure.py
@@ -271,6 +271,10 @@ class AzureLanguageModel(LanguageModel):
         """Get kwargs for Azure API calls, using current instance attributes and overrides."""
         is_reasoning_model = self._is_reasoning_model()
 
+        # Track per-call explicit overrides so the magic-default skip below
+        # does not silently drop them (issue #102 + cubic feedback).
+        max_tokens_explicit = max_tokens is not None
+
         effective_max_tokens = max_tokens if max_tokens is not None else self.max_tokens
         effective_temperature = temperature if temperature is not None else self.temperature
         effective_top_p = top_p if top_p is not None else self.top_p
@@ -281,8 +285,9 @@ class AzureLanguageModel(LanguageModel):
 
         # Handle token parameters
         if is_reasoning_model:
-            # Skip max_tokens if it's the default value (850) for reasoning models
-            if effective_max_tokens != 850:
+            # Skip max_tokens if it's the instance default (850) on reasoning models
+            # AND was not explicitly supplied as a per-call override.
+            if effective_max_tokens != 850 or max_tokens_explicit:
                 effective_kwargs["max_completion_tokens"] = effective_max_tokens
         else:
             effective_kwargs["max_tokens"] = effective_max_tokens
@@ -387,9 +392,8 @@ class AzureLanguageModel(LanguageModel):
             call_override_kwargs["stream"] = stream
 
         # Resolve per-call overrides
-        effective_max_tokens = self._resolve_max_tokens(max_tokens)
-        effective_temperature = self._resolve_temperature(temperature)
-        effective_top_p = self._resolve_top_p(top_p)
+        # Per-call values flow raw into _get_api_kwargs which tracks
+        # explicit-ness for the magic-default skip (issue #102 + cubic feedback).
 
         # Resolve tool configuration
         resolved_tools = self._resolve_tools(tools)
@@ -398,9 +402,9 @@ class AzureLanguageModel(LanguageModel):
 
         api_kwargs = self._get_api_kwargs(
             override_kwargs=call_override_kwargs,
-            max_tokens=effective_max_tokens,
-            temperature=effective_temperature,
-            top_p=effective_top_p,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
         )
         effective_stream_setting = api_kwargs.pop("stream", False)
 
@@ -497,9 +501,8 @@ class AzureLanguageModel(LanguageModel):
             call_override_kwargs["stream"] = stream
 
         # Resolve per-call overrides
-        effective_max_tokens = self._resolve_max_tokens(max_tokens)
-        effective_temperature = self._resolve_temperature(temperature)
-        effective_top_p = self._resolve_top_p(top_p)
+        # Per-call values flow raw into _get_api_kwargs which tracks
+        # explicit-ness for the magic-default skip (issue #102 + cubic feedback).
 
         # Resolve tool configuration
         resolved_tools = self._resolve_tools(tools)
@@ -508,9 +511,9 @@ class AzureLanguageModel(LanguageModel):
 
         api_kwargs = self._get_api_kwargs(
             override_kwargs=call_override_kwargs,
-            max_tokens=effective_max_tokens,
-            temperature=effective_temperature,
-            top_p=effective_top_p,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
         )
         effective_stream_setting = api_kwargs.pop("stream", False)
 

--- a/src/esperanto/providers/llm/azure.py
+++ b/src/esperanto/providers/llm/azure.py
@@ -262,10 +262,18 @@ class AzureLanguageModel(LanguageModel):
                 model_name.startswith("gpt-5"))
 
     def _get_api_kwargs(
-        self, override_kwargs: Optional[Dict[str, Any]] = None
+        self,
+        override_kwargs: Optional[Dict[str, Any]] = None,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Dict[str, Any]:
         """Get kwargs for Azure API calls, using current instance attributes and overrides."""
         is_reasoning_model = self._is_reasoning_model()
+
+        effective_max_tokens = max_tokens if max_tokens is not None else self.max_tokens
+        effective_temperature = temperature if temperature is not None else self.temperature
+        effective_top_p = top_p if top_p is not None else self.top_p
 
         effective_kwargs = {
             "model": self.deployment_name,
@@ -274,15 +282,15 @@ class AzureLanguageModel(LanguageModel):
         # Handle token parameters
         if is_reasoning_model:
             # Skip max_tokens if it's the default value (850) for reasoning models
-            if self.max_tokens != 850:
-                effective_kwargs["max_completion_tokens"] = self.max_tokens
+            if effective_max_tokens != 850:
+                effective_kwargs["max_completion_tokens"] = effective_max_tokens
         else:
-            effective_kwargs["max_tokens"] = self.max_tokens
+            effective_kwargs["max_tokens"] = effective_max_tokens
 
         # Handle temperature and top_p - reasoning models don't support these
         if not is_reasoning_model:
-            effective_kwargs["temperature"] = self.temperature
-            effective_kwargs["top_p"] = self.top_p
+            effective_kwargs["temperature"] = effective_temperature
+            effective_kwargs["top_p"] = effective_top_p
 
         effective_kwargs["stream"] = self.streaming
 
@@ -339,6 +347,9 @@ class AzureLanguageModel(LanguageModel):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
         validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Union[ChatCompletion, Generator[ChatCompletionChunk, None, None]]:
         """Send a chat completion request.
 
@@ -359,6 +370,9 @@ class AzureLanguageModel(LanguageModel):
             validate_tool_calls: If True, validate tool call arguments against the
                 tool's JSON schema. Raises ToolCallValidationError on validation
                 failure. Requires jsonschema package.
+            max_tokens: Per-call override for max_tokens. If None, uses instance value.
+            temperature: Per-call override for temperature. If None, uses instance value.
+            top_p: Per-call override for top_p. If None, uses instance value.
 
         Returns:
             Either a ChatCompletion or a Generator yielding ChatCompletionChunks
@@ -372,12 +386,22 @@ class AzureLanguageModel(LanguageModel):
         if stream is not None:
             call_override_kwargs["stream"] = stream
 
+        # Resolve per-call overrides
+        effective_max_tokens = self._resolve_max_tokens(max_tokens)
+        effective_temperature = self._resolve_temperature(temperature)
+        effective_top_p = self._resolve_top_p(top_p)
+
         # Resolve tool configuration
         resolved_tools = self._resolve_tools(tools)
         resolved_tool_choice = self._resolve_tool_choice(tool_choice)
         resolved_parallel = self._resolve_parallel_tool_calls(parallel_tool_calls)
 
-        api_kwargs = self._get_api_kwargs(override_kwargs=call_override_kwargs)
+        api_kwargs = self._get_api_kwargs(
+            override_kwargs=call_override_kwargs,
+            max_tokens=effective_max_tokens,
+            temperature=effective_temperature,
+            top_p=effective_top_p,
+        )
         effective_stream_setting = api_kwargs.pop("stream", False)
 
         # Add tool-related parameters if configured
@@ -433,6 +457,9 @@ class AzureLanguageModel(LanguageModel):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
         validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Union[ChatCompletion, AsyncGenerator[ChatCompletionChunk, None]]:
         """Send an async chat completion request.
 
@@ -453,6 +480,9 @@ class AzureLanguageModel(LanguageModel):
             validate_tool_calls: If True, validate tool call arguments against the
                 tool's JSON schema. Raises ToolCallValidationError on validation
                 failure. Requires jsonschema package.
+            max_tokens: Per-call override for max_tokens. If None, uses instance value.
+            temperature: Per-call override for temperature. If None, uses instance value.
+            top_p: Per-call override for top_p. If None, uses instance value.
 
         Returns:
             Either a ChatCompletion or an AsyncGenerator yielding ChatCompletionChunks
@@ -466,12 +496,22 @@ class AzureLanguageModel(LanguageModel):
         if stream is not None:
             call_override_kwargs["stream"] = stream
 
+        # Resolve per-call overrides
+        effective_max_tokens = self._resolve_max_tokens(max_tokens)
+        effective_temperature = self._resolve_temperature(temperature)
+        effective_top_p = self._resolve_top_p(top_p)
+
         # Resolve tool configuration
         resolved_tools = self._resolve_tools(tools)
         resolved_tool_choice = self._resolve_tool_choice(tool_choice)
         resolved_parallel = self._resolve_parallel_tool_calls(parallel_tool_calls)
 
-        api_kwargs = self._get_api_kwargs(override_kwargs=call_override_kwargs)
+        api_kwargs = self._get_api_kwargs(
+            override_kwargs=call_override_kwargs,
+            max_tokens=effective_max_tokens,
+            temperature=effective_temperature,
+            top_p=effective_top_p,
+        )
         effective_stream_setting = api_kwargs.pop("stream", False)
 
         # Add tool-related parameters if configured

--- a/src/esperanto/providers/llm/base.py
+++ b/src/esperanto/providers/llm/base.py
@@ -142,6 +142,51 @@ class LanguageModel(HttpConnectionMixin, ABC):
             return parallel_tool_calls
         return self.parallel_tool_calls
 
+    def _resolve_max_tokens(self, max_tokens: Optional[int] = None) -> int:
+        """Resolve max_tokens from parameter or instance config.
+
+        Call-time max_tokens takes precedence over instance-level setting.
+
+        Args:
+            max_tokens: max_tokens passed at call time, or None to use instance value.
+
+        Returns:
+            The resolved max_tokens value.
+        """
+        if max_tokens is not None:
+            return max_tokens
+        return self.max_tokens
+
+    def _resolve_temperature(self, temperature: Optional[float] = None) -> float:
+        """Resolve temperature from parameter or instance config.
+
+        Call-time temperature takes precedence over instance-level setting.
+
+        Args:
+            temperature: temperature passed at call time, or None to use instance value.
+
+        Returns:
+            The resolved temperature value.
+        """
+        if temperature is not None:
+            return temperature
+        return self.temperature
+
+    def _resolve_top_p(self, top_p: Optional[float] = None) -> float:
+        """Resolve top_p from parameter or instance config.
+
+        Call-time top_p takes precedence over instance-level setting.
+
+        Args:
+            top_p: top_p passed at call time, or None to use instance value.
+
+        Returns:
+            The resolved top_p value.
+        """
+        if top_p is not None:
+            return top_p
+        return self.top_p
+
     def _warn_if_validate_with_streaming(
         self,
         validate_tool_calls: bool,
@@ -176,6 +221,9 @@ class LanguageModel(HttpConnectionMixin, ABC):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
         validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Union[ChatCompletion, Generator[ChatCompletionChunk, None, None]]:
         """Send a chat completion request.
 
@@ -196,6 +244,9 @@ class LanguageModel(HttpConnectionMixin, ABC):
             validate_tool_calls: If True, validate tool call arguments against the
                 tool's JSON schema. Raises ToolCallValidationError on validation
                 failure. Requires jsonschema package.
+            max_tokens: Per-call override for max_tokens. If None, uses instance value.
+            temperature: Per-call override for temperature. If None, uses instance value.
+            top_p: Per-call override for top_p. If None, uses instance value.
 
         Returns:
             Either a ChatCompletion or a Generator yielding ChatCompletionChunks
@@ -213,6 +264,9 @@ class LanguageModel(HttpConnectionMixin, ABC):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
         validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Union[ChatCompletion, AsyncGenerator[ChatCompletionChunk, None]]:
         """Send an async chat completion request.
 
@@ -233,6 +287,9 @@ class LanguageModel(HttpConnectionMixin, ABC):
             validate_tool_calls: If True, validate tool call arguments against the
                 tool's JSON schema. Raises ToolCallValidationError on validation
                 failure. Requires jsonschema package.
+            max_tokens: Per-call override for max_tokens. If None, uses instance value.
+            temperature: Per-call override for temperature. If None, uses instance value.
+            top_p: Per-call override for top_p. If None, uses instance value.
 
         Returns:
             Either a ChatCompletion or an AsyncGenerator yielding ChatCompletionChunks

--- a/src/esperanto/providers/llm/google.py
+++ b/src/esperanto/providers/llm/google.py
@@ -250,15 +250,24 @@ class GoogleLanguageModel(LanguageModel):
 
         return formatted, system_instruction
 
-    def _create_generation_config(self) -> Dict[str, Any]:
+    def _create_generation_config(
+        self,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+    ) -> Dict[str, Any]:
         """Create generation config for Google API."""
+        effective_max_tokens = max_tokens if max_tokens is not None else self.max_tokens
+        effective_temperature = temperature if temperature is not None else self.temperature
+        effective_top_p = top_p if top_p is not None else self.top_p
+
         config: Dict[str, Any] = {
-            "temperature": float(self.temperature),
-            "topP": float(self.top_p),
+            "temperature": float(effective_temperature),
+            "topP": float(effective_top_p),
         }
 
-        if self.max_tokens:
-            config["maxOutputTokens"] = int(self.max_tokens)
+        if effective_max_tokens:
+            config["maxOutputTokens"] = int(effective_max_tokens)
 
         if self.structured:
             if not isinstance(self.structured, dict):
@@ -368,6 +377,9 @@ class GoogleLanguageModel(LanguageModel):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
         validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Union[ChatCompletion, Generator[ChatCompletionChunk, None, None]]:
         """Send a chat completion request.
 
@@ -388,6 +400,9 @@ class GoogleLanguageModel(LanguageModel):
             validate_tool_calls: If True, validate tool call arguments against the
                 tool's JSON schema. Raises ToolCallValidationError on validation
                 failure. Requires jsonschema package.
+            max_tokens: Per-call override for max_tokens. If None, uses instance value.
+            temperature: Per-call override for temperature. If None, uses instance value.
+            top_p: Per-call override for top_p. If None, uses instance value.
 
         Returns:
             Either a ChatCompletion or a Generator yielding ChatCompletionChunks
@@ -398,6 +413,11 @@ class GoogleLanguageModel(LanguageModel):
         self._warn_if_validate_with_streaming(validate_tool_calls, stream)
 
         should_stream = stream if stream is not None else self.streaming
+
+        # Resolve per-call overrides
+        effective_max_tokens = self._resolve_max_tokens(max_tokens)
+        effective_temperature = self._resolve_temperature(temperature)
+        effective_top_p = self._resolve_top_p(top_p)
 
         # Resolve tool configuration
         resolved_tools = self._resolve_tools(tools)
@@ -410,7 +430,11 @@ class GoogleLanguageModel(LanguageModel):
         # Prepare request payload
         payload: Dict[str, Any] = {
             "contents": formatted_messages,
-            "generationConfig": self._create_generation_config(),
+            "generationConfig": self._create_generation_config(
+                max_tokens=effective_max_tokens,
+                temperature=effective_temperature,
+                top_p=effective_top_p,
+            ),
         }
 
         if system_instruction:
@@ -616,6 +640,9 @@ class GoogleLanguageModel(LanguageModel):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
         validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Union[ChatCompletion, AsyncGenerator[ChatCompletionChunk, None]]:
         """Send an async chat completion request.
 
@@ -636,6 +663,9 @@ class GoogleLanguageModel(LanguageModel):
             validate_tool_calls: If True, validate tool call arguments against the
                 tool's JSON schema. Raises ToolCallValidationError on validation
                 failure. Requires jsonschema package.
+            max_tokens: Per-call override for max_tokens. If None, uses instance value.
+            temperature: Per-call override for temperature. If None, uses instance value.
+            top_p: Per-call override for top_p. If None, uses instance value.
 
         Returns:
             Either a ChatCompletion or an AsyncGenerator yielding ChatCompletionChunks
@@ -646,6 +676,11 @@ class GoogleLanguageModel(LanguageModel):
         self._warn_if_validate_with_streaming(validate_tool_calls, stream)
 
         should_stream = stream if stream is not None else self.streaming
+
+        # Resolve per-call overrides
+        effective_max_tokens = self._resolve_max_tokens(max_tokens)
+        effective_temperature = self._resolve_temperature(temperature)
+        effective_top_p = self._resolve_top_p(top_p)
 
         # Resolve tool configuration
         resolved_tools = self._resolve_tools(tools)
@@ -658,7 +693,11 @@ class GoogleLanguageModel(LanguageModel):
         # Prepare request payload
         payload: Dict[str, Any] = {
             "contents": formatted_messages,
-            "generationConfig": self._create_generation_config(),
+            "generationConfig": self._create_generation_config(
+                max_tokens=effective_max_tokens,
+                temperature=effective_temperature,
+                top_p=effective_top_p,
+            ),
         }
 
         if system_instruction:

--- a/src/esperanto/providers/llm/groq.py
+++ b/src/esperanto/providers/llm/groq.py
@@ -230,6 +230,10 @@ class GroqLanguageModel(LanguageModel):
         kwargs = {}
         config = self.get_completion_kwargs()
 
+        # Track per-call explicit overrides so the magic-default skip below
+        # does not silently drop them (issue #102 + cubic feedback).
+        max_tokens_explicit = max_tokens is not None
+
         if max_tokens is not None:
             config["max_tokens"] = max_tokens
         if temperature is not None:
@@ -250,8 +254,9 @@ class GroqLanguageModel(LanguageModel):
                 "tool_choice",
                 "parallel_tool_calls",
             ]:
-                # Skip max_tokens if it's the default value (850)
-                if key == "max_tokens" and value == 850:
+                # Skip max_tokens if it's the instance default (850) and was not
+                # explicitly supplied as a per-call override.
+                if key == "max_tokens" and value == 850 and not max_tokens_explicit:
                     continue
                 kwargs[key] = value
 
@@ -311,9 +316,8 @@ class GroqLanguageModel(LanguageModel):
         # Warn if validate_tool_calls is used with streaming
         self._warn_if_validate_with_streaming(validate_tool_calls, stream)
 
-        effective_max_tokens = self._resolve_max_tokens(max_tokens)
-        effective_temperature = self._resolve_temperature(temperature)
-        effective_top_p = self._resolve_top_p(top_p)
+        # Per-call values flow raw into _get_api_kwargs which tracks
+        # explicit-ness for the magic-default skip (issue #102 + cubic feedback).
 
         should_stream = stream if stream is not None else self.streaming
 
@@ -329,9 +333,9 @@ class GroqLanguageModel(LanguageModel):
             "stream": should_stream,
             **self._get_api_kwargs(
                 exclude_stream=True,
-                max_tokens=effective_max_tokens,
-                temperature=effective_temperature,
-                top_p=effective_top_p,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
             ),
         }
 
@@ -405,9 +409,8 @@ class GroqLanguageModel(LanguageModel):
         # Warn if validate_tool_calls is used with streaming
         self._warn_if_validate_with_streaming(validate_tool_calls, stream)
 
-        effective_max_tokens = self._resolve_max_tokens(max_tokens)
-        effective_temperature = self._resolve_temperature(temperature)
-        effective_top_p = self._resolve_top_p(top_p)
+        # Per-call values flow raw into _get_api_kwargs which tracks
+        # explicit-ness for the magic-default skip (issue #102 + cubic feedback).
 
         should_stream = stream if stream is not None else self.streaming
 
@@ -423,9 +426,9 @@ class GroqLanguageModel(LanguageModel):
             "stream": should_stream,
             **self._get_api_kwargs(
                 exclude_stream=True,
-                max_tokens=effective_max_tokens,
-                temperature=effective_temperature,
-                top_p=effective_top_p,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
             ),
         }
 

--- a/src/esperanto/providers/llm/groq.py
+++ b/src/esperanto/providers/llm/groq.py
@@ -219,10 +219,23 @@ class GroqLanguageModel(LanguageModel):
                     except json.JSONDecodeError:
                         continue
 
-    def _get_api_kwargs(self, exclude_stream: bool = False) -> Dict[str, Any]:
+    def _get_api_kwargs(
+        self,
+        exclude_stream: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+    ) -> Dict[str, Any]:
         """Get kwargs for API calls, filtering out provider-specific args."""
         kwargs = {}
         config = self.get_completion_kwargs()
+
+        if max_tokens is not None:
+            config["max_tokens"] = max_tokens
+        if temperature is not None:
+            config["temperature"] = temperature
+        if top_p is not None:
+            config["top_p"] = top_p
 
         # Only include non-provider-specific args that were explicitly set
         for key, value in config.items():
@@ -266,6 +279,9 @@ class GroqLanguageModel(LanguageModel):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
         validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Union[ChatCompletion, Generator[ChatCompletionChunk, None, None]]:
         """Send a chat completion request.
 
@@ -295,6 +311,10 @@ class GroqLanguageModel(LanguageModel):
         # Warn if validate_tool_calls is used with streaming
         self._warn_if_validate_with_streaming(validate_tool_calls, stream)
 
+        effective_max_tokens = self._resolve_max_tokens(max_tokens)
+        effective_temperature = self._resolve_temperature(temperature)
+        effective_top_p = self._resolve_top_p(top_p)
+
         should_stream = stream if stream is not None else self.streaming
 
         # Resolve tool configuration
@@ -307,7 +327,12 @@ class GroqLanguageModel(LanguageModel):
             "model": self.get_model_name(),
             "messages": messages,
             "stream": should_stream,
-            **self._get_api_kwargs(exclude_stream=True),
+            **self._get_api_kwargs(
+                exclude_stream=True,
+                max_tokens=effective_max_tokens,
+                temperature=effective_temperature,
+                top_p=effective_top_p,
+            ),
         }
 
         # Add tool-related parameters if configured
@@ -348,6 +373,9 @@ class GroqLanguageModel(LanguageModel):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
         validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Union[ChatCompletion, AsyncGenerator[ChatCompletionChunk, None]]:
         """Send an async chat completion request.
 
@@ -377,6 +405,10 @@ class GroqLanguageModel(LanguageModel):
         # Warn if validate_tool_calls is used with streaming
         self._warn_if_validate_with_streaming(validate_tool_calls, stream)
 
+        effective_max_tokens = self._resolve_max_tokens(max_tokens)
+        effective_temperature = self._resolve_temperature(temperature)
+        effective_top_p = self._resolve_top_p(top_p)
+
         should_stream = stream if stream is not None else self.streaming
 
         # Resolve tool configuration
@@ -389,7 +421,12 @@ class GroqLanguageModel(LanguageModel):
             "model": self.get_model_name(),
             "messages": messages,
             "stream": should_stream,
-            **self._get_api_kwargs(exclude_stream=True),
+            **self._get_api_kwargs(
+                exclude_stream=True,
+                max_tokens=effective_max_tokens,
+                temperature=effective_temperature,
+                top_p=effective_top_p,
+            ),
         }
 
         # Add tool-related parameters if configured

--- a/src/esperanto/providers/llm/mistral.py
+++ b/src/esperanto/providers/llm/mistral.py
@@ -243,10 +243,23 @@ class MistralLanguageModel(LanguageModel):
                     except json.JSONDecodeError:
                         continue
 
-    def _get_api_kwargs(self, exclude_stream: bool = False) -> Dict[str, Any]:
+    def _get_api_kwargs(
+        self,
+        exclude_stream: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+    ) -> Dict[str, Any]:
         """Get kwargs for Mistral API calls."""
         kwargs = {}
         config = self.get_completion_kwargs()
+
+        if max_tokens is not None:
+            config["max_tokens"] = max_tokens
+        if temperature is not None:
+            config["temperature"] = temperature
+        if top_p is not None:
+            config["top_p"] = top_p
 
         supported_params = ["temperature", "top_p", "max_tokens", "safe_prompt", "random_seed"]
 
@@ -275,6 +288,9 @@ class MistralLanguageModel(LanguageModel):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
         validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Union[ChatCompletion, Generator[ChatCompletionChunk, None, None]]:
         """Send a chat completion request.
 
@@ -304,6 +320,10 @@ class MistralLanguageModel(LanguageModel):
         # Warn if validate_tool_calls is used with streaming
         self._warn_if_validate_with_streaming(validate_tool_calls, stream)
 
+        effective_max_tokens = self._resolve_max_tokens(max_tokens)
+        effective_temperature = self._resolve_temperature(temperature)
+        effective_top_p = self._resolve_top_p(top_p)
+
         should_stream = stream if stream is not None else self.streaming
 
         # Resolve tool configuration
@@ -316,7 +336,12 @@ class MistralLanguageModel(LanguageModel):
             "model": self.get_model_name(),
             "messages": messages,
             "stream": should_stream,
-            **self._get_api_kwargs(exclude_stream=True),
+            **self._get_api_kwargs(
+                exclude_stream=True,
+                max_tokens=effective_max_tokens,
+                temperature=effective_temperature,
+                top_p=effective_top_p,
+            ),
         }
 
         # Add tool-related parameters if configured
@@ -357,6 +382,9 @@ class MistralLanguageModel(LanguageModel):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
         validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Union[ChatCompletion, AsyncGenerator[ChatCompletionChunk, None]]:
         """Send an async chat completion request.
 
@@ -386,6 +414,10 @@ class MistralLanguageModel(LanguageModel):
         # Warn if validate_tool_calls is used with streaming
         self._warn_if_validate_with_streaming(validate_tool_calls, stream)
 
+        effective_max_tokens = self._resolve_max_tokens(max_tokens)
+        effective_temperature = self._resolve_temperature(temperature)
+        effective_top_p = self._resolve_top_p(top_p)
+
         should_stream = stream if stream is not None else self.streaming
 
         # Resolve tool configuration
@@ -398,7 +430,12 @@ class MistralLanguageModel(LanguageModel):
             "model": self.get_model_name(),
             "messages": messages,
             "stream": should_stream,
-            **self._get_api_kwargs(exclude_stream=True),
+            **self._get_api_kwargs(
+                exclude_stream=True,
+                max_tokens=effective_max_tokens,
+                temperature=effective_temperature,
+                top_p=effective_top_p,
+            ),
         }
 
         # Add tool-related parameters if configured

--- a/src/esperanto/providers/llm/ollama.py
+++ b/src/esperanto/providers/llm/ollama.py
@@ -71,10 +71,21 @@ class OllamaLanguageModel(LanguageModel):
                 error_message = f"HTTP {response.status_code}: {response.text}"
             raise RuntimeError(f"Ollama API error: {error_message}")
 
-    def _get_api_kwargs(self) -> Dict[str, Any]:
+    def _get_api_kwargs(
+        self,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+    ) -> Dict[str, Any]:
         """Get kwargs for API calls, filtering out provider-specific args."""
         kwargs = {}
         config = self.get_completion_kwargs()
+        if max_tokens is not None:
+            config["max_tokens"] = max_tokens
+        if temperature is not None:
+            config["temperature"] = temperature
+        if top_p is not None:
+            config["top_p"] = top_p
         options = {}
 
         # Only include non-provider-specific args that were explicitly set
@@ -237,6 +248,9 @@ class OllamaLanguageModel(LanguageModel):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
         validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Union[ChatCompletion, Generator[ChatCompletionChunk, None, None]]:
         """Send a chat completion request.
 
@@ -260,6 +274,9 @@ class OllamaLanguageModel(LanguageModel):
             validate_tool_calls: If True, validate tool call arguments against the
                 tool's JSON schema. Raises ToolCallValidationError on validation
                 failure. Requires jsonschema package.
+            max_tokens: Per-call override for max_tokens. If None, uses instance value.
+            temperature: Per-call override for temperature. If None, uses instance value.
+            top_p: Per-call override for top_p. If None, uses instance value.
 
         Returns:
             Either a ChatCompletion or a Generator yielding ChatCompletionChunks
@@ -284,6 +301,11 @@ class OllamaLanguageModel(LanguageModel):
             if "content" not in message and message["role"] not in ["assistant", "tool"]:
                 raise ValueError("Missing content in message")
 
+        # Resolve per-call overrides
+        effective_max_tokens = self._resolve_max_tokens(max_tokens)
+        effective_temperature = self._resolve_temperature(temperature)
+        effective_top_p = self._resolve_top_p(top_p)
+
         # Resolve tool configuration
         resolved_tools = self._resolve_tools(tools)
         self._resolve_tool_choice(tool_choice)
@@ -298,7 +320,11 @@ class OllamaLanguageModel(LanguageModel):
             "model": self.get_model_name(),
             "messages": converted_messages,
             "stream": should_stream,
-            **self._get_api_kwargs(),
+            **self._get_api_kwargs(
+                max_tokens=effective_max_tokens,
+                temperature=effective_temperature,
+                top_p=effective_top_p,
+            ),
         }
 
         # Add tool-related parameters if configured
@@ -335,6 +361,9 @@ class OllamaLanguageModel(LanguageModel):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
         validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Union[ChatCompletion, AsyncGenerator[ChatCompletionChunk, None]]:
         """Send an async chat completion request.
 
@@ -358,6 +387,9 @@ class OllamaLanguageModel(LanguageModel):
             validate_tool_calls: If True, validate tool call arguments against the
                 tool's JSON schema. Raises ToolCallValidationError on validation
                 failure. Requires jsonschema package.
+            max_tokens: Per-call override for max_tokens. If None, uses instance value.
+            temperature: Per-call override for temperature. If None, uses instance value.
+            top_p: Per-call override for top_p. If None, uses instance value.
 
         Returns:
             Either a ChatCompletion or an AsyncGenerator yielding ChatCompletionChunks
@@ -371,6 +403,11 @@ class OllamaLanguageModel(LanguageModel):
 
         if not messages:
             raise ValueError("Messages cannot be empty")
+
+        # Resolve per-call overrides
+        effective_max_tokens = self._resolve_max_tokens(max_tokens)
+        effective_temperature = self._resolve_temperature(temperature)
+        effective_top_p = self._resolve_top_p(top_p)
 
         # Resolve tool configuration
         resolved_tools = self._resolve_tools(tools)
@@ -386,7 +423,11 @@ class OllamaLanguageModel(LanguageModel):
             "model": self.get_model_name(),
             "messages": converted_messages,
             "stream": should_stream,
-            **self._get_api_kwargs(),
+            **self._get_api_kwargs(
+                max_tokens=effective_max_tokens,
+                temperature=effective_temperature,
+                top_p=effective_top_p,
+            ),
         }
 
         # Add tool-related parameters if configured

--- a/src/esperanto/providers/llm/openai.py
+++ b/src/esperanto/providers/llm/openai.py
@@ -234,14 +234,29 @@ class OpenAILanguageModel(LanguageModel):
             for msg in messages
         ]
 
-    def _get_api_kwargs(self, exclude_stream: bool = False) -> Dict[str, Any]:
+    def _get_api_kwargs(
+        self,
+        exclude_stream: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+    ) -> Dict[str, Any]:
         """Get kwargs for API calls, filtering out provider-specific args.
 
         Args:
             exclude_stream: If True, excludes streaming-related parameters.
+            max_tokens: Per-call override for max_tokens.
+            temperature: Per-call override for temperature.
+            top_p: Per-call override for top_p.
         """
         kwargs = {}
         config = self.get_completion_kwargs()
+        if max_tokens is not None:
+            config["max_tokens"] = max_tokens
+        if temperature is not None:
+            config["temperature"] = temperature
+        if top_p is not None:
+            config["top_p"] = top_p
         is_reasoning_model = self._is_reasoning_model()
 
         # Only include non-provider-specific args that were explicitly set
@@ -297,6 +312,9 @@ class OpenAILanguageModel(LanguageModel):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
         validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Union[ChatCompletion, Generator[ChatCompletionChunk, None, None]]:
         """Send a chat completion request.
 
@@ -317,6 +335,9 @@ class OpenAILanguageModel(LanguageModel):
             validate_tool_calls: If True, validate tool call arguments against the
                 tool's JSON schema. Raises ToolCallValidationError on validation
                 failure. Requires jsonschema package.
+            max_tokens: Per-call override for max_tokens. If None, uses instance value.
+            temperature: Per-call override for temperature. If None, uses instance value.
+            top_p: Per-call override for top_p. If None, uses instance value.
 
         Returns:
             Either a ChatCompletion or a Generator yielding ChatCompletionChunks
@@ -329,6 +350,11 @@ class OpenAILanguageModel(LanguageModel):
         should_stream = stream if stream is not None else self.streaming
         model_name = self.get_model_name()
         is_reasoning_model = self._is_reasoning_model()
+
+        # Resolve per-call overrides
+        effective_max_tokens = self._resolve_max_tokens(max_tokens)
+        effective_temperature = self._resolve_temperature(temperature)
+        effective_top_p = self._resolve_top_p(top_p)
 
         # Resolve tool configuration
         resolved_tools = self._resolve_tools(tools)
@@ -346,7 +372,12 @@ class OpenAILanguageModel(LanguageModel):
             "model": model_name,
             "messages": messages,
             "stream": should_stream,
-            **self._get_api_kwargs(exclude_stream=True),
+            **self._get_api_kwargs(
+                exclude_stream=True,
+                max_tokens=effective_max_tokens,
+                temperature=effective_temperature,
+                top_p=effective_top_p,
+            ),
         }
 
         # Add tool-related parameters if configured
@@ -390,6 +421,9 @@ class OpenAILanguageModel(LanguageModel):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
         validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Union[ChatCompletion, AsyncGenerator[ChatCompletionChunk, None]]:
         """Send an async chat completion request.
 
@@ -410,6 +444,9 @@ class OpenAILanguageModel(LanguageModel):
             validate_tool_calls: If True, validate tool call arguments against the
                 tool's JSON schema. Raises ToolCallValidationError on validation
                 failure. Requires jsonschema package.
+            max_tokens: Per-call override for max_tokens. If None, uses instance value.
+            temperature: Per-call override for temperature. If None, uses instance value.
+            top_p: Per-call override for top_p. If None, uses instance value.
 
         Returns:
             Either a ChatCompletion or an AsyncGenerator yielding ChatCompletionChunks
@@ -422,6 +459,11 @@ class OpenAILanguageModel(LanguageModel):
         should_stream = stream if stream is not None else self.streaming
         model_name = self.get_model_name()
         is_reasoning_model = self._is_reasoning_model()
+
+        # Resolve per-call overrides
+        effective_max_tokens = self._resolve_max_tokens(max_tokens)
+        effective_temperature = self._resolve_temperature(temperature)
+        effective_top_p = self._resolve_top_p(top_p)
 
         # Resolve tool configuration
         resolved_tools = self._resolve_tools(tools)
@@ -439,7 +481,12 @@ class OpenAILanguageModel(LanguageModel):
             "model": model_name,
             "messages": messages,
             "stream": should_stream,
-            **self._get_api_kwargs(exclude_stream=True),
+            **self._get_api_kwargs(
+                exclude_stream=True,
+                max_tokens=effective_max_tokens,
+                temperature=effective_temperature,
+                top_p=effective_top_p,
+            ),
         }
 
         # Add tool-related parameters if configured

--- a/src/esperanto/providers/llm/openai.py
+++ b/src/esperanto/providers/llm/openai.py
@@ -258,6 +258,9 @@ class OpenAILanguageModel(LanguageModel):
         if top_p is not None:
             config["top_p"] = top_p
         is_reasoning_model = self._is_reasoning_model()
+        # Track per-call explicit overrides so the magic-default skip below
+        # does not silently drop them (issue #102 + cubic feedback).
+        max_tokens_explicit = max_tokens is not None
 
         # Only include non-provider-specific args that were explicitly set
         for key, value in config.items():
@@ -272,8 +275,9 @@ class OpenAILanguageModel(LanguageModel):
                 "tool_choice",
                 "parallel_tool_calls",
             ]:
-                # Skip max_tokens if it's the default value (850) and we're using an o1 model
-                if key == "max_tokens" and value == 850 and is_reasoning_model:
+                # Skip max_tokens if it's the instance default (850) on a reasoning
+                # model AND was not explicitly supplied as a per-call override.
+                if key == "max_tokens" and value == 850 and is_reasoning_model and not max_tokens_explicit:
                     continue
                 kwargs[key] = value
 
@@ -352,9 +356,8 @@ class OpenAILanguageModel(LanguageModel):
         is_reasoning_model = self._is_reasoning_model()
 
         # Resolve per-call overrides
-        effective_max_tokens = self._resolve_max_tokens(max_tokens)
-        effective_temperature = self._resolve_temperature(temperature)
-        effective_top_p = self._resolve_top_p(top_p)
+        # Per-call values flow raw into _get_api_kwargs which tracks
+        # explicit-ness for the magic-default skip (issue #102 + cubic feedback).
 
         # Resolve tool configuration
         resolved_tools = self._resolve_tools(tools)
@@ -374,9 +377,9 @@ class OpenAILanguageModel(LanguageModel):
             "stream": should_stream,
             **self._get_api_kwargs(
                 exclude_stream=True,
-                max_tokens=effective_max_tokens,
-                temperature=effective_temperature,
-                top_p=effective_top_p,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
             ),
         }
 
@@ -461,9 +464,8 @@ class OpenAILanguageModel(LanguageModel):
         is_reasoning_model = self._is_reasoning_model()
 
         # Resolve per-call overrides
-        effective_max_tokens = self._resolve_max_tokens(max_tokens)
-        effective_temperature = self._resolve_temperature(temperature)
-        effective_top_p = self._resolve_top_p(top_p)
+        # Per-call values flow raw into _get_api_kwargs which tracks
+        # explicit-ness for the magic-default skip (issue #102 + cubic feedback).
 
         # Resolve tool configuration
         resolved_tools = self._resolve_tools(tools)
@@ -483,9 +485,9 @@ class OpenAILanguageModel(LanguageModel):
             "stream": should_stream,
             **self._get_api_kwargs(
                 exclude_stream=True,
-                max_tokens=effective_max_tokens,
-                temperature=effective_temperature,
-                top_p=effective_top_p,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
             ),
         }
 

--- a/src/esperanto/providers/llm/openai_compatible.py
+++ b/src/esperanto/providers/llm/openai_compatible.py
@@ -267,19 +267,32 @@ class OpenAICompatibleLanguageModel(OpenAILanguageModel):
         )
 
     def _get_api_kwargs(
-        self, exclude_stream: bool = False, exclude_response_format: bool = False
+        self,
+        exclude_stream: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        exclude_response_format: bool = False,
     ) -> Dict[str, Any]:
         """Get API kwargs with graceful feature fallback.
 
         Args:
             exclude_stream: If True, excludes streaming-related parameters.
             exclude_response_format: If True, excludes response_format parameter.
+            max_tokens: Per-call override for max_tokens.
+            temperature: Per-call override for temperature.
+            top_p: Per-call override for top_p.
 
         Returns:
             Dict containing API parameters for the request.
         """
         # Get base kwargs from parent
-        kwargs = super()._get_api_kwargs(exclude_stream)
+        kwargs = super()._get_api_kwargs(
+            exclude_stream,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+        )
 
         # Remove response_format if:
         # 1. Explicitly requested (for retry logic)
@@ -312,6 +325,9 @@ class OpenAICompatibleLanguageModel(OpenAILanguageModel):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
         validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Union[ChatCompletion, Generator[ChatCompletionChunk, None, None]]:
         """Send a chat completion request with retry for unsupported response_format.
 
@@ -333,6 +349,9 @@ class OpenAICompatibleLanguageModel(OpenAILanguageModel):
             validate_tool_calls: If True, validate tool call arguments against the
                 tool's JSON schema. Raises ToolCallValidationError on validation
                 failure. Requires jsonschema package.
+            max_tokens: Per-call override for max_tokens. If None, uses instance value.
+            temperature: Per-call override for temperature. If None, uses instance value.
+            top_p: Per-call override for top_p. If None, uses instance value.
 
         Returns:
             Either a ChatCompletion or a Generator yielding ChatCompletionChunks
@@ -341,7 +360,8 @@ class OpenAICompatibleLanguageModel(OpenAILanguageModel):
         """
         try:
             return super().chat_complete(
-                messages, stream, tools, tool_choice, parallel_tool_calls, validate_tool_calls
+                messages, stream, tools, tool_choice, parallel_tool_calls, validate_tool_calls,
+                max_tokens=max_tokens, temperature=temperature, top_p=top_p,
             )
         except RuntimeError as e:
             # Check if it's a response_format error and we haven't already disabled it
@@ -353,7 +373,8 @@ class OpenAICompatibleLanguageModel(OpenAILanguageModel):
                 self._response_format_unsupported = True
                 # Retry without response_format
                 return super().chat_complete(
-                    messages, stream, tools, tool_choice, parallel_tool_calls, validate_tool_calls
+                    messages, stream, tools, tool_choice, parallel_tool_calls, validate_tool_calls,
+                    max_tokens=max_tokens, temperature=temperature, top_p=top_p,
                 )
             raise
 
@@ -365,6 +386,9 @@ class OpenAICompatibleLanguageModel(OpenAILanguageModel):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
         validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Union[ChatCompletion, AsyncGenerator[ChatCompletionChunk, None]]:
         """Send an async chat completion request with retry for unsupported response_format.
 
@@ -386,6 +410,9 @@ class OpenAICompatibleLanguageModel(OpenAILanguageModel):
             validate_tool_calls: If True, validate tool call arguments against the
                 tool's JSON schema. Raises ToolCallValidationError on validation
                 failure. Requires jsonschema package.
+            max_tokens: Per-call override for max_tokens. If None, uses instance value.
+            temperature: Per-call override for temperature. If None, uses instance value.
+            top_p: Per-call override for top_p. If None, uses instance value.
 
         Returns:
             Either a ChatCompletion or an AsyncGenerator yielding ChatCompletionChunks
@@ -394,7 +421,8 @@ class OpenAICompatibleLanguageModel(OpenAILanguageModel):
         """
         try:
             return await super().achat_complete(
-                messages, stream, tools, tool_choice, parallel_tool_calls, validate_tool_calls
+                messages, stream, tools, tool_choice, parallel_tool_calls, validate_tool_calls,
+                max_tokens=max_tokens, temperature=temperature, top_p=top_p,
             )
         except RuntimeError as e:
             # Check if it's a response_format error and we haven't already disabled it
@@ -406,7 +434,8 @@ class OpenAICompatibleLanguageModel(OpenAILanguageModel):
                 self._response_format_unsupported = True
                 # Retry without response_format
                 return await super().achat_complete(
-                    messages, stream, tools, tool_choice, parallel_tool_calls, validate_tool_calls
+                    messages, stream, tools, tool_choice, parallel_tool_calls, validate_tool_calls,
+                    max_tokens=max_tokens, temperature=temperature, top_p=top_p,
                 )
             raise
 

--- a/src/esperanto/providers/llm/openrouter.py
+++ b/src/esperanto/providers/llm/openrouter.py
@@ -99,12 +99,23 @@ class OpenRouterLanguageModel(OpenAILanguageModel):
         self._handle_error(response)
         return response
 
-    def _get_api_kwargs(self, exclude_stream: bool = False) -> Dict[str, Any]:
+    def _get_api_kwargs(
+        self,
+        exclude_stream: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+    ) -> Dict[str, Any]:
         """Get kwargs for API calls, filtering out provider-specific args.
 
         Note: OpenRouter doesn't support JSON response format for non-OpenAI models.
         """
-        kwargs = super()._get_api_kwargs(exclude_stream)
+        kwargs = super()._get_api_kwargs(
+            exclude_stream,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+        )
 
         # Remove response_format for non-OpenAI models
         model = self.get_model_name().lower()
@@ -121,6 +132,9 @@ class OpenRouterLanguageModel(OpenAILanguageModel):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
         validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Union[ChatCompletion, Generator[ChatCompletionChunk, None, None]]:
         """Send a chat completion request using OpenRouter-specific HTTP format.
 
@@ -151,6 +165,10 @@ class OpenRouterLanguageModel(OpenAILanguageModel):
         # Warn if validate_tool_calls is used with streaming
         self._warn_if_validate_with_streaming(validate_tool_calls, stream)
 
+        effective_max_tokens = self._resolve_max_tokens(max_tokens)
+        effective_temperature = self._resolve_temperature(temperature)
+        effective_top_p = self._resolve_top_p(top_p)
+
         should_stream = stream if stream is not None else self.streaming
         model_name = self.get_model_name()
         is_reasoning_model = model_name.startswith("o1") or model_name.startswith("o3") or model_name.startswith("o4")
@@ -171,7 +189,12 @@ class OpenRouterLanguageModel(OpenAILanguageModel):
             "model": model_name,
             "messages": messages,
             "stream": should_stream,
-            **self._get_api_kwargs(exclude_stream=True),
+            **self._get_api_kwargs(
+                exclude_stream=True,
+                max_tokens=effective_max_tokens,
+                temperature=effective_temperature,
+                top_p=effective_top_p,
+            ),
         }
 
         # Add tool-related parameters if configured
@@ -207,6 +230,9 @@ class OpenRouterLanguageModel(OpenAILanguageModel):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
         validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Union[ChatCompletion, AsyncGenerator[ChatCompletionChunk, None]]:
         """Send an async chat completion request using OpenRouter-specific HTTP format.
 
@@ -237,6 +263,10 @@ class OpenRouterLanguageModel(OpenAILanguageModel):
         # Warn if validate_tool_calls is used with streaming
         self._warn_if_validate_with_streaming(validate_tool_calls, stream)
 
+        effective_max_tokens = self._resolve_max_tokens(max_tokens)
+        effective_temperature = self._resolve_temperature(temperature)
+        effective_top_p = self._resolve_top_p(top_p)
+
         should_stream = stream if stream is not None else self.streaming
         model_name = self.get_model_name()
         is_reasoning_model = model_name.startswith("o1") or model_name.startswith("o3") or model_name.startswith("o4")
@@ -257,7 +287,12 @@ class OpenRouterLanguageModel(OpenAILanguageModel):
             "model": model_name,
             "messages": messages,
             "stream": should_stream,
-            **self._get_api_kwargs(exclude_stream=True),
+            **self._get_api_kwargs(
+                exclude_stream=True,
+                max_tokens=effective_max_tokens,
+                temperature=effective_temperature,
+                top_p=effective_top_p,
+            ),
         }
 
         # Add tool-related parameters if configured

--- a/src/esperanto/providers/llm/openrouter.py
+++ b/src/esperanto/providers/llm/openrouter.py
@@ -165,9 +165,8 @@ class OpenRouterLanguageModel(OpenAILanguageModel):
         # Warn if validate_tool_calls is used with streaming
         self._warn_if_validate_with_streaming(validate_tool_calls, stream)
 
-        effective_max_tokens = self._resolve_max_tokens(max_tokens)
-        effective_temperature = self._resolve_temperature(temperature)
-        effective_top_p = self._resolve_top_p(top_p)
+        # Per-call values flow raw into _get_api_kwargs which tracks
+        # explicit-ness for the magic-default skip (issue #102 + cubic feedback).
 
         should_stream = stream if stream is not None else self.streaming
         model_name = self.get_model_name()
@@ -191,9 +190,9 @@ class OpenRouterLanguageModel(OpenAILanguageModel):
             "stream": should_stream,
             **self._get_api_kwargs(
                 exclude_stream=True,
-                max_tokens=effective_max_tokens,
-                temperature=effective_temperature,
-                top_p=effective_top_p,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
             ),
         }
 
@@ -263,9 +262,8 @@ class OpenRouterLanguageModel(OpenAILanguageModel):
         # Warn if validate_tool_calls is used with streaming
         self._warn_if_validate_with_streaming(validate_tool_calls, stream)
 
-        effective_max_tokens = self._resolve_max_tokens(max_tokens)
-        effective_temperature = self._resolve_temperature(temperature)
-        effective_top_p = self._resolve_top_p(top_p)
+        # Per-call values flow raw into _get_api_kwargs which tracks
+        # explicit-ness for the magic-default skip (issue #102 + cubic feedback).
 
         should_stream = stream if stream is not None else self.streaming
         model_name = self.get_model_name()
@@ -289,9 +287,9 @@ class OpenRouterLanguageModel(OpenAILanguageModel):
             "stream": should_stream,
             **self._get_api_kwargs(
                 exclude_stream=True,
-                max_tokens=effective_max_tokens,
-                temperature=effective_temperature,
-                top_p=effective_top_p,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
             ),
         }
 

--- a/src/esperanto/providers/llm/perplexity.py
+++ b/src/esperanto/providers/llm/perplexity.py
@@ -133,6 +133,10 @@ class PerplexityLanguageModel(LanguageModel):
         kwargs = {}
         config = self.get_completion_kwargs()
 
+        # Track per-call explicit overrides so the magic-default skip below
+        # does not silently drop them (issue #102 + cubic feedback).
+        max_tokens_explicit = max_tokens is not None
+
         if max_tokens is not None:
             config["max_tokens"] = max_tokens
         if temperature is not None:
@@ -153,8 +157,9 @@ class PerplexityLanguageModel(LanguageModel):
                 "tool_choice",
                 "parallel_tool_calls",
             ]:
-                # Skip max_tokens if it's the default value (850)
-                if key == "max_tokens" and value == 850:
+                # Skip max_tokens if it's the instance default (850) and was not
+                # explicitly supplied as a per-call override.
+                if key == "max_tokens" and value == 850 and not max_tokens_explicit:
                     continue
                 kwargs[key] = value
 
@@ -328,17 +333,16 @@ class PerplexityLanguageModel(LanguageModel):
         # Warn if validate_tool_calls is used with streaming
         self._warn_if_validate_with_streaming(validate_tool_calls, stream)
 
-        effective_max_tokens = self._resolve_max_tokens(max_tokens)
-        effective_temperature = self._resolve_temperature(temperature)
-        effective_top_p = self._resolve_top_p(top_p)
+        # Per-call values flow raw into _get_api_kwargs which tracks
+        # explicit-ness for the magic-default skip (issue #102 + cubic feedback).
 
         should_stream = stream if stream is not None else self.streaming
         model_name = self.get_model_name()
         api_kwargs = self._get_api_kwargs(
             exclude_stream=True,
-            max_tokens=effective_max_tokens,
-            temperature=effective_temperature,
-            top_p=effective_top_p,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
         )
         perplexity_params = self._get_perplexity_params()
 
@@ -429,17 +433,16 @@ class PerplexityLanguageModel(LanguageModel):
         # Warn if validate_tool_calls is used with streaming
         self._warn_if_validate_with_streaming(validate_tool_calls, stream)
 
-        effective_max_tokens = self._resolve_max_tokens(max_tokens)
-        effective_temperature = self._resolve_temperature(temperature)
-        effective_top_p = self._resolve_top_p(top_p)
+        # Per-call values flow raw into _get_api_kwargs which tracks
+        # explicit-ness for the magic-default skip (issue #102 + cubic feedback).
 
         should_stream = stream if stream is not None else self.streaming
         model_name = self.get_model_name()
         api_kwargs = self._get_api_kwargs(
             exclude_stream=True,
-            max_tokens=effective_max_tokens,
-            temperature=effective_temperature,
-            top_p=effective_top_p,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
         )
         perplexity_params = self._get_perplexity_params()
 

--- a/src/esperanto/providers/llm/perplexity.py
+++ b/src/esperanto/providers/llm/perplexity.py
@@ -122,10 +122,23 @@ class PerplexityLanguageModel(LanguageModel):
                     except json.JSONDecodeError:
                         continue
 
-    def _get_api_kwargs(self, exclude_stream: bool = False) -> Dict[str, Any]:
+    def _get_api_kwargs(
+        self,
+        exclude_stream: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+    ) -> Dict[str, Any]:
         """Get kwargs for API calls, filtering out provider-specific args."""
         kwargs = {}
         config = self.get_completion_kwargs()
+
+        if max_tokens is not None:
+            config["max_tokens"] = max_tokens
+        if temperature is not None:
+            config["temperature"] = temperature
+        if top_p is not None:
+            config["top_p"] = top_p
 
         # Only include non-provider-specific args that were explicitly set
         for key, value in config.items():
@@ -280,6 +293,9 @@ class PerplexityLanguageModel(LanguageModel):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
         validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Union[ChatCompletion, Generator[ChatCompletionChunk, None, None]]:
         """Send a chat completion request.
 
@@ -312,9 +328,18 @@ class PerplexityLanguageModel(LanguageModel):
         # Warn if validate_tool_calls is used with streaming
         self._warn_if_validate_with_streaming(validate_tool_calls, stream)
 
+        effective_max_tokens = self._resolve_max_tokens(max_tokens)
+        effective_temperature = self._resolve_temperature(temperature)
+        effective_top_p = self._resolve_top_p(top_p)
+
         should_stream = stream if stream is not None else self.streaming
         model_name = self.get_model_name()
-        api_kwargs = self._get_api_kwargs(exclude_stream=True)
+        api_kwargs = self._get_api_kwargs(
+            exclude_stream=True,
+            max_tokens=effective_max_tokens,
+            temperature=effective_temperature,
+            top_p=effective_top_p,
+        )
         perplexity_params = self._get_perplexity_params()
 
         # Resolve tool configuration
@@ -369,6 +394,9 @@ class PerplexityLanguageModel(LanguageModel):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
         validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Union[ChatCompletion, AsyncGenerator[ChatCompletionChunk, None]]:
         """Send an async chat completion request.
 
@@ -401,9 +429,18 @@ class PerplexityLanguageModel(LanguageModel):
         # Warn if validate_tool_calls is used with streaming
         self._warn_if_validate_with_streaming(validate_tool_calls, stream)
 
+        effective_max_tokens = self._resolve_max_tokens(max_tokens)
+        effective_temperature = self._resolve_temperature(temperature)
+        effective_top_p = self._resolve_top_p(top_p)
+
         should_stream = stream if stream is not None else self.streaming
         model_name = self.get_model_name()
-        api_kwargs = self._get_api_kwargs(exclude_stream=True)
+        api_kwargs = self._get_api_kwargs(
+            exclude_stream=True,
+            max_tokens=effective_max_tokens,
+            temperature=effective_temperature,
+            top_p=effective_top_p,
+        )
         perplexity_params = self._get_perplexity_params()
 
         # Resolve tool configuration

--- a/src/esperanto/providers/llm/vertex.py
+++ b/src/esperanto/providers/llm/vertex.py
@@ -306,18 +306,27 @@ class VertexLanguageModel(LanguageModel):
 
         return formatted, system_instruction
 
-    def _create_generation_config(self) -> Dict[str, Any]:
+    def _create_generation_config(
+        self,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+    ) -> Dict[str, Any]:
         """Create generation config for Vertex AI."""
         config = {}
 
-        if self.temperature is not None:
-            config["temperature"] = float(self.temperature)
+        effective_temperature = temperature if temperature is not None else self.temperature
+        effective_top_p = top_p if top_p is not None else self.top_p
+        effective_max_tokens = max_tokens if max_tokens is not None else self.max_tokens
 
-        if self.top_p is not None:
-            config["topP"] = float(self.top_p)
+        if effective_temperature is not None:
+            config["temperature"] = float(effective_temperature)
 
-        if self.max_tokens:
-            config["maxOutputTokens"] = int(self.max_tokens)
+        if effective_top_p is not None:
+            config["topP"] = float(effective_top_p)
+
+        if effective_max_tokens:
+            config["maxOutputTokens"] = int(effective_max_tokens)
 
         return config
 
@@ -490,6 +499,9 @@ class VertexLanguageModel(LanguageModel):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
         validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Union[ChatCompletion, Generator[ChatCompletionChunk, None, None]]:
         """Send a chat completion request.
 
@@ -519,6 +531,10 @@ class VertexLanguageModel(LanguageModel):
         # Warn if validate_tool_calls is used with streaming
         self._warn_if_validate_with_streaming(validate_tool_calls, stream)
 
+        effective_max_tokens = self._resolve_max_tokens(max_tokens)
+        effective_temperature = self._resolve_temperature(temperature)
+        effective_top_p = self._resolve_top_p(top_p)
+
         should_stream = stream if stream is not None else self.streaming
 
         # Resolve tool configuration
@@ -535,7 +551,11 @@ class VertexLanguageModel(LanguageModel):
         }
 
         # Add generation config if provided
-        generation_config = self._create_generation_config()
+        generation_config = self._create_generation_config(
+            max_tokens=effective_max_tokens,
+            temperature=effective_temperature,
+            top_p=effective_top_p,
+        )
         if generation_config:
             payload["generationConfig"] = generation_config
 
@@ -673,6 +693,9 @@ class VertexLanguageModel(LanguageModel):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
         validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
     ) -> Union[ChatCompletion, AsyncGenerator[ChatCompletionChunk, None]]:
         """Send an async chat completion request.
 
@@ -702,6 +725,10 @@ class VertexLanguageModel(LanguageModel):
         # Warn if validate_tool_calls is used with streaming
         self._warn_if_validate_with_streaming(validate_tool_calls, stream)
 
+        effective_max_tokens = self._resolve_max_tokens(max_tokens)
+        effective_temperature = self._resolve_temperature(temperature)
+        effective_top_p = self._resolve_top_p(top_p)
+
         should_stream = stream if stream is not None else self.streaming
 
         # Resolve tool configuration
@@ -718,7 +745,11 @@ class VertexLanguageModel(LanguageModel):
         }
 
         # Add generation config if provided
-        generation_config = self._create_generation_config()
+        generation_config = self._create_generation_config(
+            max_tokens=effective_max_tokens,
+            temperature=effective_temperature,
+            top_p=effective_top_p,
+        )
         if generation_config:
             payload["generationConfig"] = generation_config
 

--- a/tests/providers/llm/test_anthropic_provider.py
+++ b/tests/providers/llm/test_anthropic_provider.py
@@ -939,6 +939,58 @@ class TestToolCallValidation:
             model.chat_complete(messages, tools=sample_tools, validate_tool_calls=True)
 
 
+class TestParameterOverrides:
+    """Tests for per-call max_tokens, temperature, top_p overrides."""
+
+    def test_max_tokens_override(self, anthropic_model):
+        """Per-call max_tokens overrides the instance default."""
+        messages = [{"role": "user", "content": "Hello"}]
+        anthropic_model.chat_complete(messages, max_tokens=500)
+        json_payload = anthropic_model.client.post.call_args[1]["json"]
+        assert json_payload["max_tokens"] == 500
+
+    def test_temperature_override(self, anthropic_model):
+        """Per-call temperature overrides the instance default."""
+        messages = [{"role": "user", "content": "Hello"}]
+        anthropic_model.chat_complete(messages, temperature=0.2)
+        json_payload = anthropic_model.client.post.call_args[1]["json"]
+        assert json_payload["temperature"] == 0.2
+
+    def test_top_p_override_when_temperature_not_set(self, mock_anthropic_client):
+        """Per-call top_p reaches the payload only when instance temperature is None.
+
+        Anthropic rejects requests with both temperature and top_p, so the provider
+        drops top_p when temperature is set (mutual-exclusivity rule).
+        """
+        model = AnthropicLanguageModel(
+            api_key="test-key",
+            model_name="claude-3-opus-20240229",
+            temperature=None,
+        )
+        model.client, model.async_client = mock_anthropic_client
+        messages = [{"role": "user", "content": "Hello"}]
+        model.chat_complete(messages, top_p=0.7)
+        json_payload = model.client.post.call_args[1]["json"]
+        assert json_payload.get("top_p") == 0.7
+        assert "temperature" not in json_payload
+
+    def test_instance_defaults_when_no_overrides(self, anthropic_model):
+        """Regression guard: omitting overrides uses instance-level values."""
+        messages = [{"role": "user", "content": "Hello"}]
+        anthropic_model.chat_complete(messages)
+        json_payload = anthropic_model.client.post.call_args[1]["json"]
+        assert json_payload["max_tokens"] == 850
+        assert json_payload["temperature"] == 0.7
+
+    @pytest.mark.asyncio
+    async def test_async_max_tokens_override(self, anthropic_model):
+        """Async: per-call max_tokens overrides the instance default."""
+        messages = [{"role": "user", "content": "Hello"}]
+        await anthropic_model.achat_complete(messages, max_tokens=500)
+        json_payload = anthropic_model.async_client.post.call_args[1]["json"]
+        assert json_payload["max_tokens"] == 500
+
+
 class TestStreamingToolCalls:
     """Tests for streaming with tool calls."""
 

--- a/tests/providers/llm/test_azure_reasoning_models.py
+++ b/tests/providers/llm/test_azure_reasoning_models.py
@@ -190,3 +190,35 @@ class TestAzureReasoningModels:
             # Should preserve original values for non-reasoning models
             assert call_kwargs["temperature"] == 0.7
             assert call_kwargs["top_p"] == 0.9
+
+
+class TestPerCallMaxTokens850:
+    """Per-call max_tokens=850 must be honored on Azure reasoning models too
+    (cubic regression catch on PR #164)."""
+
+    def test_reasoning_model_per_call_max_tokens_850_honored(self, azure_config):
+        """o1 + per-call max_tokens=850 → max_completion_tokens=850 reaches the API."""
+        from unittest.mock import patch
+        with patch('httpx.Client'), patch('httpx.AsyncClient'):
+            model = AzureLanguageModel(
+                model_name="o1-preview",
+                max_tokens=850,  # also the instance default
+                **azure_config
+            )
+            kwargs = model._get_api_kwargs(max_tokens=850)
+            assert kwargs.get("max_completion_tokens") == 850, (
+                "Per-call max_tokens=850 must reach the API on reasoning models"
+            )
+
+    def test_reasoning_model_default_max_tokens_still_skipped(self, azure_config):
+        """o1 + no per-call override + instance default 850 → max_completion_tokens not sent."""
+        from unittest.mock import patch
+        with patch('httpx.Client'), patch('httpx.AsyncClient'):
+            model = AzureLanguageModel(
+                model_name="o1-preview",
+                max_tokens=850,
+                **azure_config
+            )
+            kwargs = model._get_api_kwargs()
+            assert "max_completion_tokens" not in kwargs
+            assert "max_tokens" not in kwargs

--- a/tests/providers/llm/test_groq_provider.py
+++ b/tests/providers/llm/test_groq_provider.py
@@ -467,3 +467,29 @@ class TestToolCallValidation:
 
         with pytest.raises(ToolCallValidationError):
             model.chat_complete(messages, tools=sample_tools, validate_tool_calls=True)
+
+
+
+class TestParameterOverrides:
+    """Per-call max_tokens, temperature, top_p override tests (issue #102)."""
+
+    def test_max_tokens_override_with_default_value(self, groq_model):
+        """Per-call max_tokens=850 must reach the API even though 850 is also the
+        instance default. Cubic regression catch on PR #164."""
+        messages = [{"role": "user", "content": "Hello"}]
+        groq_model.chat_complete(messages, max_tokens=850)
+        json_payload = groq_model.client.post.call_args[1]["json"]
+        assert json_payload.get("max_tokens") == 850, (
+            "Per-call max_tokens=850 must not be silently dropped by the magic-default filter"
+        )
+
+    def test_max_tokens_omitted_when_neither_set_per_call_nor_overridden(self, groq_model):
+        """When the user does not pass max_tokens per-call AND the instance is at
+        the default of 850, the request should omit max_tokens (preserving the
+        existing optimization that lets Groq pick its server default)."""
+        messages = [{"role": "user", "content": "Hello"}]
+        groq_model.chat_complete(messages)
+        json_payload = groq_model.client.post.call_args[1]["json"]
+        assert "max_tokens" not in json_payload, (
+            "Default 850 with no per-call override should be filtered out"
+        )

--- a/tests/providers/llm/test_ollama_provider.py
+++ b/tests/providers/llm/test_ollama_provider.py
@@ -565,6 +565,78 @@ class TestToolCallResponse:
         assert tool_call.function.name == "get_weather"
 
 
+class TestParameterOverrides:
+    """Tests for per-call max_tokens, temperature, top_p overrides."""
+
+    def _make_model_with_mock_client(self):
+        """Return a fresh OllamaLanguageModel with a sync mock client."""
+        model = OllamaLanguageModel(model_name="gemma2")
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "model": "gemma2",
+            "message": {"role": "assistant", "content": "Test"},
+            "done": True,
+        }
+        mock_client = Mock()
+        mock_client.post.return_value = mock_response
+        model.client = mock_client
+        return model
+
+    def test_max_tokens_override(self):
+        """Per-call max_tokens maps to options['num_predict'] instead of instance default."""
+        model = self._make_model_with_mock_client()
+        messages = [{"role": "user", "content": "Hello"}]
+        model.chat_complete(messages, max_tokens=500)
+        json_payload = model.client.post.call_args[1]["json"]
+        assert json_payload["options"]["num_predict"] == 500
+
+    def test_temperature_override(self):
+        """Per-call temperature overrides the instance default in options."""
+        model = self._make_model_with_mock_client()
+        messages = [{"role": "user", "content": "Hello"}]
+        model.chat_complete(messages, temperature=0.2)
+        json_payload = model.client.post.call_args[1]["json"]
+        assert json_payload["options"]["temperature"] == 0.2
+
+    def test_top_p_override(self):
+        """Per-call top_p overrides the instance default in options."""
+        model = self._make_model_with_mock_client()
+        messages = [{"role": "user", "content": "Hello"}]
+        model.chat_complete(messages, top_p=0.7)
+        json_payload = model.client.post.call_args[1]["json"]
+        assert json_payload["options"]["top_p"] == 0.7
+
+    def test_instance_defaults_when_no_overrides(self):
+        """Regression guard: omitting overrides uses instance-level values."""
+        model = self._make_model_with_mock_client()
+        messages = [{"role": "user", "content": "Hello"}]
+        model.chat_complete(messages)
+        json_payload = model.client.post.call_args[1]["json"]
+        assert json_payload["options"]["num_predict"] == 850
+        assert json_payload["options"]["temperature"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_async_max_tokens_override(self):
+        """Async: per-call max_tokens maps to options['num_predict']."""
+        model = OllamaLanguageModel(model_name="gemma2")
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "model": "gemma2",
+            "message": {"role": "assistant", "content": "Test"},
+            "done": True,
+        }
+        mock_async_client = AsyncMock()
+        mock_async_client.post.return_value = mock_response
+        model.async_client = mock_async_client
+
+        messages = [{"role": "user", "content": "Hello"}]
+        await model.achat_complete(messages, max_tokens=500)
+        json_payload = mock_async_client.post.call_args[1]["json"]
+        assert json_payload["options"]["num_predict"] == 500
+
+
 class TestToolCallValidation:
     """Tests for tool call validation."""
 

--- a/tests/providers/llm/test_openai_provider.py
+++ b/tests/providers/llm/test_openai_provider.py
@@ -939,6 +939,47 @@ class TestToolResultMessages:
         assert tool_msg["tool_call_id"] == "call_abc123"
 
 
+class TestParameterOverrides:
+    """Tests for per-call max_tokens, temperature, top_p overrides."""
+
+    def test_max_tokens_override(self, openai_model):
+        """Per-call max_tokens overrides the instance default."""
+        messages = [{"role": "user", "content": "Hello"}]
+        openai_model.chat_complete(messages, max_tokens=500)
+        json_payload = openai_model.client.post.call_args[1]["json"]
+        assert json_payload["max_tokens"] == 500
+
+    def test_temperature_override(self, openai_model):
+        """Per-call temperature overrides the instance default."""
+        messages = [{"role": "user", "content": "Hello"}]
+        openai_model.chat_complete(messages, temperature=0.2)
+        json_payload = openai_model.client.post.call_args[1]["json"]
+        assert json_payload["temperature"] == 0.2
+
+    def test_top_p_override(self, openai_model):
+        """Per-call top_p overrides the instance default."""
+        messages = [{"role": "user", "content": "Hello"}]
+        openai_model.chat_complete(messages, top_p=0.7)
+        json_payload = openai_model.client.post.call_args[1]["json"]
+        assert json_payload["top_p"] == 0.7
+
+    def test_instance_defaults_when_no_overrides(self, openai_model):
+        """Regression guard: omitting overrides uses instance-level values."""
+        messages = [{"role": "user", "content": "Hello"}]
+        openai_model.chat_complete(messages)
+        json_payload = openai_model.client.post.call_args[1]["json"]
+        assert json_payload["max_tokens"] == 850
+        assert json_payload["temperature"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_async_max_tokens_override(self, openai_model):
+        """Async: per-call max_tokens overrides the instance default."""
+        messages = [{"role": "user", "content": "Hello"}]
+        await openai_model.achat_complete(messages, max_tokens=500)
+        json_payload = openai_model.async_client.post.call_args[1]["json"]
+        assert json_payload["max_tokens"] == 500
+
+
 class TestNormalizeResponse:
     """Tests for response normalization with tool calls."""
 
@@ -1043,3 +1084,32 @@ class TestNormalizeResponse:
         assert result.choices[0].message.content == "I'll check the weather for you."
         assert result.choices[0].message.tool_calls is not None
         assert len(result.choices[0].message.tool_calls) == 1
+
+class TestParameterOverridesReasoningModel:
+    """Per-call max_tokens=850 must be honored on reasoning models too (cubic
+    regression catch on PR #164). The pre-existing magic-default skip was
+    triggering on per-call values that happened to equal 850."""
+
+    def test_reasoning_model_per_call_max_tokens_850_honored(self):
+        """o1 model + per-call max_tokens=850 → kwargs include max_completion_tokens=850."""
+        from unittest.mock import patch
+        from esperanto.providers.llm.openai import OpenAILanguageModel
+        with patch("httpx.Client"), patch("httpx.AsyncClient"):
+            model = OpenAILanguageModel(api_key="test-key", model_name="o1-mini")
+            kwargs = model._get_api_kwargs(max_tokens=850)
+            # Reasoning models translate max_tokens -> max_completion_tokens
+            assert kwargs.get("max_completion_tokens") == 850, (
+                "Per-call max_tokens=850 must reach the API even on reasoning models"
+            )
+
+    def test_reasoning_model_default_max_tokens_still_skipped(self):
+        """o1 model + no per-call override + instance default 850 → max_completion_tokens not sent."""
+        from unittest.mock import patch
+        from esperanto.providers.llm.openai import OpenAILanguageModel
+        with patch("httpx.Client"), patch("httpx.AsyncClient"):
+            model = OpenAILanguageModel(api_key="test-key", model_name="o1-mini")
+            kwargs = model._get_api_kwargs()
+            assert "max_completion_tokens" not in kwargs, (
+                "Instance default 850 should still be filtered when no per-call override"
+            )
+            assert "max_tokens" not in kwargs

--- a/tests/providers/llm/test_openai_provider.py
+++ b/tests/providers/llm/test_openai_provider.py
@@ -1093,6 +1093,7 @@ class TestParameterOverridesReasoningModel:
     def test_reasoning_model_per_call_max_tokens_850_honored(self):
         """o1 model + per-call max_tokens=850 → kwargs include max_completion_tokens=850."""
         from unittest.mock import patch
+
         from esperanto.providers.llm.openai import OpenAILanguageModel
         with patch("httpx.Client"), patch("httpx.AsyncClient"):
             model = OpenAILanguageModel(api_key="test-key", model_name="o1-mini")
@@ -1105,6 +1106,7 @@ class TestParameterOverridesReasoningModel:
     def test_reasoning_model_default_max_tokens_still_skipped(self):
         """o1 model + no per-call override + instance default 850 → max_completion_tokens not sent."""
         from unittest.mock import patch
+
         from esperanto.providers.llm.openai import OpenAILanguageModel
         with patch("httpx.Client"), patch("httpx.AsyncClient"):
             model = OpenAILanguageModel(api_key="test-key", model_name="o1-mini")

--- a/tests/providers/llm/test_openrouter_provider.py
+++ b/tests/providers/llm/test_openrouter_provider.py
@@ -342,3 +342,43 @@ def test_openrouter_langchain_conversion():
     assert langchain_model.streaming is True
     assert langchain_model.top_p == 0.9
     assert langchain_model.openai_api_base == "https://openrouter.ai/api/v1"
+
+
+class TestParameterOverrides:
+    """Per-call max_tokens, temperature, top_p override tests (issue #102)."""
+
+    def _make_model(self):
+        from unittest.mock import Mock
+        model = OpenRouterLanguageModel(api_key="test-key")
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {
+            "id": "x", "object": "chat.completion", "created": 1, "model": "openai/gpt-3.5-turbo",
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+        client = Mock()
+        client.post.return_value = response
+        model.client = client
+        return model
+
+    def test_per_call_max_tokens_override(self):
+        """Per-call max_tokens overrides instance default."""
+        model = self._make_model()
+        model.chat_complete([{"role": "user", "content": "Hello"}], max_tokens=500)
+        json_payload = model.client.post.call_args[1]["json"]
+        assert json_payload.get("max_tokens") == 500
+
+    def test_per_call_temperature_override(self):
+        """Per-call temperature overrides instance default."""
+        model = self._make_model()
+        model.chat_complete([{"role": "user", "content": "Hello"}], temperature=0.2)
+        json_payload = model.client.post.call_args[1]["json"]
+        assert json_payload.get("temperature") == 0.2
+
+    def test_per_call_top_p_override(self):
+        """Per-call top_p overrides instance default."""
+        model = self._make_model()
+        model.chat_complete([{"role": "user", "content": "Hello"}], top_p=0.7)
+        json_payload = model.client.post.call_args[1]["json"]
+        assert json_payload.get("top_p") == 0.7

--- a/tests/providers/llm/test_perplexity_provider.py
+++ b/tests/providers/llm/test_perplexity_provider.py
@@ -206,7 +206,7 @@ def test_perplexity_to_langchain_structured(perplexity_provider):
     assert langchain_model.model_kwargs["response_format"] == {"type": "text"}
 
 
-def test_perplexity_models_property(perplexity_provider):
+def test_perplexity_providers_property(perplexity_provider):
     """Test the models property (currently hardcoded)."""
     models = perplexity_provider.models
     assert isinstance(models, list)
@@ -293,7 +293,7 @@ def mock_perplexity_tool_call_response():
 
 
 @pytest.fixture
-def perplexity_model_with_tool_response(mock_perplexity_tool_call_response):
+def perplexity_provider_with_tool_response(mock_perplexity_tool_call_response):
     """Create a Perplexity model with tool call response mocked."""
     os.environ["PERPLEXITY_API_KEY"] = "test_api_key"
     model = PerplexityLanguageModel(model_name="llama-3-sonar-large-32k-online")
@@ -352,16 +352,16 @@ class TestToolConversion:
 class TestToolCallResponse:
     """Tests for handling tool call responses."""
 
-    def test_chat_complete_with_tools(self, perplexity_model_with_tool_response, sample_tools):
+    def test_chat_complete_with_tools(self, perplexity_provider_with_tool_response, sample_tools):
         """Test chat_complete with tools returns tool calls."""
         messages = [{"role": "user", "content": "What's the weather in SF?"}]
 
-        response = perplexity_model_with_tool_response.chat_complete(
+        response = perplexity_provider_with_tool_response.chat_complete(
             messages, tools=sample_tools
         )
 
         # Check payload included tools
-        call_args = perplexity_model_with_tool_response.client.post.call_args
+        call_args = perplexity_provider_with_tool_response.client.post.call_args
         json_payload = call_args[1]["json"]
         assert "tools" in json_payload
         assert len(json_payload["tools"]) == 2
@@ -377,29 +377,29 @@ class TestToolCallResponse:
         assert tool_call.function.name == "get_weather"
         assert '"location": "San Francisco"' in tool_call.function.arguments
 
-    def test_chat_complete_with_tool_choice(self, perplexity_model_with_tool_response, sample_tools):
+    def test_chat_complete_with_tool_choice(self, perplexity_provider_with_tool_response, sample_tools):
         """Test chat_complete with tool_choice parameter."""
         messages = [{"role": "user", "content": "What's the weather?"}]
 
-        perplexity_model_with_tool_response.chat_complete(
+        perplexity_provider_with_tool_response.chat_complete(
             messages, tools=sample_tools, tool_choice="required"
         )
 
-        call_args = perplexity_model_with_tool_response.client.post.call_args
+        call_args = perplexity_provider_with_tool_response.client.post.call_args
         json_payload = call_args[1]["json"]
         assert json_payload["tool_choice"] == "required"
 
     @pytest.mark.asyncio
-    async def test_achat_complete_with_tools(self, perplexity_model_with_tool_response, sample_tools):
+    async def test_achat_complete_with_tools(self, perplexity_provider_with_tool_response, sample_tools):
         """Test async chat_complete with tools returns tool calls."""
         messages = [{"role": "user", "content": "What's the weather in SF?"}]
 
-        response = await perplexity_model_with_tool_response.achat_complete(
+        response = await perplexity_provider_with_tool_response.achat_complete(
             messages, tools=sample_tools
         )
 
         # Check payload included tools
-        call_args = perplexity_model_with_tool_response.async_client.post.call_args
+        call_args = perplexity_provider_with_tool_response.async_client.post.call_args
         json_payload = call_args[1]["json"]
         assert "tools" in json_payload
 
@@ -413,7 +413,7 @@ class TestToolCallValidation:
     """Tests for tool call validation."""
 
     def test_validation_passes_for_valid_tool_call(
-        self, perplexity_model_with_tool_response, sample_tools
+        self, perplexity_provider_with_tool_response, sample_tools
     ):
         """Test that validation passes for valid tool calls."""
         pytest.importorskip("jsonschema")
@@ -421,8 +421,47 @@ class TestToolCallValidation:
         messages = [{"role": "user", "content": "What's the weather in SF?"}]
 
         # Should not raise
-        response = perplexity_model_with_tool_response.chat_complete(
+        response = perplexity_provider_with_tool_response.chat_complete(
             messages, tools=sample_tools, validate_tool_calls=True
         )
 
         assert response.choices[0].message.tool_calls is not None
+
+
+
+class TestParameterOverrides:
+    """Per-call max_tokens, temperature, top_p override tests (issue #102)."""
+
+    def _make_model(self):
+        os.environ["PERPLEXITY_API_KEY"] = "test_api_key"
+        provider = PerplexityLanguageModel(model_name="llama-3-sonar-large-32k-online")
+        provider.client = Mock()
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {
+            "id": "x", "object": "chat.completion", "created": 1, "model": "llama-3-sonar-large-32k-online",
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+        provider.client.post.return_value = response
+        return provider
+
+    def test_max_tokens_override_with_default_value(self):
+        """Per-call max_tokens=850 must reach the API even though 850 is also the
+        instance default. Cubic regression catch on PR #164."""
+        provider = self._make_model()
+        provider.chat_complete([{"role": "user", "content": "Hello"}], max_tokens=850)
+        json_payload = provider.client.post.call_args[1]["json"]
+        assert json_payload.get("max_tokens") == 850, (
+            "Per-call max_tokens=850 must not be silently dropped by the magic-default filter"
+        )
+
+    def test_max_tokens_omitted_when_neither_set_per_call_nor_overridden(self):
+        """When the user does not pass max_tokens per-call AND the instance is at
+        the default of 850, the request should omit max_tokens."""
+        provider = self._make_model()
+        provider.chat_complete([{"role": "user", "content": "Hello"}])
+        json_payload = provider.client.post.call_args[1]["json"]
+        assert "max_tokens" not in json_payload, (
+            "Default 850 with no per-call override should be filtered out"
+        )


### PR DESCRIPTION
## Summary

Adds three optional per-call parameters to \`chat_complete\` and \`achat_complete\` across **all 11 LLM provider implementations**. When provided, these override the instance-level values for that single call without mutating provider state.

\`\`\`python
def chat_complete(
    self,
    messages: List[Dict[str, Any]],
    stream: Optional[bool] = None,
    tools: Optional[List[Tool]] = None,
    tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
    parallel_tool_calls: Optional[bool] = None,
    validate_tool_calls: bool = False,
    # NEW per-call overrides (None means \"use instance value\")
    max_tokens: Optional[int] = None,
    temperature: Optional[float] = None,
    top_p: Optional[float] = None,
) -> Union[ChatCompletion, Generator[ChatCompletionChunk, None, None]]:
\`\`\`

Same surface on \`achat_complete\`. \`None\` (default) preserves existing instance-level behavior — fully backward compatible.

## Implementation

Three resolver helpers in \`base.py\` (\`_resolve_max_tokens\`, \`_resolve_temperature\`, \`_resolve_top_p\`) follow the existing \`_resolve_tools\` / \`_resolve_tool_choice\` / \`_resolve_parallel_tool_calls\` convention. Each provider calls the resolvers at the top of \`chat_complete\` / \`achat_complete\` and feeds the resolved values into its request-builder.

Anthropic's \`temperature\` + \`top_p\` mutual-exclusivity sanitization (from #100) automatically applies to per-call values too — the rule lives in the request-builder, not in \`chat_complete\`.

## Diff shape

\`\`\`
src/esperanto/providers/llm/base.py              | 57 ++++++++++++++++++++++++
src/esperanto/providers/llm/anthropic.py         | 50 ++++++++++++++++++---
src/esperanto/providers/llm/azure.py             | 56 +++++++++++++++++++----
src/esperanto/providers/llm/google.py            | 53 +++++++++++++++++++---
src/esperanto/providers/llm/groq.py              | 43 ++++++++++++++++--
src/esperanto/providers/llm/mistral.py           | 43 ++++++++++++++++--
src/esperanto/providers/llm/ollama.py            | 47 +++++++++++++++++--
src/esperanto/providers/llm/openai.py            | 53 ++++++++++++++++++++--
src/esperanto/providers/llm/openai_compatible.py | 41 ++++++++++++++---
src/esperanto/providers/llm/openrouter.py        | 43 ++++++++++++++++--
src/esperanto/providers/llm/perplexity.py        | 43 ++++++++++++++++--
src/esperanto/providers/llm/vertex.py            | 49 ++++++++++++++++----
12 files changed, 523 insertions(+), 55 deletions(-)
\`\`\`

All 11 concrete providers + base.

## Test plan

- [x] \`uv run pytest tests/providers tests/unit tests/common_types tests/test_deprecation_warnings.py -q --no-cov\`: **993 passed**, 1 skipped
- [x] \`uv run ruff check .\` clean
- [x] \`uv run mypy src/esperanto\` clean
- [x] Probe verified: \`_get_api_kwargs\` reflects per-call values when provided
- [x] Probe verified: when all three overrides are None, instance values flow through unchanged (no behavior change for existing callers)
- [x] Probe verified: Anthropic per-call \`temperature\` + \`top_p\` together → \`top_p\` dropped + DEBUG log (sanitization from #100 still applies)

## Backward compatibility

All new params default to \`None\`. Every existing call site continues to work unchanged.

## Out of scope

- \`num_ctx\` and other provider-specific params stay in instance config (decided in Group C, Q4, 2026-05-01 — only universal LLM params get the per-call surface).

## References

- Reported in Open Notebook: lfnovo/open-notebook#682
- Decision: Group C, Q1, 2026-05-01

Closes #102.