### PR TITLE
docs(contributing): add release-test playbook for maintainers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,109 @@ Each release-gated test class is `skipif`-gated on the env vars its provider nee
 
 If a test fails with a "deployment not found" or similar provider-specific error rather than skipping, it usually means partial credentials are set (e.g., API key but no endpoint for Azure). The skipif gates require all the env vars the provider's `__post_init__` actually reads.
 
+### Release-test playbook
+
+A start-to-finish runbook for the release-time validation ritual.
+
+**1. Pre-flight**
+
+```bash
+# Be on main, fully synced
+git checkout main
+git pull --ff-only
+
+# Working tree clean (release tests must not be polluted by WIP changes)
+git status
+
+# .env loaded with the credentials you want to exercise
+ls .env
+```
+
+The release suite is meant to be run from `main` against the code about to ship — do not run it from a feature branch unless you're specifically validating that branch.
+
+**2. Run the full suite**
+
+```bash
+uv run pytest -m release
+```
+
+Expected runtime: **~2-3 minutes** with credentials for ~15 providers configured. Rough cost: **<$0.50 per full run** (most provider calls are short prompts to small models). Costs scale with how many providers your `.env` enables.
+
+For a quick smoke before the full run:
+
+```bash
+# Just chat completion across providers (fastest, cheapest)
+uv run pytest -m release tests/integration/test_chat_completion_real.py
+
+# Just one provider, all surfaces
+uv run pytest -m release -k TestOpenAI
+
+# Just the streaming path (highest regression-prevention value)
+uv run pytest -m release -k "streaming"
+```
+
+**3. Interpret results**
+
+Each test reports as one of:
+
+| Result | Meaning | Action |
+|--------|---------|--------|
+| `PASSED` | Real API call succeeded | None |
+| `SKIPPED` | Required env var(s) not set, or known-unsupported feature (e.g. Perplexity tool calling) | None — gating works as designed |
+| `XFAIL` | Known-broken test, tracked in a follow-up issue (e.g. `xfail(reason="see #N")`) | None — fix lands when the linked issue is resolved |
+| `XPASS` | Known-broken test that unexpectedly passed | Investigate — flip the `xfail` to expected-pass and close the linked issue |
+| `FAILED` | Real regression, env mismatch, or provider API change | Triage (next section) |
+
+Healthy release run looks like: many PASS, some SKIPPED (providers without credentials), 0 FAILED.
+
+**4. Triage failures**
+
+When something fails, distinguish:
+
+- **Provider parity bug** (Esperanto's fault): the test caught an inconsistency between what users get from one provider vs another. Fix in the provider source under `src/esperanto/providers/`. Example: Azure streaming yielding empty-`choices` chunks (PR #179).
+- **Provider API change** (their fault): the underlying provider deprecated a model, changed an endpoint, or evolved a request format. Fix in the provider source or in test defaults. Example: Google `text-embedding-004` deprecated on v1beta (#177).
+- **Test infrastructure bug**: the test gating, fixture, or assertion is wrong. Fix in `tests/integration/test_*_real.py`.
+- **Env mismatch**: partial credentials, wrong deployment name, expired token. Fix your `.env` or skip cleanly via skipif tightening.
+
+For non-trivial failures, file a follow-up issue rather than blocking the release. Mark the failing tests `@pytest.mark.xfail(reason="see #N")` so the suite stays green for the next maintainer.
+
+**5. Where in the release process to run this**
+
+Run the release suite **before tagging a release** — it's the last gate that catches cross-provider regressions the mocked unit tests can't. Specifically:
+
+1. Cut a release branch (or work on `main` if shipping straight from there).
+2. Update `CHANGELOG.md` with the release version and date.
+3. Run `uv run pytest` (default, mocked) — must be green.
+4. Run `uv run ruff check .` and `uv run mypy src/esperanto` — must be green.
+5. **Run `uv run pytest -m release`** — must be green or have only known-tracked xfails.
+6. Bump version, commit, tag, push tag.
+7. Build + publish.
+
+If step 5 surfaces a real regression, the release waits.
+
+**6. Audio fixture**
+
+`tests/fixtures/sample.mp3` is a committed 8-second MP3 (sliced from `notebooks/podcast.mp3`) used by the STT release tests. The test asserts the transcription contains `"Supernova"` (case-insensitive substring). The rest of `tests/fixtures/` is gitignored — only `sample.mp3` is committed via a `.gitignore` negation pattern.
+
+If you replace the fixture with a different clip, update `EXPECTED_TRANSCRIPT_FRAGMENT` in `tests/integration/test_stt_real.py`.
+
+**7. Local Ollama coverage (optional)**
+
+The Ollama tests auto-probe `http://localhost:11434/api/tags`. To enable local Ollama coverage:
+
+```bash
+# Install Ollama (one-time): https://ollama.com/
+ollama serve  # if not already running
+
+# For tool-calling tests specifically, pull qwen3:32b
+ollama pull qwen3:32b
+
+# Tests will now auto-detect and run
+uv run pytest -m release -k "Ollama"
+```
+
+For remote Ollama, set `OLLAMA_BASE_URL=https://your-ollama-host`.
+
 ## Adding a New Provider
 
 This is the most common type of contribution. To keep Esperanto maintainable, we have clear criteria for what we accept.


### PR DESCRIPTION
The existing 'Release Tests' section in CONTRIBUTING.md covered the basics (invocation, cost warning, env requirement, provider matrix) but lacked an end-to-end runbook for someone running the suite for the first time before a release.

Adds a 7-step playbook:

1. **Pre-flight** — clean tree, .env loaded, on main
2. **Run the suite** — full + useful filter examples + expected runtime + cost
3. **Interpret results** — PASS/SKIPPED/FAILED/XFAIL/XPASS table
4. **Triage failures** — distinguishing parity bug vs API change vs test bug vs env mismatch
5. **Where in the release process** — concrete step-by-step before tagging
6. **Audio fixture explanation** — what sample.mp3 is, how to swap
7. **Local Ollama setup** — how to enable Ollama coverage

Helps a maintainer pick up the release ritual without needing tribal knowledge from whoever wrote the test infrastructure.

## Targets

\`feat/release-test-infrastructure\`. Once merged, PR #181 picks it up automatically.

Pure docs change — no code touched.

Part of #141 test infrastructure delivery.