### PR TITLE
test(integration): Phase A review fixes (skipif gating + persistence catch)

### DIFF
--- a/tests/integration/test_chat_completion_real.py
+++ b/tests/integration/test_chat_completion_real.py
@@ -222,8 +222,16 @@ class TestVertexChat:
 
 @pytest.mark.release
 @pytest.mark.skipif(
-    not os.getenv("AZURE_OPENAI_API_KEY_LLM"),
-    reason="AZURE_OPENAI_API_KEY_LLM not configured",
+    not (
+        (os.getenv("AZURE_OPENAI_API_KEY_LLM") or os.getenv("AZURE_OPENAI_API_KEY"))
+        and (os.getenv("AZURE_OPENAI_ENDPOINT_LLM") or os.getenv("AZURE_OPENAI_ENDPOINT"))
+        and (
+            os.getenv("AZURE_OPENAI_API_VERSION_LLM")
+            or os.getenv("OPENAI_API_VERSION")
+            or os.getenv("AZURE_OPENAI_API_VERSION")
+        )
+    ),
+    reason="Azure LLM requires API key, endpoint, and API version (AZURE_OPENAI_API_KEY[_LLM] + AZURE_OPENAI_ENDPOINT[_LLM] + AZURE_OPENAI_API_VERSION[_LLM])",
 )
 class TestAzureChat:
     """Real integration tests for Azure OpenAI chat completion."""
@@ -350,15 +358,15 @@ class TestMistralChat:
 
 @pytest.mark.release
 @pytest.mark.skipif(
-    not os.getenv("OLLAMA_BASE_URL"),
-    reason="OLLAMA_BASE_URL not configured",
+    not (os.getenv("OLLAMA_BASE_URL") or os.getenv("OLLAMA_API_BASE")),
+    reason="OLLAMA_BASE_URL or OLLAMA_API_BASE not configured",
 )
 class TestOllamaChat:
     """Real integration tests for Ollama chat completion."""
 
     def test_sync_chat_complete(self):
         model = AIFactory.create_language(
-            "ollama", "qwen3:32b", config={"base_url": os.getenv("OLLAMA_BASE_URL")}
+            "ollama", "qwen3:32b", config={"base_url": os.getenv("OLLAMA_BASE_URL") or os.getenv("OLLAMA_API_BASE")}
         )
         response = model.chat_complete(messages=MESSAGES)
         assert isinstance(response, ChatCompletion)
@@ -367,7 +375,7 @@ class TestOllamaChat:
 
     async def test_async_chat_complete(self):
         model = AIFactory.create_language(
-            "ollama", "qwen3:32b", config={"base_url": os.getenv("OLLAMA_BASE_URL")}
+            "ollama", "qwen3:32b", config={"base_url": os.getenv("OLLAMA_BASE_URL") or os.getenv("OLLAMA_API_BASE")}
         )
         response = await model.achat_complete(messages=MESSAGES)
         assert isinstance(response, ChatCompletion)
@@ -376,7 +384,7 @@ class TestOllamaChat:
 
     def test_sync_streaming(self):
         model = AIFactory.create_language(
-            "ollama", "qwen3:32b", config={"base_url": os.getenv("OLLAMA_BASE_URL")}
+            "ollama", "qwen3:32b", config={"base_url": os.getenv("OLLAMA_BASE_URL") or os.getenv("OLLAMA_API_BASE")}
         )
         response = model.chat_complete(messages=MESSAGES, stream=True)
         total_content = ""
@@ -388,7 +396,7 @@ class TestOllamaChat:
 
     async def test_async_streaming(self):
         model = AIFactory.create_language(
-            "ollama", "qwen3:32b", config={"base_url": os.getenv("OLLAMA_BASE_URL")}
+            "ollama", "qwen3:32b", config={"base_url": os.getenv("OLLAMA_BASE_URL") or os.getenv("OLLAMA_API_BASE")}
         )
         response = await model.achat_complete(messages=MESSAGES, stream=True)
         total_content = ""

--- a/tests/integration/test_tts_real.py
+++ b/tests/integration/test_tts_real.py
@@ -169,11 +169,7 @@ class TestVertexTTS:
     not (
         (os.getenv("AZURE_OPENAI_API_KEY_TTS") or os.getenv("AZURE_OPENAI_API_KEY"))
         and (os.getenv("AZURE_OPENAI_ENDPOINT_TTS") or os.getenv("AZURE_OPENAI_ENDPOINT"))
-        and (
-            os.getenv("AZURE_OPENAI_API_VERSION_TTS")
-            or os.getenv("OPENAI_API_VERSION")
-            or os.getenv("AZURE_OPENAI_API_VERSION")
-        )
+        and (os.getenv("AZURE_OPENAI_API_VERSION_TTS") or os.getenv("AZURE_OPENAI_API_VERSION"))
     ),
     reason="Azure TTS requires API key, endpoint, and API version (AZURE_OPENAI_API_KEY[_TTS] + AZURE_OPENAI_ENDPOINT[_TTS] + AZURE_OPENAI_API_VERSION[_TTS])",
 )
@@ -291,12 +287,20 @@ class TestOpenAICompatibleTTS:
     """Real integration tests for OpenAI-compatible text-to-speech."""
 
     def test_sync_generate_speech(self):
-        """Test sync speech generation."""
+        """Test sync speech generation.
+
+        Uses the provider's default voice rather than hardcoding 'alloy', so
+        non-OpenAI-mimicking endpoints (which don't have an 'alloy' voice)
+        still work. Override via OPENAI_COMPATIBLE_TTS_VOICE if the default
+        voice is not appropriate for the configured backend.
+        """
+        voice_override = os.getenv("OPENAI_COMPATIBLE_TTS_VOICE")
+        kwargs = {"voice": voice_override} if voice_override else {}
         model = AIFactory.create_text_to_speech(
             "openai-compatible",
             config={"base_url": os.getenv("OPENAI_COMPATIBLE_BASE_URL_TTS") or os.getenv("OPENAI_COMPATIBLE_BASE_URL")},
         )
-        response = model.generate_speech(TEST_TEXT, voice="alloy")
+        response = model.generate_speech(TEST_TEXT, **kwargs)
         assert response.audio_data
         assert response.content_type.startswith("audio/")
 


### PR DESCRIPTION
## Summary

Pre-flight Phase A static review of the integration branch (\`feat/release-test-infrastructure\`) caught 4 issues that the cubic reviews on the per-phase PRs (#171, #172, #173) missed.

## The 4 fixes

| # | File | Issue | Notes |
|---|------|-------|-------|
| 1 | \`test_chat_completion_real.py\` | Azure LLM skipif gates only on API key | Same incompleteness pattern cubic caught on embedding/STT/TTS but missed in the larger chat file. |
| 2 | \`test_chat_completion_real.py\` | Ollama chat skipif inconsistent with embedding | Embedding accepts \`OLLAMA_BASE_URL or OLLAMA_API_BASE\`; chat only accepted the first. Provider source falls back through both. |
| 3 | \`test_tts_real.py\` | **OC TTS sync test still hardcoded \`voice=\"alloy\"\`** | Round-3 cubic feedback on #173 caught this but the in-line fix only persisted for async — sync was lost when a Python helper script crashed mid-run before writing the file. Cubic re-reviewed at 5/5 and missed the partial fix. |
| 4 | \`test_tts_real.py\` | Azure TTS skipif had stale \`OPENAI_API_VERSION\` fallback | Azure TTS provider only reads \`AZURE_OPENAI_API_VERSION_TTS\` or \`AZURE_OPENAI_API_VERSION\` (unlike LLM/embedding which DO read \`OPENAI_API_VERSION\` for backward compat). Same persistence bug as #3. |

## Lessons

The persistence bug (#3 + #4) is a real cautionary tale: when applying iterative fixes via scripts that crash mid-run, the partial state can survive into a commit and slip through subsequent reviews because the file LOOKS partially correct. The Phase A review framework caught what cubic's narrow-window reviews didn't.

## Test plan

- [x] \`uv run pytest -m release tests/integration/ --collect-only\` — 151 tests collect unchanged
- [x] \`uv run ruff check\` clean
- [x] No source code changes; pure test-file gating fixes
- [x] No CHANGELOG entry needed (these are test-infra refinements, not user-facing)

## Targets

This PR targets \`feat/release-test-infrastructure\`. After merge, the integration branch will be ready for Phases B (structural verification) and C (smoke run with real keys) of the pre-flight review.

Part of the #141 test infrastructure delivery.