### PR TITLE
fix: address 6 cubic findings on integration→main PR #181

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ Each release-gated test class is `skipif`-gated on the env vars its provider nee
 | OpenAI | `OPENAI_API_KEY` |
 | Anthropic | `ANTHROPIC_API_KEY` |
 | Google (Gemini) | `GOOGLE_API_KEY` or `GEMINI_API_KEY` |
-| Vertex AI | `GOOGLE_APPLICATION_CREDENTIALS` + (`VERTEX_PROJECT` or `GOOGLE_CLOUD_PROJECT`) |
+| Vertex AI | `VERTEX_PROJECT` or `GOOGLE_CLOUD_PROJECT` (auth auto-discovered: ADC, `GOOGLE_APPLICATION_CREDENTIALS`, or `gcloud auth application-default login`) |
 | Azure OpenAI | `AZURE_OPENAI_API_KEY[_LLM/_EMBEDDING/_STT/_TTS]` + `AZURE_OPENAI_ENDPOINT[_*]` + `AZURE_OPENAI_API_VERSION[_*]`; for TTS also `AZURE_OPENAI_DEPLOYMENT_NAME_TTS` |
 | Ollama | none — auto-probes `http://localhost:11434`. Override with `OLLAMA_BASE_URL` or `OLLAMA_API_BASE` for remote/non-default. |
 | Mistral | `MISTRAL_API_KEY` |
@@ -139,7 +139,7 @@ Each release-gated test class is `skipif`-gated on the env vars its provider nee
 | Voyage | `VOYAGE_API_KEY` |
 | ElevenLabs | `ELEVENLABS_API_KEY` |
 | Transformers (local reranker) | none — gates on `sentence-transformers` package being installed |
-| OpenAI-compatible (LiteLLM, vLLM, Together, etc.) | `OPENAI_COMPATIBLE_API_KEY[_LLM/_EMBEDDING/_STT/_TTS]` + `OPENAI_COMPATIBLE_BASE_URL[_*]` |
+| OpenAI-compatible (LiteLLM, vLLM, Together, etc.) | `OPENAI_COMPATIBLE_BASE_URL[_LLM/_EMBEDDING/_STT/_TTS]` (required); `OPENAI_COMPATIBLE_API_KEY[_*]` (optional — local servers like LiteLLM may not need auth; cloud-hosted ones like Together do) |
 
 If a test fails with a "deployment not found" or similar provider-specific error rather than skipping, it usually means partial credentials are set (e.g., API key but no endpoint for Azure). The skipif gates require all the env vars the provider's `__post_init__` actually reads.
 

--- a/tests/integration/test_chat_completion_real.py
+++ b/tests/integration/test_chat_completion_real.py
@@ -14,14 +14,19 @@ from esperanto import AIFactory
 from esperanto.common_types import ChatCompletion, ChatCompletionChunk
 
 
-def _ollama_available() -> bool:
-    """Probe for a reachable Ollama instance.
+def _ollama_available(required_model: str = "") -> bool:
+    """Probe for a reachable Ollama instance, optionally requiring a model.
 
     Ollama defaults to ``http://localhost:11434`` per its own provider source,
     so the test should run whenever Ollama is reachable — locally OR via the
     optional ``OLLAMA_BASE_URL`` / ``OLLAMA_API_BASE`` env override. Avoids
     skipping tests when the user has Ollama running locally without setting
     an env var.
+
+    When ``required_model`` is supplied, also confirm that model is in the
+    server's ``/api/tags`` listing — protects tests that need a specific
+    model (e.g. tool-calling needs ``qwen3:32b``) from running and failing
+    against a server that doesn't have it pulled.
     """
     import httpx
     base_url = (
@@ -31,7 +36,12 @@ def _ollama_available() -> bool:
     )
     try:
         response = httpx.get(f"{base_url}/api/tags", timeout=2.0)
-        return response.status_code == 200
+        if response.status_code != 200:
+            return False
+        if required_model:
+            tags = [m.get("name", "") for m in response.json().get("models", [])]
+            return any(required_model in tag for tag in tags)
+        return True
     except Exception:
         return False
 
@@ -193,14 +203,17 @@ class TestGoogleChat:
 
 
 @pytest.mark.release
-@pytest.mark.skip(
-    reason="Vertex AI requires ADC or GOOGLE_APPLICATION_CREDENTIALS — not a simple API-key env var; omitted in tool-calling tests for the same reason"
+@pytest.mark.release
+@pytest.mark.skipif(
+    not (os.getenv("VERTEX_PROJECT") or os.getenv("GOOGLE_CLOUD_PROJECT")),
+    reason="Vertex AI requires VERTEX_PROJECT or GOOGLE_CLOUD_PROJECT (auth via ADC, GOOGLE_APPLICATION_CREDENTIALS, or gcloud)",
 )
 class TestVertexChat:
     """Real integration tests for Vertex AI chat completion.
 
-    NOTE: Vertex AI requires Google Application Default Credentials (ADC) or
-    GOOGLE_APPLICATION_CREDENTIALS, not a simple API key. These tests are skipped.
+    NOTE: Vertex AI requires a project ID via env var. Authentication is
+    auto-discovered by the Google SDK (ADC, GOOGLE_APPLICATION_CREDENTIALS,
+    or gcloud login).
     """
 
     def test_sync_chat_complete(self):
@@ -264,9 +277,14 @@ class TestAzureChat:
             "azure",
             os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME_LLM", "gpt-4o-mini"),
             config={
-                "api_key": os.getenv("AZURE_OPENAI_API_KEY_LLM"),
-                "base_url": os.getenv("AZURE_OPENAI_ENDPOINT_LLM"),
-                "api_version": os.getenv("OPENAI_API_VERSION", "2024-12-01-preview"),
+                "api_key": os.getenv("AZURE_OPENAI_API_KEY_LLM") or os.getenv("AZURE_OPENAI_API_KEY"),
+                "base_url": os.getenv("AZURE_OPENAI_ENDPOINT_LLM") or os.getenv("AZURE_OPENAI_ENDPOINT"),
+                "api_version": (
+                    os.getenv("AZURE_OPENAI_API_VERSION_LLM")
+                    or os.getenv("OPENAI_API_VERSION")
+                    or os.getenv("AZURE_OPENAI_API_VERSION")
+                    or "2024-12-01-preview"
+                ),
             },
         )
         response = model.chat_complete(messages=MESSAGES)
@@ -279,9 +297,14 @@ class TestAzureChat:
             "azure",
             os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME_LLM", "gpt-4o-mini"),
             config={
-                "api_key": os.getenv("AZURE_OPENAI_API_KEY_LLM"),
-                "base_url": os.getenv("AZURE_OPENAI_ENDPOINT_LLM"),
-                "api_version": os.getenv("OPENAI_API_VERSION", "2024-12-01-preview"),
+                "api_key": os.getenv("AZURE_OPENAI_API_KEY_LLM") or os.getenv("AZURE_OPENAI_API_KEY"),
+                "base_url": os.getenv("AZURE_OPENAI_ENDPOINT_LLM") or os.getenv("AZURE_OPENAI_ENDPOINT"),
+                "api_version": (
+                    os.getenv("AZURE_OPENAI_API_VERSION_LLM")
+                    or os.getenv("OPENAI_API_VERSION")
+                    or os.getenv("AZURE_OPENAI_API_VERSION")
+                    or "2024-12-01-preview"
+                ),
             },
         )
         response = await model.achat_complete(messages=MESSAGES)
@@ -294,9 +317,14 @@ class TestAzureChat:
             "azure",
             os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME_LLM", "gpt-4o-mini"),
             config={
-                "api_key": os.getenv("AZURE_OPENAI_API_KEY_LLM"),
-                "base_url": os.getenv("AZURE_OPENAI_ENDPOINT_LLM"),
-                "api_version": os.getenv("OPENAI_API_VERSION", "2024-12-01-preview"),
+                "api_key": os.getenv("AZURE_OPENAI_API_KEY_LLM") or os.getenv("AZURE_OPENAI_API_KEY"),
+                "base_url": os.getenv("AZURE_OPENAI_ENDPOINT_LLM") or os.getenv("AZURE_OPENAI_ENDPOINT"),
+                "api_version": (
+                    os.getenv("AZURE_OPENAI_API_VERSION_LLM")
+                    or os.getenv("OPENAI_API_VERSION")
+                    or os.getenv("AZURE_OPENAI_API_VERSION")
+                    or "2024-12-01-preview"
+                ),
             },
         )
         response = model.chat_complete(messages=MESSAGES, stream=True)
@@ -312,9 +340,14 @@ class TestAzureChat:
             "azure",
             os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME_LLM", "gpt-4o-mini"),
             config={
-                "api_key": os.getenv("AZURE_OPENAI_API_KEY_LLM"),
-                "base_url": os.getenv("AZURE_OPENAI_ENDPOINT_LLM"),
-                "api_version": os.getenv("OPENAI_API_VERSION", "2024-12-01-preview"),
+                "api_key": os.getenv("AZURE_OPENAI_API_KEY_LLM") or os.getenv("AZURE_OPENAI_API_KEY"),
+                "base_url": os.getenv("AZURE_OPENAI_ENDPOINT_LLM") or os.getenv("AZURE_OPENAI_ENDPOINT"),
+                "api_version": (
+                    os.getenv("AZURE_OPENAI_API_VERSION_LLM")
+                    or os.getenv("OPENAI_API_VERSION")
+                    or os.getenv("AZURE_OPENAI_API_VERSION")
+                    or "2024-12-01-preview"
+                ),
             },
         )
         response = await model.achat_complete(messages=MESSAGES, stream=True)

--- a/tests/integration/test_embedding_real.py
+++ b/tests/integration/test_embedding_real.py
@@ -48,14 +48,19 @@ def _assert_valid_embedding(result: list, expected_len: int) -> None:
 # =============================================================================
 
 
-def _ollama_available() -> bool:
-    """Probe for a reachable Ollama instance.
+def _ollama_available(required_model: str = "") -> bool:
+    """Probe for a reachable Ollama instance, optionally requiring a model.
 
     Ollama defaults to ``http://localhost:11434`` per its own provider source,
     so the test should run whenever Ollama is reachable — locally OR via the
     optional ``OLLAMA_BASE_URL`` / ``OLLAMA_API_BASE`` env override. Avoids
     skipping tests when the user has Ollama running locally without setting
     an env var.
+
+    When ``required_model`` is supplied, also confirm that model is in the
+    server's ``/api/tags`` listing — protects tests that need a specific
+    model (e.g. tool-calling needs ``qwen3:32b``) from running and failing
+    against a server that doesn't have it pulled.
     """
     import httpx
     base_url = (
@@ -65,7 +70,12 @@ def _ollama_available() -> bool:
     )
     try:
         response = httpx.get(f"{base_url}/api/tags", timeout=2.0)
-        return response.status_code == 200
+        if response.status_code != 200:
+            return False
+        if required_model:
+            tags = [m.get("name", "") for m in response.json().get("models", [])]
+            return any(required_model in tag for tag in tags)
+        return True
     except Exception:
         return False
 

--- a/tests/integration/test_tool_calling_real.py
+++ b/tests/integration/test_tool_calling_real.py
@@ -74,14 +74,19 @@ def weather_tools():
 # =============================================================================
 
 
-def _ollama_available() -> bool:
-    """Probe for a reachable Ollama instance.
+def _ollama_available(required_model: str = "") -> bool:
+    """Probe for a reachable Ollama instance, optionally requiring a model.
 
     Ollama defaults to ``http://localhost:11434`` per its own provider source,
     so the test should run whenever Ollama is reachable — locally OR via the
     optional ``OLLAMA_BASE_URL`` / ``OLLAMA_API_BASE`` env override. Avoids
     skipping tests when the user has Ollama running locally without setting
     an env var.
+
+    When ``required_model`` is supplied, also confirm that model is in the
+    server's ``/api/tags`` listing — protects tests that need a specific
+    model (e.g. tool-calling needs ``qwen3:32b``) from running and failing
+    against a server that doesn't have it pulled.
     """
     import httpx
     base_url = (
@@ -91,7 +96,12 @@ def _ollama_available() -> bool:
     )
     try:
         response = httpx.get(f"{base_url}/api/tags", timeout=2.0)
-        return response.status_code == 200
+        if response.status_code != 200:
+            return False
+        if required_model:
+            tags = [m.get("name", "") for m in response.json().get("models", [])]
+            return any(required_model in tag for tag in tags)
+        return True
     except Exception:
         return False
 
@@ -921,8 +931,8 @@ class TestAzureToolCalling:
 
 @pytest.mark.release
 @pytest.mark.skipif(
-    not _ollama_available(),
-    reason="Ollama not reachable at configured base URL or localhost:11434",
+    not _ollama_available(required_model="qwen3:32b"),
+    reason="Ollama not reachable, or qwen3:32b model not pulled (pull via: ollama pull qwen3:32b)",
 )
 class TestOllamaToolCalling:
     """Real integration tests for Ollama tool calling."""

--- a/tests/integration/test_tts_real.py
+++ b/tests/integration/test_tts_real.py
@@ -185,9 +185,10 @@ class TestAzureTTS:
         """Test sync speech generation."""
         model = AIFactory.create_text_to_speech(
             "azure",
+            os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME_TTS"),
             config={
-                "api_key": os.getenv("AZURE_OPENAI_API_KEY_TTS"),
-                "base_url": os.getenv("AZURE_OPENAI_ENDPOINT_TTS"),
+                "api_key": os.getenv("AZURE_OPENAI_API_KEY_TTS") or os.getenv("AZURE_OPENAI_API_KEY"),
+                "base_url": os.getenv("AZURE_OPENAI_ENDPOINT_TTS") or os.getenv("AZURE_OPENAI_ENDPOINT"),
             },
         )
         response = model.generate_speech(TEST_TEXT, voice="alloy")
@@ -198,9 +199,10 @@ class TestAzureTTS:
         """Test async speech generation."""
         model = AIFactory.create_text_to_speech(
             "azure",
+            os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME_TTS"),
             config={
-                "api_key": os.getenv("AZURE_OPENAI_API_KEY_TTS"),
-                "base_url": os.getenv("AZURE_OPENAI_ENDPOINT_TTS"),
+                "api_key": os.getenv("AZURE_OPENAI_API_KEY_TTS") or os.getenv("AZURE_OPENAI_API_KEY"),
+                "base_url": os.getenv("AZURE_OPENAI_ENDPOINT_TTS") or os.getenv("AZURE_OPENAI_ENDPOINT"),
             },
         )
 


### PR DESCRIPTION
Addresses all 6 cubic findings on PR #181 (integration→main spot-check round).

| # | Severity | Fix |
|---|---|---|
| 1 | P1 | Azure TTS now passes \`AZURE_OPENAI_DEPLOYMENT_NAME_TTS\` as \`model_name\` (was using default \`tts-1\`). Also adds endpoint/key fallback to unsuffixed Azure envs. |
| 2 | P2 | Azure LLM api_version/key/endpoint precedence now matches the provider source: \`*_LLM\` → \`OPENAI_API_VERSION\` (for version) / unsuffixed Azure envs (for key+endpoint) → fallback. |
| 3 | P2 | Vertex chat tests were unconditionally skipped (harny gave up). Now \`skipif\` on \`VERTEX_PROJECT\`/\`GOOGLE_CLOUD_PROJECT\` so they run when configured. |
| 4 | P2 | Ollama tool-calling now also probes for \`qwen3:32b\` via \`/api/tags\` (extended \`_ollama_available()\` helper). Skips cleanly when model isn't pulled. |
| 5 | P2 | CONTRIBUTING Vertex row corrected — Google SDK auto-discovers auth; only the project env var is strictly required. |
| 6 | P2 | CONTRIBUTING OpenAI-compatible row corrected — API key is optional (local LiteLLM doesn't need auth). |

## Verified

Smoke-ran the affected providers: \`TestAzureChat\` (4) PASS, \`TestVertexChat\` (4) SKIP with informative new reason, \`TestAzureTTS\` (2) SKIP, \`TestOllamaToolCalling\` (2) SKIP with model-not-pulled message.

## Targets

\`feat/release-test-infrastructure\`. Once merged, PR #181 (integration→main) auto-picks up all 6 fixes and goes back to cubic for re-review.

Part of #141 test infrastructure delivery.