### PR TITLE
fix(tts/google): switch default to gemini-3.1-flash-tts-preview, gate systemInstruction by family

### DIFF
--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -64,7 +64,7 @@ model = AIFactory.create_language("google", "gemini-2.0-flash")
 embedder = AIFactory.create_embedding("google", "text-embedding-004")
 
 # Text-to-speech
-speaker = AIFactory.create_text_to_speech("google", "gemini-2.5-flash-preview-tts")
+speaker = AIFactory.create_text_to_speech("google", "gemini-3.1-flash-tts-preview")
 ```
 
 ### Direct Instantiation
@@ -89,7 +89,7 @@ embedder = GoogleEmbeddingModel(
 # Text-to-speech
 tts = GoogleTextToSpeech(
     api_key="your-api-key",
-    model_name="gemini-2.5-flash-preview-tts"
+    model_name="gemini-3.1-flash-tts-preview"
 )
 ```
 
@@ -410,7 +410,7 @@ from esperanto.factory import AIFactory
 
 speaker = AIFactory.create_text_to_speech(
     "google",
-    "gemini-2.5-flash-preview-tts",
+    "gemini-3.1-flash-tts-preview",
     config={
         "timeout": 300.0  # 5 minutes timeout
     }
@@ -423,7 +423,7 @@ speaker = AIFactory.create_text_to_speech(
 from esperanto.factory import AIFactory
 
 # Create text-to-speech model
-model = AIFactory.create_text_to_speech("google", "gemini-2.5-flash-preview-tts")
+model = AIFactory.create_text_to_speech("google", "gemini-3.1-flash-tts-preview")
 
 # Generate speech
 response = model.generate_speech(
@@ -486,7 +486,7 @@ print(f"Generated multi-speaker dialogue with {len(speaker_configs)} voices")
 
 ```python
 async def create_dialogue():
-    model = AIFactory.create_text_to_speech("google", "gemini-2.5-flash-preview-tts")
+    model = AIFactory.create_text_to_speech("google", "gemini-3.1-flash-tts-preview")
 
     interview_text = """
     Interviewer: Welcome to our tech podcast. Today we're discussing AI.

--- a/src/esperanto/providers/tts/google.py
+++ b/src/esperanto/providers/tts/google.py
@@ -10,17 +10,30 @@ import httpx
 
 from .base import AudioResponse, Model, TextToSpeechModel, Voice
 
+DEFAULT_MODEL = "gemini-3.1-flash-tts-preview"
+# Legacy gemini-2.5-* TTS models reject bare `contents` text with
+# "Model tried to generate text" unless a systemInstruction is attached.
+# Newer gemini-3.x models reject systemInstruction with
+# "Developer instruction is not enabled for this model".
+# So the field has to be conditional on the model family.
+_LEGACY_MODEL_PREFIX = "gemini-2.5"
+
+
+def _needs_system_instruction(model_name: str) -> bool:
+    """Return True when the model family requires a systemInstruction field."""
+    return bool(model_name) and model_name.startswith(_LEGACY_MODEL_PREFIX)
+
 
 class GoogleTextToSpeechModel(TextToSpeechModel):
     """Google GenAI Text-to-Speech provider implementation.
-    
+
     Uses the Gemini API for text-to-speech generation.
     Supports single voice and multi-speaker conversations.
     """
-    
+
     def __init__(
         self,
-        model_name: str = "gemini-2.5-flash-preview-tts",
+        model_name: str = DEFAULT_MODEL,
         base_url: Optional[str] = None,
         **kwargs
     ) -> None:
@@ -71,7 +84,7 @@ class GoogleTextToSpeechModel(TextToSpeechModel):
 
     def _get_default_model(self) -> str:
         """Get the default model name."""
-        return "gemini-2.5-flash-preview-tts"
+        return DEFAULT_MODEL
 
     @property
     def provider(self) -> str:
@@ -291,8 +304,14 @@ class GoogleTextToSpeechModel(TextToSpeechModel):
     def _get_models(self) -> List[Model]:
         """List all available models for this provider."""
         return [
+            Model(id=DEFAULT_MODEL, owned_by="Google", context_window=None),
             Model(
                 id="gemini-2.5-flash-preview-tts",
+                owned_by="Google",
+                context_window=None,
+            ),
+            Model(
+                id="gemini-2.5-pro-preview-tts",
                 owned_by="Google",
                 context_window=None,
             ),
@@ -325,9 +344,7 @@ class GoogleTextToSpeechModel(TextToSpeechModel):
                     "text": text
                 }]
             }],
-            "systemInstruction": {
-                "parts": [{"text": "Read aloud the following text."}]
-            },
+            # systemInstruction is added below for legacy gemini-2.5-* models only.
             "generationConfig": {
                 "responseModalities": ["AUDIO"],
                 "speechConfig": {
@@ -340,6 +357,11 @@ class GoogleTextToSpeechModel(TextToSpeechModel):
             },
             "model": model_name,
         }
+
+        if _needs_system_instruction(model_name):
+            payload["systemInstruction"] = {
+                "parts": [{"text": "Read aloud the following text."}]
+            }
 
         # Make HTTP request
         response = self.client.post(
@@ -400,9 +422,7 @@ class GoogleTextToSpeechModel(TextToSpeechModel):
                     "text": text
                 }]
             }],
-            "systemInstruction": {
-                "parts": [{"text": "Read aloud the following text."}]
-            },
+            # systemInstruction is added below for legacy gemini-2.5-* models only.
             "generationConfig": {
                 "responseModalities": ["AUDIO"],
                 "speechConfig": {
@@ -415,6 +435,11 @@ class GoogleTextToSpeechModel(TextToSpeechModel):
             },
             "model": model_name,
         }
+
+        if _needs_system_instruction(model_name):
+            payload["systemInstruction"] = {
+                "parts": [{"text": "Read aloud the following text."}]
+            }
 
         # Make async HTTP request
         response = await self.async_client.post(
@@ -493,9 +518,7 @@ class GoogleTextToSpeechModel(TextToSpeechModel):
                     "text": text
                 }]
             }],
-            "systemInstruction": {
-                "parts": [{"text": "Read aloud the following text."}]
-            },
+            # systemInstruction is added below for legacy gemini-2.5-* models only.
             "generationConfig": {
                 "responseModalities": ["AUDIO"],
                 "speechConfig": {
@@ -506,6 +529,11 @@ class GoogleTextToSpeechModel(TextToSpeechModel):
             },
             "model": model_name,
         }
+
+        if _needs_system_instruction(model_name):
+            payload["systemInstruction"] = {
+                "parts": [{"text": "Read aloud the following text."}]
+            }
 
         # Make HTTP request
         response = self.client.post(
@@ -578,9 +606,7 @@ class GoogleTextToSpeechModel(TextToSpeechModel):
                     "text": text
                 }]
             }],
-            "systemInstruction": {
-                "parts": [{"text": "Read aloud the following text."}]
-            },
+            # systemInstruction is added below for legacy gemini-2.5-* models only.
             "generationConfig": {
                 "responseModalities": ["AUDIO"],
                 "speechConfig": {
@@ -591,6 +617,11 @@ class GoogleTextToSpeechModel(TextToSpeechModel):
             },
             "model": model_name,
         }
+
+        if _needs_system_instruction(model_name):
+            payload["systemInstruction"] = {
+                "parts": [{"text": "Read aloud the following text."}]
+            }
 
         # Make async HTTP request
         response = await self.async_client.post(

--- a/tests/providers/tts/test_google.py
+++ b/tests/providers/tts/test_google.py
@@ -13,16 +13,11 @@ def test_init():
     assert model.provider == "google"
 
 
-def test_generate_speech():
-    """Test synchronous speech generation with httpx mocking."""
-
-    from esperanto.providers.tts.google import GoogleTextToSpeechModel
-    
-    # Create fresh model instance
-    model = GoogleTextToSpeechModel(api_key="test-key")
-    
-    # Mock Google API response data
-    mock_response_data = {
+def _make_mock_response():
+    """Build a mock Google TTS HTTP response with valid base64-encoded PCM data."""
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {
         "candidates": [
             {
                 "content": {
@@ -37,85 +32,126 @@ def test_generate_speech():
             }
         ]
     }
-    
-    # Mock HTTP response
-    mock_response = Mock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = mock_response_data
-    
-    # Mock the client
+    return response
+
+
+def test_default_model_is_gemini_31():
+    """Default model is gemini-3.1-flash-tts-preview (newer; gemini-2.5-* preview models
+    are now flaky on Google's side and require the legacy systemInstruction quirk)."""
+    model = GoogleTextToSpeechModel(api_key="test-key")
+    assert model._get_default_model() == "gemini-3.1-flash-tts-preview"
+
+
+def test_generate_speech_default_model_omits_system_instruction():
+    """Default model (gemini-3.1-*) must NOT include systemInstruction — the new API
+    rejects it with 'Developer instruction is not enabled for this model'."""
+    model = GoogleTextToSpeechModel(api_key="test-key")
     mock_client = Mock()
-    mock_client.post.return_value = mock_response
+    mock_client.post.return_value = _make_mock_response()
     model.client = mock_client
 
-    response = model.generate_speech(
-        text="Hello world",
-        voice="en-US-Standard-A"
-    )
+    response = model.generate_speech(text="Hello world", voice="achernar")
 
-    assert b"test audio data" in response.audio_data  # Original data is embedded in WAV format
-    assert response.content_type == "audio/wav"
-    assert response.model == "gemini-2.5-flash-preview-tts"
-    assert response.voice == "en-US-Standard-A"
+    assert response.model == "gemini-3.1-flash-tts-preview"
+    assert response.voice == "achernar"
     assert response.provider == "google"
+    payload = mock_client.post.call_args.kwargs["json"]
+    assert "systemInstruction" not in payload
 
-    # Verify systemInstruction is present in the request payload
-    call_kwargs = mock_client.post.call_args.kwargs
-    assert "systemInstruction" in call_kwargs["json"]
-    assert call_kwargs["json"]["systemInstruction"] == {"parts": [{"text": "Read aloud the following text."}]}
+
+def test_generate_speech_legacy_model_includes_system_instruction():
+    """Legacy gemini-2.5-* models still require the systemInstruction quirk from #178."""
+    model = GoogleTextToSpeechModel(
+        api_key="test-key",
+        model_name="gemini-2.5-flash-preview-tts",
+    )
+    mock_client = Mock()
+    mock_client.post.return_value = _make_mock_response()
+    model.client = mock_client
+
+    model.generate_speech(text="Hello world", voice="achernar")
+
+    payload = mock_client.post.call_args.kwargs["json"]
+    assert payload["systemInstruction"] == {
+        "parts": [{"text": "Read aloud the following text."}]
+    }
 
 
 @pytest.mark.asyncio
-async def test_agenerate_speech():
-    """Test asynchronous speech generation with httpx mocking."""
-
-    from esperanto.providers.tts.google import GoogleTextToSpeechModel
-    
-    # Create fresh model instance
+async def test_agenerate_speech_default_model_omits_system_instruction():
+    """Async path: default model (3.1) omits systemInstruction."""
     model = GoogleTextToSpeechModel(api_key="test-key")
-    
-    # Mock Google API response data
-    mock_response_data = {
-        "candidates": [
-            {
-                "content": {
-                    "parts": [
-                        {
-                            "inlineData": {
-                                "data": base64.b64encode(b"test audio data").decode()
-                            }
-                        }
-                    ]
-                }
-            }
-        ]
-    }
-    
-    # Mock HTTP response
-    mock_response = Mock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = mock_response_data
-    
-    # Mock the async client
     mock_async_client = AsyncMock()
-    mock_async_client.post.return_value = mock_response
+    mock_async_client.post.return_value = _make_mock_response()
     model.async_client = mock_async_client
 
-    response = await model.agenerate_speech(
-        text="Hello world",
-        voice="en-US-Standard-A"
+    response = await model.agenerate_speech(text="Hello world", voice="achernar")
+
+    assert response.model == "gemini-3.1-flash-tts-preview"
+    payload = mock_async_client.post.call_args.kwargs["json"]
+    assert "systemInstruction" not in payload
+
+
+@pytest.mark.asyncio
+async def test_agenerate_speech_legacy_model_includes_system_instruction():
+    """Async path: legacy gemini-2.5-* models include systemInstruction."""
+    model = GoogleTextToSpeechModel(
+        api_key="test-key",
+        model_name="gemini-2.5-pro-preview-tts",
+    )
+    mock_async_client = AsyncMock()
+    mock_async_client.post.return_value = _make_mock_response()
+    model.async_client = mock_async_client
+
+    await model.agenerate_speech(text="Hello world", voice="achernar")
+
+    payload = mock_async_client.post.call_args.kwargs["json"]
+    assert payload["systemInstruction"] == {
+        "parts": [{"text": "Read aloud the following text."}]
+    }
+
+
+def test_multi_speaker_default_model_omits_system_instruction():
+    """Multi-speaker variant honors the same conditional rule."""
+    model = GoogleTextToSpeechModel(api_key="test-key")
+    mock_client = Mock()
+    mock_client.post.return_value = _make_mock_response()
+    model.client = mock_client
+
+    model.generate_multi_speaker_speech(
+        text="Joe: hi\nJane: hello",
+        speaker_configs=[
+            {"speaker": "Joe", "voice": "Kore"},
+            {"speaker": "Jane", "voice": "Puck"},
+        ],
     )
 
-    assert b"test audio data" in response.audio_data  # Original data is embedded in WAV format
-    assert response.content_type == "audio/wav"
-    assert response.model == "gemini-2.5-flash-preview-tts"
-    assert response.voice == "en-US-Standard-A"
-    assert response.provider == "google"
+    payload = mock_client.post.call_args.kwargs["json"]
+    assert "systemInstruction" not in payload
 
-    # Verify systemInstruction is present in the request payload
-    call_kwargs = mock_async_client.post.call_args.kwargs
-    assert "systemInstruction" in call_kwargs["json"]
-    assert call_kwargs["json"]["systemInstruction"] == {"parts": [{"text": "Read aloud the following text."}]}
+
+def test_multi_speaker_legacy_model_includes_system_instruction():
+    """Multi-speaker variant on legacy gemini-2.5-* still emits systemInstruction."""
+    model = GoogleTextToSpeechModel(
+        api_key="test-key",
+        model_name="gemini-2.5-flash-preview-tts",
+    )
+    mock_client = Mock()
+    mock_client.post.return_value = _make_mock_response()
+    model.client = mock_client
+
+    model.generate_multi_speaker_speech(
+        text="Joe: hi\nJane: hello",
+        speaker_configs=[
+            {"speaker": "Joe", "voice": "Kore"},
+            {"speaker": "Jane", "voice": "Puck"},
+        ],
+    )
+
+    payload = mock_client.post.call_args.kwargs["json"]
+    assert payload["systemInstruction"] == {
+        "parts": [{"text": "Read aloud the following text."}]
+    }
 
 
 def test_available_voices():


### PR DESCRIPTION
## Summary

The previous default model \`gemini-2.5-flash-preview-tts\` is now returning **500 Internal Server Error** from Google's API on every TTS call — verified via curl, fails with or without the \`systemInstruction\` workaround from #178. \`gemini-2.5-pro-preview-tts\` has the same problem.

The newer \`gemini-3.1-flash-tts-preview\` works on bare text but explicitly rejects \`systemInstruction\` with \`"Developer instruction is not enabled for this model"\`.

So:
- **Default model** → \`gemini-3.1-flash-tts-preview\`.
- **\`systemInstruction\` payload field** → now conditional on \`gemini-2.5-*\` family via a small \`_needs_system_instruction(model_name)\` helper. Applied across all 4 payload sites: sync/async × single-voice/multi-speaker.
- **Backwards-compat**: passing \`model_name="gemini-2.5-flash-preview-tts"\` explicitly still emits \`systemInstruction\` as before (so users on the old model don't get a new 400 from us — they still hit Google's 500, but that's not a regression).

Found while running the v2.21.0 release-test ritual — \`TestGoogleTTS\` real-API tests were the only non-billing/non-setup failures.

## Test plan

- [x] \`uv run pytest tests/providers tests/unit tests/common_types tests/test_deprecation_warnings.py tests/test_factory.py tests/test_model_discovery.py -q --no-cov\` → **1200 passed**, 1 skipped, 1 xfailed.
- [x] \`uv run ruff check .\` → clean.
- [x] \`uv run mypy src/esperanto\` → 0 issues.
- [x] \`uv run pytest tests/integration/test_tts_real.py::TestGoogleTTS -m release\` → **2 passed**.
- [x] 9 unit tests in \`tests/providers/tts/test_google.py\`: default model is 3.1, default omits \`systemInstruction\`, legacy 2.5 includes it (sync + async + multi-speaker variants).