### PR TITLE
test(integration): add release-gated chat completion tests across all LLM providers (closes #167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Mistral Speech-to-Text provider** — new `MistralSpeechToTextModel` supporting `voxtral-mini-latest` (default) and `voxtral-small-latest`. Unlike OpenAI Whisper, Mistral returns the detected language in the response body, which is surfaced as `TranscriptionResponse.language`. Accessible via `AIFactory.create_stt("mistral")`.
 - **Mistral Speech-to-Text provider** — new `MistralSpeechToTextModel` supporting `voxtral-mini-latest` (default) and `voxtral-small-latest`. Unlike OpenAI Whisper, Mistral returns the detected language in the response body, which is surfaced as `TranscriptionResponse.language`. Accessible via `AIFactory.create_speech_to_text("mistral")`.
 - **`TranscriptionResponse.provider`** — STT responses now expose the originating provider name as an optional field, matching the existing `AudioResponse.provider` field. All STT providers (`openai`, `elevenlabs`, `azure`) already passed this kwarg, but Pydantic was silently dropping it. Existing callers continue to work unchanged. (#126)
+- **Release-gated integration tests for chat completion** — Added `tests/integration/test_chat_completion_real.py` with sync/async and streaming coverage across all LLM providers (OpenAI, Anthropic, Google, Vertex, Azure, Mistral, Ollama, Groq, OpenRouter, Perplexity, DeepSeek, xAI, DashScope, MiniMax).
 
 ### Changed
 

--- a/tests/integration/test_chat_completion_real.py
+++ b/tests/integration/test_chat_completion_real.py
@@ -1,0 +1,735 @@
+"""Real integration tests for chat completion - these call actual APIs.
+
+These tests verify that basic chat completion (sync/async, streaming/non-streaming)
+works correctly with real API calls across all LLM providers.
+
+Run with: uv run pytest tests/integration/test_chat_completion_real.py -v -s
+"""
+
+import os
+
+import pytest
+
+from esperanto import AIFactory
+from esperanto.common_types import ChatCompletion, ChatCompletionChunk
+
+MESSAGES = [{"role": "user", "content": "Say hello in one sentence."}]
+
+
+# =============================================================================
+# OpenAI Tests
+# =============================================================================
+
+
+@pytest.mark.release
+@pytest.mark.skipif(
+    not os.getenv("OPENAI_API_KEY"),
+    reason="OPENAI_API_KEY not configured",
+)
+class TestOpenAIChat:
+    """Real integration tests for OpenAI chat completion."""
+
+    def test_sync_chat_complete(self):
+        model = AIFactory.create_language("openai", "gpt-4o-mini")
+        response = model.chat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    async def test_async_chat_complete(self):
+        model = AIFactory.create_language("openai", "gpt-4o-mini")
+        response = await model.achat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    def test_sync_streaming(self):
+        model = AIFactory.create_language("openai", "gpt-4o-mini")
+        response = model.chat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+    async def test_async_streaming(self):
+        model = AIFactory.create_language("openai", "gpt-4o-mini")
+        response = await model.achat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        async for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+
+# =============================================================================
+# Anthropic Tests
+# =============================================================================
+
+
+@pytest.mark.release
+@pytest.mark.skipif(
+    not os.getenv("ANTHROPIC_API_KEY"),
+    reason="ANTHROPIC_API_KEY not configured",
+)
+class TestAnthropicChat:
+    """Real integration tests for Anthropic chat completion."""
+
+    def test_sync_chat_complete(self):
+        model = AIFactory.create_language("anthropic", "claude-3-5-haiku-latest")
+        response = model.chat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    async def test_async_chat_complete(self):
+        model = AIFactory.create_language("anthropic", "claude-3-5-haiku-latest")
+        response = await model.achat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    def test_sync_streaming(self):
+        model = AIFactory.create_language("anthropic", "claude-3-5-haiku-latest")
+        response = model.chat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+    async def test_async_streaming(self):
+        model = AIFactory.create_language("anthropic", "claude-3-5-haiku-latest")
+        response = await model.achat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        async for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+
+# =============================================================================
+# Google Tests
+# =============================================================================
+
+
+@pytest.mark.release
+@pytest.mark.skipif(
+    not (os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")),
+    reason="GOOGLE_API_KEY or GEMINI_API_KEY not configured",
+)
+class TestGoogleChat:
+    """Real integration tests for Google chat completion."""
+
+    def test_sync_chat_complete(self):
+        api_key = os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
+        model = AIFactory.create_language("google", "gemini-2.0-flash", config={"api_key": api_key})
+        response = model.chat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    async def test_async_chat_complete(self):
+        api_key = os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
+        model = AIFactory.create_language("google", "gemini-2.0-flash", config={"api_key": api_key})
+        response = await model.achat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    def test_sync_streaming(self):
+        api_key = os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
+        model = AIFactory.create_language("google", "gemini-2.0-flash", config={"api_key": api_key})
+        response = model.chat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+    async def test_async_streaming(self):
+        api_key = os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
+        model = AIFactory.create_language("google", "gemini-2.0-flash", config={"api_key": api_key})
+        response = await model.achat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        async for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+
+# =============================================================================
+# Vertex AI Tests
+# =============================================================================
+
+
+@pytest.mark.release
+@pytest.mark.skip(
+    reason="Vertex AI requires ADC or GOOGLE_APPLICATION_CREDENTIALS — not a simple API-key env var; omitted in tool-calling tests for the same reason"
+)
+class TestVertexChat:
+    """Real integration tests for Vertex AI chat completion.
+
+    NOTE: Vertex AI requires Google Application Default Credentials (ADC) or
+    GOOGLE_APPLICATION_CREDENTIALS, not a simple API key. These tests are skipped.
+    """
+
+    def test_sync_chat_complete(self):
+        model = AIFactory.create_language("vertex", "gemini-2.0-flash")
+        response = model.chat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    async def test_async_chat_complete(self):
+        model = AIFactory.create_language("vertex", "gemini-2.0-flash")
+        response = await model.achat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    def test_sync_streaming(self):
+        model = AIFactory.create_language("vertex", "gemini-2.0-flash")
+        response = model.chat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+    async def test_async_streaming(self):
+        model = AIFactory.create_language("vertex", "gemini-2.0-flash")
+        response = await model.achat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        async for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+
+# =============================================================================
+# Azure Tests
+# =============================================================================
+
+
+@pytest.mark.release
+@pytest.mark.skipif(
+    not os.getenv("AZURE_OPENAI_API_KEY_LLM"),
+    reason="AZURE_OPENAI_API_KEY_LLM not configured",
+)
+class TestAzureChat:
+    """Real integration tests for Azure OpenAI chat completion."""
+
+    def test_sync_chat_complete(self):
+        model = AIFactory.create_language(
+            "azure",
+            os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME_LLM", "gpt-4o-mini"),
+            config={
+                "api_key": os.getenv("AZURE_OPENAI_API_KEY_LLM"),
+                "base_url": os.getenv("AZURE_OPENAI_ENDPOINT_LLM"),
+                "api_version": os.getenv("OPENAI_API_VERSION", "2024-12-01-preview"),
+            },
+        )
+        response = model.chat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    async def test_async_chat_complete(self):
+        model = AIFactory.create_language(
+            "azure",
+            os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME_LLM", "gpt-4o-mini"),
+            config={
+                "api_key": os.getenv("AZURE_OPENAI_API_KEY_LLM"),
+                "base_url": os.getenv("AZURE_OPENAI_ENDPOINT_LLM"),
+                "api_version": os.getenv("OPENAI_API_VERSION", "2024-12-01-preview"),
+            },
+        )
+        response = await model.achat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    def test_sync_streaming(self):
+        model = AIFactory.create_language(
+            "azure",
+            os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME_LLM", "gpt-4o-mini"),
+            config={
+                "api_key": os.getenv("AZURE_OPENAI_API_KEY_LLM"),
+                "base_url": os.getenv("AZURE_OPENAI_ENDPOINT_LLM"),
+                "api_version": os.getenv("OPENAI_API_VERSION", "2024-12-01-preview"),
+            },
+        )
+        response = model.chat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+    async def test_async_streaming(self):
+        model = AIFactory.create_language(
+            "azure",
+            os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME_LLM", "gpt-4o-mini"),
+            config={
+                "api_key": os.getenv("AZURE_OPENAI_API_KEY_LLM"),
+                "base_url": os.getenv("AZURE_OPENAI_ENDPOINT_LLM"),
+                "api_version": os.getenv("OPENAI_API_VERSION", "2024-12-01-preview"),
+            },
+        )
+        response = await model.achat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        async for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+
+# =============================================================================
+# Mistral Tests
+# =============================================================================
+
+
+@pytest.mark.release
+@pytest.mark.skipif(
+    not os.getenv("MISTRAL_API_KEY"),
+    reason="MISTRAL_API_KEY not configured",
+)
+class TestMistralChat:
+    """Real integration tests for Mistral chat completion."""
+
+    def test_sync_chat_complete(self):
+        model = AIFactory.create_language("mistral", "mistral-small-latest")
+        response = model.chat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    async def test_async_chat_complete(self):
+        model = AIFactory.create_language("mistral", "mistral-small-latest")
+        response = await model.achat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    def test_sync_streaming(self):
+        model = AIFactory.create_language("mistral", "mistral-small-latest")
+        response = model.chat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+    async def test_async_streaming(self):
+        model = AIFactory.create_language("mistral", "mistral-small-latest")
+        response = await model.achat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        async for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+
+# =============================================================================
+# Ollama Tests
+# =============================================================================
+
+
+@pytest.mark.release
+@pytest.mark.skipif(
+    not os.getenv("OLLAMA_BASE_URL"),
+    reason="OLLAMA_BASE_URL not configured",
+)
+class TestOllamaChat:
+    """Real integration tests for Ollama chat completion."""
+
+    def test_sync_chat_complete(self):
+        model = AIFactory.create_language(
+            "ollama", "qwen3:32b", config={"base_url": os.getenv("OLLAMA_BASE_URL")}
+        )
+        response = model.chat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    async def test_async_chat_complete(self):
+        model = AIFactory.create_language(
+            "ollama", "qwen3:32b", config={"base_url": os.getenv("OLLAMA_BASE_URL")}
+        )
+        response = await model.achat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    def test_sync_streaming(self):
+        model = AIFactory.create_language(
+            "ollama", "qwen3:32b", config={"base_url": os.getenv("OLLAMA_BASE_URL")}
+        )
+        response = model.chat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+    async def test_async_streaming(self):
+        model = AIFactory.create_language(
+            "ollama", "qwen3:32b", config={"base_url": os.getenv("OLLAMA_BASE_URL")}
+        )
+        response = await model.achat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        async for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+
+# =============================================================================
+# Groq Tests
+# =============================================================================
+
+
+@pytest.mark.release
+@pytest.mark.skipif(
+    not os.getenv("GROQ_API_KEY"),
+    reason="GROQ_API_KEY not configured",
+)
+class TestGroqChat:
+    """Real integration tests for Groq chat completion."""
+
+    def test_sync_chat_complete(self):
+        model = AIFactory.create_language("groq", "llama-3.3-70b-versatile")
+        response = model.chat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    async def test_async_chat_complete(self):
+        model = AIFactory.create_language("groq", "llama-3.3-70b-versatile")
+        response = await model.achat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    def test_sync_streaming(self):
+        model = AIFactory.create_language("groq", "llama-3.3-70b-versatile")
+        response = model.chat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+    async def test_async_streaming(self):
+        model = AIFactory.create_language("groq", "llama-3.3-70b-versatile")
+        response = await model.achat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        async for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+
+# =============================================================================
+# OpenRouter Tests
+# =============================================================================
+
+
+@pytest.mark.release
+@pytest.mark.skipif(
+    not os.getenv("OPENROUTER_API_KEY"),
+    reason="OPENROUTER_API_KEY not configured",
+)
+class TestOpenRouterChat:
+    """Real integration tests for OpenRouter chat completion."""
+
+    def test_sync_chat_complete(self):
+        model = AIFactory.create_language("openrouter", "openai/gpt-4o-mini")
+        response = model.chat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    async def test_async_chat_complete(self):
+        model = AIFactory.create_language("openrouter", "openai/gpt-4o-mini")
+        response = await model.achat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    def test_sync_streaming(self):
+        model = AIFactory.create_language("openrouter", "openai/gpt-4o-mini")
+        response = model.chat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+    async def test_async_streaming(self):
+        model = AIFactory.create_language("openrouter", "openai/gpt-4o-mini")
+        response = await model.achat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        async for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+
+# =============================================================================
+# Perplexity Tests
+# =============================================================================
+
+
+@pytest.mark.release
+@pytest.mark.skipif(
+    not os.getenv("PERPLEXITY_API_KEY"),
+    reason="PERPLEXITY_API_KEY not configured",
+)
+class TestPerplexityChat:
+    """Real integration tests for Perplexity chat completion."""
+
+    def test_sync_chat_complete(self):
+        model = AIFactory.create_language("perplexity", "sonar")
+        response = model.chat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    async def test_async_chat_complete(self):
+        model = AIFactory.create_language("perplexity", "sonar")
+        response = await model.achat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    def test_sync_streaming(self):
+        model = AIFactory.create_language("perplexity", "sonar")
+        response = model.chat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+    async def test_async_streaming(self):
+        model = AIFactory.create_language("perplexity", "sonar")
+        response = await model.achat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        async for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+
+# =============================================================================
+# DeepSeek Tests
+# =============================================================================
+
+
+@pytest.mark.release
+@pytest.mark.skipif(
+    not os.getenv("DEEPSEEK_API_KEY"),
+    reason="DEEPSEEK_API_KEY not configured",
+)
+class TestDeepSeekChat:
+    """Real integration tests for DeepSeek chat completion."""
+
+    def test_sync_chat_complete(self):
+        model = AIFactory.create_language("deepseek", "deepseek-chat")
+        response = model.chat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    async def test_async_chat_complete(self):
+        model = AIFactory.create_language("deepseek", "deepseek-chat")
+        response = await model.achat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    def test_sync_streaming(self):
+        model = AIFactory.create_language("deepseek", "deepseek-chat")
+        response = model.chat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+    async def test_async_streaming(self):
+        model = AIFactory.create_language("deepseek", "deepseek-chat")
+        response = await model.achat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        async for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+
+# =============================================================================
+# xAI Tests
+# =============================================================================
+
+
+@pytest.mark.release
+@pytest.mark.skipif(
+    not os.getenv("XAI_API_KEY"),
+    reason="XAI_API_KEY not configured",
+)
+class TestXAIChat:
+    """Real integration tests for xAI chat completion."""
+
+    def test_sync_chat_complete(self):
+        model = AIFactory.create_language("xai", "grok-3")
+        response = model.chat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    async def test_async_chat_complete(self):
+        model = AIFactory.create_language("xai", "grok-3")
+        response = await model.achat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    def test_sync_streaming(self):
+        model = AIFactory.create_language("xai", "grok-3")
+        response = model.chat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+    async def test_async_streaming(self):
+        model = AIFactory.create_language("xai", "grok-3")
+        response = await model.achat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        async for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+
+# =============================================================================
+# DashScope Tests
+# =============================================================================
+
+
+@pytest.mark.release
+@pytest.mark.skipif(
+    not os.getenv("DASHSCOPE_API_KEY"),
+    reason="DASHSCOPE_API_KEY not configured",
+)
+class TestDashScopeChat:
+    """Real integration tests for DashScope chat completion."""
+
+    def test_sync_chat_complete(self):
+        model = AIFactory.create_language("dashscope", "qwen-plus")
+        response = model.chat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    async def test_async_chat_complete(self):
+        model = AIFactory.create_language("dashscope", "qwen-plus")
+        response = await model.achat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    def test_sync_streaming(self):
+        model = AIFactory.create_language("dashscope", "qwen-plus")
+        response = model.chat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+    async def test_async_streaming(self):
+        model = AIFactory.create_language("dashscope", "qwen-plus")
+        response = await model.achat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        async for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+
+# =============================================================================
+# MiniMax Tests
+# =============================================================================
+
+
+@pytest.mark.release
+@pytest.mark.skipif(
+    not os.getenv("MINIMAX_API_KEY"),
+    reason="MINIMAX_API_KEY not configured",
+)
+class TestMiniMaxChat:
+    """Real integration tests for MiniMax chat completion."""
+
+    def test_sync_chat_complete(self):
+        model = AIFactory.create_language("minimax", "MiniMax-M2.5")
+        response = model.chat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    async def test_async_chat_complete(self):
+        model = AIFactory.create_language("minimax", "MiniMax-M2.5")
+        response = await model.achat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 0
+
+    def test_sync_streaming(self):
+        model = AIFactory.create_language("minimax", "MiniMax-M2.5")
+        response = model.chat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0
+
+    async def test_async_streaming(self):
+        model = AIFactory.create_language("minimax", "MiniMax-M2.5")
+        response = await model.achat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        async for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert len(total_content) > 0


### PR DESCRIPTION
## Summary

**Phase 2 of #141.** Adds real-API tests for plain chat completion + streaming across **all 14 LLM providers**, gated by the \`release\` pytest marker (registered in Phase 1 / #166).

This is the regression-prevention bullseye — three of the recent regressions (#119 null embeddings, #128 ToolCall objects in streams, #135 deprecation warnings) were streaming/normalization bugs that mocked tests can't catch. Real-API streaming tests would have caught them.

## Coverage

\`tests/integration/test_chat_completion_real.py\` — 14 provider classes, 4 tests each (56 total):

| Class | Provider | Skipif |
|-------|----------|--------|
| TestOpenAIChat | openai | OPENAI_API_KEY |
| TestAnthropicChat | anthropic | ANTHROPIC_API_KEY |
| TestGoogleChat | google | GOOGLE_API_KEY |
| TestVertexChat | vertex | (skipped — needs GCP setup) |
| TestAzureChat | azure | AZURE_OPENAI_API_KEY |
| TestMistralChat | mistral | MISTRAL_API_KEY |
| TestOllamaChat | ollama | OLLAMA_BASE_URL probe |
| TestGroqChat | groq | GROQ_API_KEY |
| TestOpenRouterChat | openrouter | OPENROUTER_API_KEY |
| TestPerplexityChat | perplexity | PERPLEXITY_API_KEY |
| TestDeepSeekChat | deepseek | DEEPSEEK_API_KEY |
| TestXAIChat | xai | XAI_API_KEY |
| TestDashScopeChat | dashscope | DASHSCOPE_API_KEY |
| TestMiniMaxChat | minimax | MINIMAX_API_KEY |

Per-class tests:
- \`test_sync_chat_complete\` — basic non-tool completion
- \`test_async_chat_complete\` — same on async path
- \`test_sync_streaming\` — chunks normalize, content reconstructs
- \`test_async_streaming\` — same on async stream

All gated with \`@pytest.mark.release\` + \`@pytest.mark.skipif\` so missing keys → skipped, not failed.

## Targeting

This PR targets \`feat/release-test-infrastructure\` (the integration branch), not \`main\`. The full Phase 2-4 of #141 will land on integration first as one validated unit, then ship to main via a single integration→main PR.

## Test plan

- [x] \`uv run pytest -m release tests/integration/test_chat_completion_real.py --collect-only\` — 56 items collected, no errors
- [x] \`uv run pytest\` (default invocation) does NOT collect any of these tests
- [x] \`uv run pytest tests/providers tests/unit tests/common_types tests/test_deprecation_warnings.py -q --no-cov\` exits 0 (996 passed, 1 skipped)
- [x] \`uv run ruff check .\` clean
- [x] \`uv run mypy src/esperanto\` clean
- [x] CHANGELOG.md entry under \`### Added\`

Closes #167. Phase 2 of #141.