### PR TITLE
fix(tests): allow release tests to access real provider env vars

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -299,6 +299,15 @@ _PROVIDER_ENV_VARS = [
 
 
 @pytest.fixture(autouse=True)
-def _clean_provider_env(monkeypatch):
+def _clean_provider_env(request, monkeypatch):
+    """Scrub provider env vars before each test to prevent local credentials
+    from leaking into provider tests (see #144 / PR #152).
+
+    EXCEPTION: tests marked with ``@pytest.mark.release`` deliberately need
+    real provider credentials in order to make actual API calls. Skip the
+    cleanup for those so the release suite (``uv run pytest -m release``)
+    can find the keys it needs."""
+    if request.node.get_closest_marker("release"):
+        return
     for var in _PROVIDER_ENV_VARS:
         monkeypatch.delenv(var, raising=False)


### PR DESCRIPTION
## Summary

The \`_clean_provider_env\` autouse fixture (added in PR #152 to fix env-pollution from local shell credentials leaking into mocked provider tests) was scrubbing env vars for **all** tests, including release-gated real-API tests. Result: \`uv run pytest -m release\` silently failed every test with \"API key not found\" even when keys were correctly set in \`.env\`, because the fixture \`monkeypatch.delenv\`'d them before the test ran.

## Fix

Skip the cleanup when the test carries the \`@pytest.mark.release\` marker. Those tests deliberately need real credentials to make actual API calls; that's the whole point of the marker.

\`\`\`python
@pytest.fixture(autouse=True)
def _clean_provider_env(request, monkeypatch):
    if request.node.get_closest_marker(\"release\"):
        return  # Release tests need real env vars
    for var in _PROVIDER_ENV_VARS:
        monkeypatch.delenv(var, raising=False)
\`\`\`

## Why this slipped through

Phase 1 (#170) introduced the \`release\` marker and applied it to the existing \`test_tool_calling_real.py\`. Phase 2-4 (#171, #172, #173) added 129 more release-gated tests. None of these PRs ever actually **ran** the release tests against real APIs — every cubic review and CI run used \`--collect-only\` or excluded the marker. Phase A static review and Phase B structural verification of the integration branch also both used \`--collect-only\`. The first end-to-end run of the release suite was Phase C of the integration→main pre-flight review, where 17 tests failed in one shot — all with the same env-stripping signature.

## Verified

- \`uv run pytest tests/providers tests/unit tests/common_types tests/test_deprecation_warnings.py -q --no-cov\` → **1022 passed** (env scrub preserved for non-release tests; the original PR #144/#152 fix still works as designed)
- \`uv run pytest -m release tests/integration/test_chat_completion_real.py::TestOpenAIChat::test_sync_chat_complete --no-cov -v\` → **passes against real OpenAI API**

## Targets

This PR targets \`feat/release-test-infrastructure\` (the integration branch). After merge, Phase C of the pre-flight review can actually run, and the integration→main PR will ship the fix as part of the test-infra delivery.

Part of #141 test infrastructure delivery.