### PR TITLE
test(integration): Ollama auto-probe + provider credentials reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,34 @@ uv run pytest -m release
 - They are deliberately excluded from CI. Running them is a local-only ritual, intended for maintainers to verify everything works end-to-end before publishing a release.
 - Do not add release tests to the default test scope, and do not run them in automated pipelines.
 
+### Provider credentials reference
+
+Each release-gated test class is `skipif`-gated on the env vars its provider needs. Set whichever subset you want to validate; tests without configured credentials skip cleanly. Common envs:
+
+| Provider | Required env vars |
+|----------|-------------------|
+| OpenAI | `OPENAI_API_KEY` |
+| Anthropic | `ANTHROPIC_API_KEY` |
+| Google (Gemini) | `GOOGLE_API_KEY` or `GEMINI_API_KEY` |
+| Vertex AI | `GOOGLE_APPLICATION_CREDENTIALS` + (`VERTEX_PROJECT` or `GOOGLE_CLOUD_PROJECT`) |
+| Azure OpenAI | `AZURE_OPENAI_API_KEY[_LLM/_EMBEDDING/_STT/_TTS]` + `AZURE_OPENAI_ENDPOINT[_*]` + `AZURE_OPENAI_API_VERSION[_*]`; for TTS also `AZURE_OPENAI_DEPLOYMENT_NAME_TTS` |
+| Ollama | none — auto-probes `http://localhost:11434`. Override with `OLLAMA_BASE_URL` or `OLLAMA_API_BASE` for remote/non-default. |
+| Mistral | `MISTRAL_API_KEY` |
+| Groq | `GROQ_API_KEY` |
+| DeepSeek | `DEEPSEEK_API_KEY` |
+| xAI | `XAI_API_KEY` |
+| OpenRouter | `OPENROUTER_API_KEY` |
+| Perplexity | `PERPLEXITY_API_KEY` (note: tool-calling tests skip — Perplexity API doesn't support tools) |
+| MiniMax | `MINIMAX_API_KEY` |
+| DashScope (Qwen) | `DASHSCOPE_API_KEY` |
+| Jina | `JINA_API_KEY` |
+| Voyage | `VOYAGE_API_KEY` |
+| ElevenLabs | `ELEVENLABS_API_KEY` |
+| Transformers (local reranker) | none — gates on `sentence-transformers` package being installed |
+| OpenAI-compatible (LiteLLM, vLLM, Together, etc.) | `OPENAI_COMPATIBLE_API_KEY[_LLM/_EMBEDDING/_STT/_TTS]` + `OPENAI_COMPATIBLE_BASE_URL[_*]` |
+
+If a test fails with a "deployment not found" or similar provider-specific error rather than skipping, it usually means partial credentials are set (e.g., API key but no endpoint for Azure). The skipif gates require all the env vars the provider's `__post_init__` actually reads.
+
 ## Adding a New Provider
 
 This is the most common type of contribution. To keep Esperanto maintainable, we have clear criteria for what we accept.

--- a/tests/integration/test_chat_completion_real.py
+++ b/tests/integration/test_chat_completion_real.py
@@ -13,6 +13,29 @@ import pytest
 from esperanto import AIFactory
 from esperanto.common_types import ChatCompletion, ChatCompletionChunk
 
+
+def _ollama_available() -> bool:
+    """Probe for a reachable Ollama instance.
+
+    Ollama defaults to ``http://localhost:11434`` per its own provider source,
+    so the test should run whenever Ollama is reachable — locally OR via the
+    optional ``OLLAMA_BASE_URL`` / ``OLLAMA_API_BASE`` env override. Avoids
+    skipping tests when the user has Ollama running locally without setting
+    an env var.
+    """
+    import httpx
+    base_url = (
+        os.getenv("OLLAMA_BASE_URL")
+        or os.getenv("OLLAMA_API_BASE")
+        or "http://localhost:11434"
+    )
+    try:
+        response = httpx.get(f"{base_url}/api/tags", timeout=2.0)
+        return response.status_code == 200
+    except Exception:
+        return False
+
+
 MESSAGES = [{"role": "user", "content": "Say hello in one sentence."}]
 
 
@@ -358,8 +381,8 @@ class TestMistralChat:
 
 @pytest.mark.release
 @pytest.mark.skipif(
-    not (os.getenv("OLLAMA_BASE_URL") or os.getenv("OLLAMA_API_BASE")),
-    reason="OLLAMA_BASE_URL or OLLAMA_API_BASE not configured",
+    not _ollama_available(),
+    reason="Ollama not reachable at configured base URL or localhost:11434",
 )
 class TestOllamaChat:
     """Real integration tests for Ollama chat completion."""

--- a/tests/integration/test_embedding_real.py
+++ b/tests/integration/test_embedding_real.py
@@ -48,6 +48,28 @@ def _assert_valid_embedding(result: list, expected_len: int) -> None:
 # =============================================================================
 
 
+def _ollama_available() -> bool:
+    """Probe for a reachable Ollama instance.
+
+    Ollama defaults to ``http://localhost:11434`` per its own provider source,
+    so the test should run whenever Ollama is reachable — locally OR via the
+    optional ``OLLAMA_BASE_URL`` / ``OLLAMA_API_BASE`` env override. Avoids
+    skipping tests when the user has Ollama running locally without setting
+    an env var.
+    """
+    import httpx
+    base_url = (
+        os.getenv("OLLAMA_BASE_URL")
+        or os.getenv("OLLAMA_API_BASE")
+        or "http://localhost:11434"
+    )
+    try:
+        response = httpx.get(f"{base_url}/api/tags", timeout=2.0)
+        return response.status_code == 200
+    except Exception:
+        return False
+
+
 @pytest.mark.release
 @pytest.mark.skipif(
     not os.getenv("OPENAI_API_KEY"),
@@ -335,8 +357,8 @@ class TestTransformersEmbedding:
 
 @pytest.mark.release
 @pytest.mark.skipif(
-    not (os.getenv("OLLAMA_BASE_URL") or os.getenv("OLLAMA_API_BASE")),
-    reason="OLLAMA_BASE_URL or OLLAMA_API_BASE not configured",
+    not _ollama_available(),
+    reason="Ollama not reachable at configured base URL or localhost:11434",
 )
 class TestOllamaEmbedding:
     """Real integration tests for Ollama embeddings."""

--- a/tests/integration/test_tool_calling_real.py
+++ b/tests/integration/test_tool_calling_real.py
@@ -74,6 +74,28 @@ def weather_tools():
 # =============================================================================
 
 
+def _ollama_available() -> bool:
+    """Probe for a reachable Ollama instance.
+
+    Ollama defaults to ``http://localhost:11434`` per its own provider source,
+    so the test should run whenever Ollama is reachable — locally OR via the
+    optional ``OLLAMA_BASE_URL`` / ``OLLAMA_API_BASE`` env override. Avoids
+    skipping tests when the user has Ollama running locally without setting
+    an env var.
+    """
+    import httpx
+    base_url = (
+        os.getenv("OLLAMA_BASE_URL")
+        or os.getenv("OLLAMA_API_BASE")
+        or "http://localhost:11434"
+    )
+    try:
+        response = httpx.get(f"{base_url}/api/tags", timeout=2.0)
+        return response.status_code == 200
+    except Exception:
+        return False
+
+
 @pytest.mark.release
 @pytest.mark.skipif(
     not os.getenv("OPENAI_API_KEY"),
@@ -899,8 +921,8 @@ class TestAzureToolCalling:
 
 @pytest.mark.release
 @pytest.mark.skipif(
-    not os.getenv("OLLAMA_BASE_URL"),
-    reason="OLLAMA_BASE_URL not configured",
+    not _ollama_available(),
+    reason="Ollama not reachable at configured base URL or localhost:11434",
 )
 class TestOllamaToolCalling:
     """Real integration tests for Ollama tool calling."""


### PR DESCRIPTION
## Summary

Two improvements caught during the integration→main spot-check (Phase E review):

### 1. Ollama auto-probe instead of env-var requirement

Previously, Ollama release tests skipped unless \`OLLAMA_BASE_URL\` or \`OLLAMA_API_BASE\` was explicitly set in \`.env\`. But the Ollama provider source falls through to \`http://localhost:11434\` by default — so users with local Ollama running had their tests skipped unnecessarily.

Replaced the env-var skipif with a \`_ollama_available()\` helper that probes \`{base_url}/api/tags\` at the configured-or-default URL:

\`\`\`python
def _ollama_available() -> bool:
    base_url = (
        os.getenv(\"OLLAMA_BASE_URL\")
        or os.getenv(\"OLLAMA_API_BASE\")
        or \"http://localhost:11434\"
    )
    try:
        response = httpx.get(f\"{base_url}/api/tags\", timeout=2.0)
        return response.status_code == 200
    except Exception:
        return False
\`\`\`

Applied across all three Ollama-using release files: \`test_chat_completion_real.py\`, \`test_embedding_real.py\`, and \`test_tool_calling_real.py\` (pre-existing). ~13 tests now run for users with local Ollama, ~0 effort.

### 2. Provider credentials reference table in CONTRIBUTING

Added a table under \`## Release Tests\` listing which env vars enable each provider class. Useful for maintainers running the release suite to understand at a glance which subset their \`.env\` exercises and what extra credentials would expand coverage.

Covers all 19 provider integrations (LLM + embedding + STT + TTS + reranker + their type-suffixed Azure variants).

## Targets

\`feat/release-test-infrastructure\`. Once merged, #181 (integration→main) picks up both improvements automatically.

Part of #141 test infrastructure delivery.