### PR TITLE
ci: run lint+test on PRs to feat/* branches too

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'feat/*' ]
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'feat/*' ]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Currently \`lint.yml\` and \`test.yml\` only fire on PRs targeting \`main\`. PRs targeting a feature integration branch (like \`feat/release-test-infrastructure\` where #141 is being staged) only get cubic review and miss the lint+test gates entirely.

This means structural issues can land on the integration branch and only get caught at the final integration→main PR, which is too late for clean per-phase review.

## Change

Both workflows extend their trigger from \`branches: [main]\` to \`branches: [main, 'feat/*']\`. Any PR targeting a \`feat/something\` branch now runs the full lint+test suite alongside cubic review.

## Test plan

- [x] Both workflow files updated symmetrically
- [x] Existing \`branches: [main]\` behavior preserved (main-targeted PRs unchanged)
- [x] PRs to \`feat/*\` branches will now run lint+test
- [x] No code changes; pure CI configuration

## Why now

Phase 2-4 of #141 (#171, #172, #173) all target \`feat/release-test-infrastructure\` and currently get cubic but no lint/test runs. After this lands, those PRs (or any new push to them) will get full CI.