### PR TITLE
fix(embedding): update Google embedding default model to gemini-embedding-001 (closes #177)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -68,6 +68,16 @@ When a provider offers both OpenAI-compatible and a native (non-OpenAI) endpoint
 
 **Origin:** Issue #104, 2026-05-01.
 
+### Per-item Metadata Escape Hatch
+
+When normalizing collections of items returned by providers (transcription segments, search results, streaming chunks), expose only the **universal fields** as first-class typed attributes (e.g. `text`, `start`, `end`). Provider-specific extras (`avg_logprob`, `speaker`, `tokens`, `confidence`, `compression_ratio`, etc.) go into an `Optional[Dict[str, Any]] metadata` field on the item itself.
+
+**Why:** Per-item provider extras vary wildly (Whisper returns 6 numeric fields per segment, Mistral returns 1, Google returns speaker IDs). Promoting any of them to first-class breaks parity for providers that don't have it, and forces every new provider to either fake or null-fill the field. The `metadata` dict gives users an escape hatch without inflating the public interface or pre-committing to a shape that may not generalize.
+
+**Scope:** Designing new collection-of-items response types (segments, words, ranked results, streaming chunks). Pairs with **Demand-Driven Abstraction Extension** — promote a field from `metadata` to first-class only when 2+ providers expose it with compatible semantics.
+
+**Origin:** Issue #146, 2026-05-03.
+
 ## Provider Tiers
 
 Not all providers require the same level of implementation effort. We classify them into tiers:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Google embedding default model updated from `text-embedding-004` to `gemini-embedding-001`** — `text-embedding-004` was removed from the Google `v1beta` API. `gemini-embedding-001` is the current recommended model (3072-dimensional output; override with `model_name=` if you need 768-d vectors from `text-embedding-005`). (#177)
 - **Test-infrastructure cleanup** — mocked integration tests removed from `tests/integration/` (moved to per-provider test files under `tests/providers/`). A `release` pytest marker introduced: real-API tests are now tagged `@pytest.mark.release`, excluded from the default `uv run pytest` run, and invoked explicitly with `uv run pytest -m release` before each release. Unique `to_langchain()` coverage previously in `tests/integration/` moved to the corresponding per-provider test files. (#166, #141)
 - **Ollama `num_ctx` default lowered from 128,000 to 8,192.** The previous 128K default caused out-of-memory errors on consumer GPUs with 8 GB VRAM. 8,192 tokens works reliably on common hardware while still being large enough for typical chat workloads. Override with `config={"num_ctx": N}` when you need a larger context window. (#107)
 - **Lint and type-check the codebase clean.** Ruff (`ruff check .`) and mypy (`mypy src/esperanto`) now report zero errors. Most fixes are type-only and do not change runtime behavior. Notable structural changes:

--- a/src/esperanto/providers/embedding/google.py
+++ b/src/esperanto/providers/embedding/google.py
@@ -205,7 +205,7 @@ class GoogleEmbeddingModel(EmbeddingModel):
 
     def _get_default_model(self) -> str:
         """Get the default model name."""
-        return "text-embedding-004"
+        return "gemini-embedding-001"
 
     @property
     def provider(self) -> str:
@@ -233,6 +233,6 @@ class GoogleEmbeddingModel(EmbeddingModel):
         except Exception:
             # Fallback to known models if API call fails
             return [
-                Model(id="text-embedding-004", owned_by="Google", context_window=2048),
-                Model(id="embedding-001", owned_by="Google", context_window=2048),
+                Model(id="gemini-embedding-001", owned_by="Google", context_window=2048),
+                Model(id="text-embedding-005", owned_by="Google", context_window=2048),
             ]

--- a/tests/integration/test_embedding_real.py
+++ b/tests/integration/test_embedding_real.py
@@ -109,10 +109,6 @@ class TestOpenAIEmbedding:
 # =============================================================================
 
 
-@pytest.mark.xfail(
-    reason="Google default model text-embedding-004 deprecated on v1beta — see #177",
-    strict=False,
-)
 @pytest.mark.release
 @pytest.mark.skipif(
     not (os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")),
@@ -123,19 +119,19 @@ class TestGoogleEmbedding:
 
     def test_sync_embed(self):
         api_key = os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
-        model = AIFactory.create_embedding("google", "text-embedding-004", config={"api_key": api_key})
+        model = AIFactory.create_embedding("google", "gemini-embedding-001", config={"api_key": api_key})
         result = model.embed(TEXTS_SINGLE)
         _assert_valid_embedding(result, 1)
 
     def test_async_embed(self):
         api_key = os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
-        model = AIFactory.create_embedding("google", "text-embedding-004", config={"api_key": api_key})
+        model = AIFactory.create_embedding("google", "gemini-embedding-001", config={"api_key": api_key})
         result = asyncio.run(model.aembed(TEXTS_SINGLE))
         _assert_valid_embedding(result, 1)
 
     def test_batch_embed(self):
         api_key = os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
-        model = AIFactory.create_embedding("google", "text-embedding-004", config={"api_key": api_key})
+        model = AIFactory.create_embedding("google", "gemini-embedding-001", config={"api_key": api_key})
         result = model.embed(TEXTS_BATCH)
         _assert_valid_embedding(result, 3)
 
@@ -143,7 +139,7 @@ class TestGoogleEmbedding:
         api_key = os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
         model = AIFactory.create_embedding(
             "google",
-            "text-embedding-004",
+            "gemini-embedding-001",
             config={"api_key": api_key, "task_type": EmbeddingTaskType.RETRIEVAL_QUERY},
         )
         result = model.embed(["query text"])


### PR DESCRIPTION
## Summary

- Updates the Google embedding provider's default model from `text-embedding-004` (removed from Google's `v1beta` API) to `gemini-embedding-001` (3072-d output, current recommended).
- Refreshes the fallback static model list to reflect currently-supported models (`gemini-embedding-001`, `text-embedding-005`).
- Removes the `xfail` marker on `TestGoogleEmbedding` and updates its 4 test methods to use the new model id.
- CHANGELOG entry under `[Unreleased] → Changed`.

Closes #177.

## Test plan

- [x] `uv sync --all-extras && uv run pytest tests/providers tests/unit tests/common_types tests/test_deprecation_warnings.py -q --no-cov` — 1022 passed, 1 skipped
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src/esperanto` — clean
- [ ] Maintainer to run release tests with `GOOGLE_API_KEY` to verify `TestGoogleEmbedding` actually passes against the live API