### PR TITLE
feat(stt): support for segments data, update usage data and default to verbose_json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **STT segments + Whisper/Voxtral usage** — Speech-to-text responses now carry
+  timestamped segments and STT-specific usage on `TranscriptionResponse`. Two
+  new common types are exported from `esperanto.common_types`:
+  - `TranscriptionSegment` (`text`, `start`, `end`, optional
+    `metadata: Dict[str, Any]`) — the per-item metadata escape hatch holds
+    provider-specific extras such as `avg_logprob`, `compression_ratio`,
+    `no_speech_prob`, `confidence`, and `speaker`, so the top-level interface
+    stays uniform across providers.
+  - `TranscriptionUsage` (`input_seconds`, `input_tokens`, `output_tokens`,
+    `total_tokens`) — STT-aware usage with `input_seconds` for audio billing,
+    distinct from the LLM `Usage` type.
+  `TranscriptionResponse` gains a `segments: Optional[List[TranscriptionSegment]]`
+  field (defaults to `None`). For Whisper-family providers (OpenAI, Groq,
+  Azure), Esperanto now automatically requests `response_format=verbose_json`
+  in the underlying HTTP call so callers receive segments and `duration`
+  without any extra configuration ("Hot-Swap-First Defaults"). Mistral
+  natively returns segments and a `usage` block with `prompt_audio_seconds` —
+  both are now mapped onto the response. ElevenLabs and Google leave
+  `segments=None` (they don't return them and Esperanto never synthesizes
+  segments from text alone, per the "Unsupported Response Fields Stay `None`"
+  principle). Resolves #146 (Whisper-family segments + usage) and #193
+  (Azure parity). (#146, #193)
+
+### Changed
+
+- **`TranscriptionResponse.usage` is now `Optional[TranscriptionUsage]`** (was
+  `Optional[Usage]`, the LLM token-usage type). No existing STT provider in
+  Esperanto populated `usage` before this release, so callers reading from
+  STT responses are not affected in practice. New STT-specific fields
+  (`input_seconds`) are only available on the new type.
+
 ## [2.21.0] - 2026-05-15
 
 ### Added

--- a/docs/capabilities/speech-to-text.md
+++ b/docs/capabilities/speech-to-text.md
@@ -119,26 +119,30 @@ result = transcriber.transcribe("audio.mp3")
 
 ### Verbose JSON Format
 
-Get detailed information including timestamps:
+Whisper-family providers (OpenAI, Groq, Azure) auto-opt-in to verbose JSON so
+that segments and duration are always available on the returned
+`TranscriptionResponse`. You don't need to pass any config:
 
 ```python
-transcriber = AIFactory.create_speech_to_text(
-    "openai", "whisper-1",
-    config={"response_format": "verbose_json"}
-)
+transcriber = AIFactory.create_speech_to_text("openai", "whisper-1")
+response = transcriber.transcribe("audio.mp3")
 
-result = transcriber.transcribe("audio.mp3")
-# Returns:
-# {
-#   "text": "Full transcription...",
-#   "language": "en",
-#   "duration": 125.5,
-#   "segments": [
-#     {"start": 0.0, "end": 3.2, "text": "First segment"},
-#     ...
-#   ]
-# }
+print(response.text)        # Full transcription
+print(response.language)    # "english" (detected)
+print(response.duration)    # 125.5 (seconds)
+
+# Timestamped segments are populated automatically
+if response.segments:
+    for segment in response.segments:
+        print(f"[{segment.start:.2f}s - {segment.end:.2f}s] {segment.text}")
+        # Whisper-specific extras live in segment.metadata:
+        # avg_logprob, compression_ratio, no_speech_prob, temperature, tokens, id, seek
 ```
+
+Mistral natively returns segments as well, and exposes per-audio billing on
+`response.usage.input_seconds`. Providers that don't return segments
+(ElevenLabs, Google) leave `response.segments` as `None` — Esperanto never
+synthesizes segments from text alone.
 
 ### Subtitle Formats
 

--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -341,6 +341,25 @@ async def transcribe_batch():
         print(f"{audio_file}: {response.text[:100]}...")
 ```
 
+**Example - Segments and Duration:**
+
+Azure's Whisper deployments return the same `verbose_json` shape as OpenAI.
+Esperanto requests it automatically, so you get timestamped segments and
+duration without any extra configuration:
+
+```python
+response = model.transcribe("meeting.mp3")
+
+print(f"Duration: {response.duration:.2f}s")
+print(f"Language: {response.language}")
+
+if response.segments:
+    for segment in response.segments:
+        print(f"[{segment.start:.2f}s - {segment.end:.2f}s] {segment.text}")
+        # Whisper extras (avg_logprob, compression_ratio, no_speech_prob,
+        # temperature, tokens, id, seek) live in segment.metadata.
+```
+
 ### Text-to-Speech
 
 **Available Models:**

--- a/docs/providers/groq.md
+++ b/docs/providers/groq.md
@@ -269,6 +269,23 @@ async def transcribe_async():
     print(f"Language: {response.language}")
 ```
 
+**Example - Segments and Duration:**
+
+Groq inherits OpenAI's `verbose_json` behavior, so segments and duration come
+back automatically:
+
+```python
+response = model.transcribe("audio.mp3")
+
+print(f"Duration: {response.duration:.2f}s")
+
+if response.segments:
+    for segment in response.segments:
+        print(f"[{segment.start:.2f}s - {segment.end:.2f}s] {segment.text}")
+        # Per-segment Whisper extras (avg_logprob, compression_ratio, etc.)
+        # live in segment.metadata.
+```
+
 **Example - Batch Processing:**
 
 ```python

--- a/docs/providers/mistral_stt.md
+++ b/docs/providers/mistral_stt.md
@@ -95,9 +95,48 @@ asyncio.run(main())
 TranscriptionResponse(
     text="Transcribed text here",
     language="en",       # detected language from Mistral
+    duration=12.4,        # audio duration in seconds (when provided)
     model="voxtral-mini-latest",
     provider="mistral",
+    segments=[
+        TranscriptionSegment(
+            text="Transcribed text here",
+            start=0.0,
+            end=12.4,
+            metadata={
+                "id": 0,
+                "confidence": 0.95,
+                "speaker": "speaker_0",
+                "language": "en",
+            },
+        ),
+        # ... more segments
+    ],
+    usage=TranscriptionUsage(
+        input_seconds=12.4,   # audio seconds billed (Mistral-specific)
+        input_tokens=120,
+        output_tokens=80,
+        total_tokens=200,
+    ),
 )
+```
+
+### Iterating over segments
+
+Mistral natively returns timestamped segments. Esperanto exposes them on
+`response.segments` so you can render captions, build subtitles, or extract
+per-speaker turns:
+
+```python
+response = transcriber.transcribe("interview.mp3")
+
+if response.segments:
+    for segment in response.segments:
+        speaker = segment.metadata.get("speaker") if segment.metadata else None
+        print(f"[{segment.start:.2f}s - {segment.end:.2f}s] {speaker}: {segment.text}")
+
+if response.usage and response.usage.input_seconds:
+    print(f"Billed for {response.usage.input_seconds:.2f}s of audio")
 ```
 
 ## Error Handling

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -316,6 +316,29 @@ async def transcribe_async():
     print(f"Language: {response.language}")
 ```
 
+**Example - Segments and Duration:**
+
+OpenAI Whisper returns timestamped segments by default. Esperanto always
+requests `response_format=verbose_json`, so callers get them without any extra
+configuration:
+
+```python
+response = model.transcribe("audio.mp3")
+
+print(f"Duration: {response.duration:.2f}s")
+print(f"Language: {response.language}")
+
+if response.segments:
+    for segment in response.segments:
+        print(f"[{segment.start:.2f}s - {segment.end:.2f}s] {segment.text}")
+        # Per-segment provider extras (avg_logprob, compression_ratio,
+        # no_speech_prob, temperature, tokens, id, seek) live in metadata.
+        if segment.metadata:
+            confidence_signal = segment.metadata.get("avg_logprob")
+            if confidence_signal is not None:
+                print(f"  avg_logprob: {confidence_signal:.3f}")
+```
+
 ### Text-to-Speech
 
 **Available Models:**

--- a/src/esperanto/common_types/CLAUDE.md
+++ b/src/esperanto/common_types/CLAUDE.md
@@ -7,7 +7,7 @@ Shared type definitions and response models used across all provider types.
 - **`model.py`**: `Model` dataclass representing AI model metadata (id, owner, context_window)
 - **`response.py`**: Chat completion response types (`ChatCompletion`, `ChatCompletionChunk`, `Message`, `Choice`, `Usage`) and tool types (`Tool`, `ToolFunction`, `ToolCall`, `FunctionCall`)
 - **`task_type.py`**: `EmbeddingTaskType` enum for task-aware embeddings
-- **`stt.py`**: `TranscriptionResponse` for speech-to-text results
+- **`stt.py`**: `TranscriptionResponse`, `TranscriptionSegment`, and `TranscriptionUsage` for speech-to-text results
 - **`tts.py`**: `AudioResponse` and `Voice` for text-to-speech
 - **`reranker.py`**: `RerankResponse` and `RerankResult` for document reranking
 - **`exceptions.py`**: `ToolCallValidationError` for tool call validation failures
@@ -142,9 +142,31 @@ STT providers return `TranscriptionResponse` (stt.py):
 
 - `text`: str (transcribed text)
 - `language`: Optional[str] (detected/specified language)
-- `duration`: Optional[float] (audio duration)
-- `segments`: Optional[List] (timestamped segments)
-- `words`: Optional[List] (word-level timestamps)
+- `duration`: Optional[float] (audio duration in seconds)
+- `segments`: Optional[List[TranscriptionSegment]] (timestamped segments — `None`
+  when the provider doesn't return them; never synthesized from `text`)
+- `usage`: Optional[TranscriptionUsage] (STT-specific usage with
+  `input_seconds` + token counts; `None` when the provider doesn't return one)
+
+`TranscriptionSegment` (stt.py) carries one timestamped span:
+
+- `text`: str (segment text)
+- `start`: float (start time in seconds)
+- `end`: float (end time in seconds)
+- `metadata`: Optional[Dict[str, Any]] (provider-specific extras such as
+  `avg_logprob`, `compression_ratio`, `confidence`, `speaker` — per-item escape
+  hatch so provider-specific fields don't leak into the top-level interface)
+
+`TranscriptionUsage` (stt.py) is the STT-aware usage type:
+
+- `input_seconds`: Optional[float] (audio seconds billed — unique to STT)
+- `input_tokens`: Optional[int] (prompt tokens, when applicable)
+- `output_tokens`: Optional[int] (completion tokens, when applicable)
+- `total_tokens`: Optional[int] (total tokens, when applicable)
+
+Note: `TranscriptionResponse.usage` is `TranscriptionUsage`, not the LLM `Usage`
+type — STT providers historically left usage `None`, so this type tightening
+is safe in practice.
 
 ### Reranker Response
 

--- a/src/esperanto/common_types/__init__.py
+++ b/src/esperanto/common_types/__init__.py
@@ -16,7 +16,7 @@ from .response import (
     ToolFunction,
     Usage,
 )
-from .stt import TranscriptionResponse
+from .stt import TranscriptionResponse, TranscriptionSegment, TranscriptionUsage
 from .task_type import EmbeddingTaskType
 from .tts import AudioResponse
 from .validation import find_tool_by_name, validate_tool_call, validate_tool_calls
@@ -42,6 +42,8 @@ __all__ = [
     "find_tool_by_name",
     # Other types
     "TranscriptionResponse",
+    "TranscriptionSegment",
+    "TranscriptionUsage",
     "AudioResponse",
     "Model",
     "EmbeddingTaskType",

--- a/src/esperanto/common_types/stt.py
+++ b/src/esperanto/common_types/stt.py
@@ -1,10 +1,45 @@
 """Speech-to-text type definitions for Esperanto."""
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from esperanto.common_types.response import Usage
+
+class TranscriptionSegment(BaseModel):
+    """A single timestamped segment of a transcription."""
+
+    text: str = Field(description="Segment text")
+    start: float = Field(description="Start time in seconds")
+    end: float = Field(description="End time in seconds")
+    metadata: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Provider-specific extras for this segment "
+            "(e.g. avg_logprob, confidence, tokens). See provider docs for the keys."
+        ),
+    )
+
+    model_config = ConfigDict(frozen=True)
+
+
+class TranscriptionUsage(BaseModel):
+    """Usage statistics for a transcription request."""
+
+    input_seconds: Optional[float] = Field(
+        default=None,
+        description="Audio duration sent to the provider, in seconds (if reported).",
+    )
+    input_tokens: Optional[int] = Field(
+        default=None, description="Input/prompt tokens consumed (if reported)."
+    )
+    output_tokens: Optional[int] = Field(
+        default=None, description="Output/completion tokens produced (if reported)."
+    )
+    total_tokens: Optional[int] = Field(
+        default=None, description="Total tokens for the request (if reported)."
+    )
+
+    model_config = ConfigDict(frozen=True)
 
 
 class TranscriptionResponse(BaseModel):
@@ -17,7 +52,7 @@ class TranscriptionResponse(BaseModel):
     duration: Optional[float] = Field(
         default=None, description="Duration of the audio in seconds"
     )
-    usage: Optional[Usage] = Field(
+    usage: Optional[TranscriptionUsage] = Field(
         default=None, description="Usage statistics for this transcription"
     )
     model: Optional[str] = Field(
@@ -28,6 +63,13 @@ class TranscriptionResponse(BaseModel):
     )
     metadata: Optional[Dict[str, Any]] = Field(
         default=None, description="Additional metadata from the provider"
+    )
+    segments: Optional[List[TranscriptionSegment]] = Field(
+        default=None,
+        description=(
+            "Timestamped segments of the transcription, when the provider supports it. "
+            "Providers that don't return segment-level data leave this as None."
+        ),
     )
 
     model_config = ConfigDict(frozen=True)

--- a/src/esperanto/providers/stt/CLAUDE.md
+++ b/src/esperanto/providers/stt/CLAUDE.md
@@ -113,22 +113,30 @@ from esperanto.common_types import (
 
 # Map provider-specific segments (if any) into TranscriptionSegment.
 # Per-item escape hatch: provider-specific extras go in `metadata`, not as
-# first-class fields.
+# first-class fields. Use defensive key access — providers vary in which
+# per-segment fields they return (e.g. Mistral has no `avg_logprob`).
+_METADATA_KEYS = ("avg_logprob", "compression_ratio", "no_speech_prob")
 segments = [
     TranscriptionSegment(
-        text=raw["text"],
-        start=float(raw["start"]),
-        end=float(raw["end"]),
-        metadata={"avg_logprob": raw["avg_logprob"]} or None,
+        text=raw.get("text", ""),
+        start=float(raw.get("start", 0.0)),
+        end=float(raw.get("end", 0.0)),
+        metadata={k: raw[k] for k in _METADATA_KEYS if k in raw} or None,
     )
     for raw in api_response.get("segments") or []
 ] or None
 
-usage = TranscriptionUsage(
-    input_seconds=api_response["usage"].get("prompt_audio_seconds"),
-    input_tokens=api_response["usage"].get("prompt_tokens"),
-    output_tokens=api_response["usage"].get("completion_tokens"),
-    total_tokens=api_response["usage"].get("total_tokens"),
+# Many providers omit `usage` entirely — guard before indexing.
+usage_data = api_response.get("usage")
+usage = (
+    TranscriptionUsage(
+        input_seconds=usage_data.get("prompt_audio_seconds"),
+        input_tokens=usage_data.get("prompt_tokens"),
+        output_tokens=usage_data.get("completion_tokens"),
+        total_tokens=usage_data.get("total_tokens"),
+    )
+    if usage_data
+    else None
 )
 
 return TranscriptionResponse(

--- a/src/esperanto/providers/stt/CLAUDE.md
+++ b/src/esperanto/providers/stt/CLAUDE.md
@@ -105,16 +105,55 @@ def __post_init__(self):
 Build `TranscriptionResponse` from API results:
 
 ```python
-from esperanto.common_types import TranscriptionResponse
+from esperanto.common_types import (
+    TranscriptionResponse,
+    TranscriptionSegment,
+    TranscriptionUsage,
+)
+
+# Map provider-specific segments (if any) into TranscriptionSegment.
+# Per-item escape hatch: provider-specific extras go in `metadata`, not as
+# first-class fields.
+segments = [
+    TranscriptionSegment(
+        text=raw["text"],
+        start=float(raw["start"]),
+        end=float(raw["end"]),
+        metadata={"avg_logprob": raw["avg_logprob"]} or None,
+    )
+    for raw in api_response.get("segments") or []
+] or None
+
+usage = TranscriptionUsage(
+    input_seconds=api_response["usage"].get("prompt_audio_seconds"),
+    input_tokens=api_response["usage"].get("prompt_tokens"),
+    output_tokens=api_response["usage"].get("completion_tokens"),
+    total_tokens=api_response["usage"].get("total_tokens"),
+)
 
 return TranscriptionResponse(
     text=api_response["text"],
     language=api_response.get("language"),  # if available
-    duration=audio_duration,  # if available
-    segments=segments,  # if available (timestamped segments)
-    words=words,  # if available (word-level timestamps)
+    duration=api_response.get("duration"),  # if available
+    segments=segments,                       # None when provider has no segments
+    usage=usage,                             # None when provider has no usage block
+    model=self.get_model_name(),
+    provider=self.provider,
 )
 ```
+
+#### Hot-Swap-First Defaults
+
+For Whisper-family providers (OpenAI, Groq, Azure), Esperanto always requests
+`response_format="verbose_json"` in `_get_api_kwargs()` so callers get segments
+and duration without any opt-in. Mistral and other providers that natively
+return segments must NOT set `response_format`.
+
+#### Unsupported Response Fields Stay None
+
+Providers that don't return segments (ElevenLabs, Google) leave `segments=None`.
+Do NOT synthesize segments from `text` alone — that would lie to callers about
+the provider's real capabilities.
 
 ## Integration
 
@@ -158,6 +197,8 @@ return TranscriptionResponse(
 - Max file size: 25MB
 - Returns language, duration, and segments with timestamps
 - Supports prompt for context and spelling hints
+- Esperanto always sends `response_format="verbose_json"` so segments/duration
+  come back without callers having to opt in
 
 ### Google Speech-to-Text
 
@@ -173,6 +214,8 @@ return TranscriptionResponse(
 - OpenAI-compatible API format
 - Same file size/format limits as OpenAI
 - Much faster than standard Whisper
+- Inherits segment + duration mapping from `OpenAISpeechToTextModel` — no
+  Groq-specific overrides needed
 
 ### Azure Speech Service
 
@@ -180,6 +223,17 @@ return TranscriptionResponse(
 - Different authentication (subscription key + region)
 - Supports real-time streaming (beyond file transcription)
 - Different response format than others
+- Like OpenAI, Esperanto always sends `response_format="verbose_json"` so
+  segments and duration come back automatically (Azure's Whisper deployments
+  accept the same request shape)
+
+### Mistral Voxtral
+
+- Natively returns segments and a `usage` block with `prompt_audio_seconds`
+- Do NOT set `response_format` — Mistral rejects unknown fields and already
+  returns the verbose shape
+- Per-segment metadata: `confidence`, `speaker`, `language` (all mapped into
+  `segment.metadata`)
 
 ## Common Implementation Patterns
 

--- a/src/esperanto/providers/stt/CLAUDE.md
+++ b/src/esperanto/providers/stt/CLAUDE.md
@@ -102,7 +102,9 @@ def __post_init__(self):
 
 ### Response Construction
 
-Build `TranscriptionResponse` from API results:
+Build `TranscriptionResponse` from API results. The patterns below mirror
+the helpers in `base.py` and `mistral.py` — copy them verbatim rather than
+assuming any given key is present in the provider payload.
 
 ```python
 from esperanto.common_types import (
@@ -111,24 +113,37 @@ from esperanto.common_types import (
     TranscriptionUsage,
 )
 
-# Map provider-specific segments (if any) into TranscriptionSegment.
 # Per-item escape hatch: provider-specific extras go in `metadata`, not as
-# first-class fields.
+# first-class fields. Use `.get(...)` (or `if key in segment`) for every
+# optional field — providers vary in which segment fields they return
+# (e.g. Whisper has `avg_logprob`; Mistral has `confidence`, `speaker`).
+SEGMENT_METADATA_KEYS = ("avg_logprob",)  # provider-specific tuple
+
+raw_segments = api_response.get("segments") or []
 segments = [
     TranscriptionSegment(
-        text=raw["text"],
-        start=float(raw["start"]),
-        end=float(raw["end"]),
-        metadata={"avg_logprob": raw["avg_logprob"]} or None,
+        text=raw.get("text", ""),
+        start=float(raw.get("start", 0.0)),
+        end=float(raw.get("end", 0.0)),
+        # Dict comp + `if key in raw` produces `{}` when no extras are
+        # present, and `or None` then collapses that to `None`.
+        metadata={k: raw[k] for k in SEGMENT_METADATA_KEYS if k in raw}
+        or None,
     )
-    for raw in api_response.get("segments") or []
+    for raw in raw_segments
 ] or None
 
-usage = TranscriptionUsage(
-    input_seconds=api_response["usage"].get("prompt_audio_seconds"),
-    input_tokens=api_response["usage"].get("prompt_tokens"),
-    output_tokens=api_response["usage"].get("completion_tokens"),
-    total_tokens=api_response["usage"].get("total_tokens"),
+# `usage` must be `None` when the provider omits the block entirely.
+usage_data = api_response.get("usage")
+usage = (
+    TranscriptionUsage(
+        input_seconds=usage_data.get("prompt_audio_seconds"),
+        input_tokens=usage_data.get("prompt_tokens"),
+        output_tokens=usage_data.get("completion_tokens"),
+        total_tokens=usage_data.get("total_tokens"),
+    )
+    if usage_data
+    else None
 )
 
 return TranscriptionResponse(

--- a/src/esperanto/providers/stt/CLAUDE.md
+++ b/src/esperanto/providers/stt/CLAUDE.md
@@ -102,9 +102,7 @@ def __post_init__(self):
 
 ### Response Construction
 
-Build `TranscriptionResponse` from API results. The patterns below mirror
-the helpers in `base.py` and `mistral.py` — copy them verbatim rather than
-assuming any given key is present in the provider payload.
+Build `TranscriptionResponse` from API results:
 
 ```python
 from esperanto.common_types import (
@@ -113,37 +111,24 @@ from esperanto.common_types import (
     TranscriptionUsage,
 )
 
+# Map provider-specific segments (if any) into TranscriptionSegment.
 # Per-item escape hatch: provider-specific extras go in `metadata`, not as
-# first-class fields. Use `.get(...)` (or `if key in segment`) for every
-# optional field — providers vary in which segment fields they return
-# (e.g. Whisper has `avg_logprob`; Mistral has `confidence`, `speaker`).
-SEGMENT_METADATA_KEYS = ("avg_logprob",)  # provider-specific tuple
-
-raw_segments = api_response.get("segments") or []
+# first-class fields.
 segments = [
     TranscriptionSegment(
-        text=raw.get("text", ""),
-        start=float(raw.get("start", 0.0)),
-        end=float(raw.get("end", 0.0)),
-        # Dict comp + `if key in raw` produces `{}` when no extras are
-        # present, and `or None` then collapses that to `None`.
-        metadata={k: raw[k] for k in SEGMENT_METADATA_KEYS if k in raw}
-        or None,
+        text=raw["text"],
+        start=float(raw["start"]),
+        end=float(raw["end"]),
+        metadata={"avg_logprob": raw["avg_logprob"]} or None,
     )
-    for raw in raw_segments
+    for raw in api_response.get("segments") or []
 ] or None
 
-# `usage` must be `None` when the provider omits the block entirely.
-usage_data = api_response.get("usage")
-usage = (
-    TranscriptionUsage(
-        input_seconds=usage_data.get("prompt_audio_seconds"),
-        input_tokens=usage_data.get("prompt_tokens"),
-        output_tokens=usage_data.get("completion_tokens"),
-        total_tokens=usage_data.get("total_tokens"),
-    )
-    if usage_data
-    else None
+usage = TranscriptionUsage(
+    input_seconds=api_response["usage"].get("prompt_audio_seconds"),
+    input_tokens=api_response["usage"].get("prompt_tokens"),
+    output_tokens=api_response["usage"].get("completion_tokens"),
+    total_tokens=api_response["usage"].get("total_tokens"),
 )
 
 return TranscriptionResponse(
@@ -232,15 +217,20 @@ the provider's real capabilities.
 - Inherits segment + duration mapping from `OpenAISpeechToTextModel` — no
   Groq-specific overrides needed
 
-### Azure Speech Service
+### Azure OpenAI Whisper
 
-- Uses Speech SDK or REST API
-- Different authentication (subscription key + region)
-- Supports real-time streaming (beyond file transcription)
-- Different response format than others
-- Like OpenAI, Esperanto always sends `response_format="verbose_json"` so
-  segments and duration come back automatically (Azure's Whisper deployments
-  accept the same request shape)
+- Uses Azure-hosted OpenAI Whisper deployments via the REST `/audio/transcriptions`
+  endpoint (NOT the native Azure Speech Service, which is a separate product
+  with its own SDK, `Ocp-Apim-Subscription-Key` auth, and streaming protocol).
+- Authentication: `api-key` header (Azure OpenAI flavor), resolved from
+  `AZURE_OPENAI_API_KEY_STT` / `AZURE_OPENAI_API_KEY` env vars or
+  `config["api_key"]`.
+- URL is built from `{azure_endpoint}/openai/deployments/{deployment_name}/audio/transcriptions?api-version={api_version}`,
+  so `model_name` is the *deployment name*, not the underlying model.
+- Same OpenAI Whisper response shape, including `verbose_json` (segments,
+  duration, language). Esperanto always sends `response_format="verbose_json"`
+  so callers get the segments + duration for free.
+- Same file size/format limits as OpenAI (25 MB, MP3/MP4/MPEG/MPGA/M4A/WAV/WEBM).
 
 ### Mistral Voxtral
 

--- a/src/esperanto/providers/stt/azure.py
+++ b/src/esperanto/providers/stt/azure.py
@@ -9,10 +9,13 @@ import httpx
 from esperanto.common_types import (
     Model,
     TranscriptionResponse,
-    TranscriptionSegment,
 )
-from esperanto.providers.stt.base import SpeechToTextModel, _guess_audio_content_type
-from esperanto.providers.stt.openai import _WHISPER_SEGMENT_METADATA_KEYS
+from esperanto.providers.stt.base import (
+    _WHISPER_SEGMENT_METADATA_KEYS,
+    SpeechToTextModel,
+    _build_transcription_response,
+    _guess_audio_content_type,
+)
 
 
 @dataclass
@@ -137,34 +140,12 @@ class AzureSpeechToTextModel(SpeechToTextModel):
         language: Optional[str] = None,
     ) -> TranscriptionResponse:
         """Build a TranscriptionResponse from an Azure OpenAI Whisper ``verbose_json`` payload."""
-        raw_segments = response_data.get("segments") or []
-        segments: Optional[List[TranscriptionSegment]] = None
-        if raw_segments:
-            segments = [
-                TranscriptionSegment(
-                    text=segment.get("text", ""),
-                    start=float(segment.get("start", 0.0)),
-                    end=float(segment.get("end", 0.0)),
-                    metadata={
-                        key: segment[key]
-                        for key in _WHISPER_SEGMENT_METADATA_KEYS
-                        if key in segment
-                    }
-                    or None,
-                )
-                for segment in raw_segments
-            ]
-
-        duration_raw = response_data.get("duration")
-        duration = float(duration_raw) if duration_raw is not None else None
-
-        return TranscriptionResponse(
-            text=response_data["text"],
-            language=response_data.get("language") or language,
-            duration=duration,
+        return _build_transcription_response(
+            response_data,
             model=self.deployment_name,
             provider=self.provider,
-            segments=segments,
+            metadata_keys=_WHISPER_SEGMENT_METADATA_KEYS,
+            language_fallback=language,
         )
 
     def transcribe(

--- a/src/esperanto/providers/stt/azure.py
+++ b/src/esperanto/providers/stt/azure.py
@@ -6,8 +6,13 @@ from typing import Any, BinaryIO, Dict, List, Optional, Union
 
 import httpx
 
-from esperanto.common_types import Model, TranscriptionResponse
+from esperanto.common_types import (
+    Model,
+    TranscriptionResponse,
+    TranscriptionSegment,
+)
 from esperanto.providers.stt.base import SpeechToTextModel, _guess_audio_content_type
+from esperanto.providers.stt.openai import _WHISPER_SEGMENT_METADATA_KEYS
 
 
 @dataclass
@@ -107,6 +112,61 @@ class AzureSpeechToTextModel(SpeechToTextModel):
         """Get the model name (deployment name for Azure)."""
         return self.deployment_name
 
+    def _get_api_kwargs(
+        self, language: Optional[str] = None, prompt: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Get kwargs for the Azure OpenAI Whisper request.
+
+        Always requests ``verbose_json`` so segments and duration are returned,
+        matching the OpenAI provider's Hot-Swap-First Defaults behavior. Azure
+        OpenAI Whisper accepts the same request shape as OpenAI Whisper.
+        """
+        data: Dict[str, Any] = {
+            "model": self.deployment_name,
+            "response_format": "verbose_json",
+        }
+        if language:
+            data["language"] = language
+        if prompt:
+            data["prompt"] = prompt
+        return data
+
+    def _build_response(
+        self,
+        response_data: Dict[str, Any],
+        language: Optional[str] = None,
+    ) -> TranscriptionResponse:
+        """Build a TranscriptionResponse from an Azure OpenAI Whisper ``verbose_json`` payload."""
+        raw_segments = response_data.get("segments") or []
+        segments: Optional[List[TranscriptionSegment]] = None
+        if raw_segments:
+            segments = [
+                TranscriptionSegment(
+                    text=segment.get("text", ""),
+                    start=float(segment.get("start", 0.0)),
+                    end=float(segment.get("end", 0.0)),
+                    metadata={
+                        key: segment[key]
+                        for key in _WHISPER_SEGMENT_METADATA_KEYS
+                        if key in segment
+                    }
+                    or None,
+                )
+                for segment in raw_segments
+            ]
+
+        duration_raw = response_data.get("duration")
+        duration = float(duration_raw) if duration_raw is not None else None
+
+        return TranscriptionResponse(
+            text=response_data["text"],
+            language=response_data.get("language") or language,
+            duration=duration,
+            model=self.deployment_name,
+            provider=self.provider,
+            segments=segments,
+        )
+
     def transcribe(
         self,
         audio_file: Union[str, BinaryIO],
@@ -116,12 +176,8 @@ class AzureSpeechToTextModel(SpeechToTextModel):
         """Transcribe audio using Azure OpenAI."""
         url = self._build_url("audio/transcriptions")
 
-        # Prepare API kwargs
-        data = {"model": self.deployment_name}
-        if language:
-            data["language"] = language
-        if prompt:
-            data["prompt"] = prompt
+        # Prepare API kwargs (always requests verbose_json)
+        data = self._get_api_kwargs(language=language, prompt=prompt)
 
         # Handle file input
         if isinstance(audio_file, str):
@@ -148,12 +204,7 @@ class AzureSpeechToTextModel(SpeechToTextModel):
         self._handle_error(response)
         response_data = response.json()
 
-        return TranscriptionResponse(
-            text=response_data["text"],
-            language=language,  # Azure doesn't return detected language
-            model=self.deployment_name,
-            provider=self.provider,
-        )
+        return self._build_response(response_data, language=language)
 
     async def atranscribe(
         self,
@@ -164,12 +215,8 @@ class AzureSpeechToTextModel(SpeechToTextModel):
         """Async transcribe audio using Azure OpenAI."""
         url = self._build_url("audio/transcriptions")
 
-        # Prepare API kwargs
-        data = {"model": self.deployment_name}
-        if language:
-            data["language"] = language
-        if prompt:
-            data["prompt"] = prompt
+        # Prepare API kwargs (always requests verbose_json)
+        data = self._get_api_kwargs(language=language, prompt=prompt)
 
         # Handle file input
         if isinstance(audio_file, str):
@@ -196,9 +243,4 @@ class AzureSpeechToTextModel(SpeechToTextModel):
         self._handle_error(response)
         response_data = response.json()
 
-        return TranscriptionResponse(
-            text=response_data["text"],
-            language=language,  # Azure doesn't return detected language
-            model=self.deployment_name,
-            provider=self.provider,
-        )
+        return self._build_response(response_data, language=language)

--- a/src/esperanto/providers/stt/base.py
+++ b/src/esperanto/providers/stt/base.py
@@ -5,9 +5,14 @@ import pathlib
 import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, BinaryIO, Dict, List, Optional, Union
+from typing import Any, BinaryIO, Dict, List, Optional, Sequence, Union
 
-from esperanto.common_types import Model, TranscriptionResponse
+from esperanto.common_types import (
+    Model,
+    TranscriptionResponse,
+    TranscriptionSegment,
+    TranscriptionUsage,
+)
 from esperanto.utils.connect import HttpConnectionMixin
 
 _AUDIO_CONTAINER_EXTENSIONS = {
@@ -17,6 +22,19 @@ _AUDIO_CONTAINER_EXTENSIONS = {
     ".mpga": "audio/mpeg",
     ".m4a": "audio/mp4",
 }
+
+# Whisper model-family per-segment fields surfaced via TranscriptionSegment.metadata
+# rather than promoted to first-class fields. Reused by OpenAI, Groq (inherited),
+# and Azure providers. See ARCHITECTURE.md ("Per-item Metadata Escape Hatch").
+_WHISPER_SEGMENT_METADATA_KEYS = (
+    "id",
+    "seek",
+    "tokens",
+    "temperature",
+    "avg_logprob",
+    "compression_ratio",
+    "no_speech_prob",
+)
 
 
 def _guess_audio_content_type(filename: Optional[str]) -> str:
@@ -34,6 +52,63 @@ def _guess_audio_content_type(filename: Optional[str]) -> str:
     if mime_type and mime_type.startswith("audio/"):
         return mime_type
     return "audio/mpeg"
+
+
+def _build_transcription_response(
+    response_data: Dict[str, Any],
+    *,
+    model: str,
+    provider: str,
+    metadata_keys: Sequence[str],
+    usage: Optional[TranscriptionUsage] = None,
+    language_fallback: Optional[str] = None,
+) -> TranscriptionResponse:
+    """Map a verbose transcription payload into a :class:`TranscriptionResponse`.
+
+    Handles the common shape returned by Whisper-family providers (OpenAI,
+    Groq, Azure) and Mistral Voxtral. Each provider only needs to supply its
+    own ``metadata_keys`` tuple and (for Mistral) a pre-built ``usage`` object.
+
+    - ``segments`` is mapped into a list of :class:`TranscriptionSegment` with
+      provider-specific per-segment extras routed through ``segment.metadata``
+      per ARCHITECTURE.md ("Per-item Metadata Escape Hatch").
+    - ``duration`` is cast to float when present, ``None`` otherwise.
+    - ``language`` falls back to ``language_fallback`` (typically the
+      caller-supplied input language) when the provider doesn't echo a
+      detected language.
+    - ``usage`` is passed through verbatim; providers without an STT usage
+      block simply leave it ``None``.
+    """
+    raw_segments = response_data.get("segments") or []
+    segments: Optional[List[TranscriptionSegment]] = None
+    if raw_segments:
+        segments = [
+            TranscriptionSegment(
+                text=segment.get("text", ""),
+                start=float(segment.get("start", 0.0)),
+                end=float(segment.get("end", 0.0)),
+                metadata={
+                    key: segment[key]
+                    for key in metadata_keys
+                    if key in segment
+                }
+                or None,
+            )
+            for segment in raw_segments
+        ]
+
+    duration_raw = response_data.get("duration")
+    duration = float(duration_raw) if duration_raw is not None else None
+
+    return TranscriptionResponse(
+        text=response_data["text"],
+        language=response_data.get("language") or language_fallback,
+        duration=duration,
+        usage=usage,
+        model=model,
+        provider=provider,
+        segments=segments,
+    )
 
 
 @dataclass

--- a/src/esperanto/providers/stt/mistral.py
+++ b/src/esperanto/providers/stt/mistral.py
@@ -6,11 +6,25 @@ from typing import Any, BinaryIO, Dict, List, Optional, Union
 
 import httpx
 
-from esperanto.common_types import TranscriptionResponse
+from esperanto.common_types import (
+    TranscriptionResponse,
+    TranscriptionSegment,
+    TranscriptionUsage,
+)
 from esperanto.providers.stt.base import (
     Model,
     SpeechToTextModel,
     _guess_audio_content_type,
+)
+
+# Mistral-specific per-segment fields routed through TranscriptionSegment.metadata
+# rather than promoted to first-class fields. See ARCHITECTURE.md
+# ("Per-item Metadata Escape Hatch").
+_MISTRAL_SEGMENT_METADATA_KEYS = (
+    "id",
+    "confidence",
+    "speaker",
+    "language",
 )
 
 
@@ -71,6 +85,51 @@ class MistralSpeechToTextModel(SpeechToTextModel):
             data["prompt"] = prompt
         return data
 
+    @staticmethod
+    def _build_usage(usage_data: Optional[Dict[str, Any]]) -> Optional[TranscriptionUsage]:
+        """Map Mistral's usage payload into TranscriptionUsage, or return None."""
+        if not usage_data:
+            return None
+        return TranscriptionUsage(
+            input_seconds=usage_data.get("prompt_audio_seconds"),
+            input_tokens=usage_data.get("prompt_tokens"),
+            output_tokens=usage_data.get("completion_tokens"),
+            total_tokens=usage_data.get("total_tokens"),
+        )
+
+    def _build_response(self, response_data: Dict[str, Any]) -> TranscriptionResponse:
+        """Build a TranscriptionResponse from a Mistral Voxtral payload."""
+        raw_segments = response_data.get("segments") or []
+        segments: Optional[List[TranscriptionSegment]] = None
+        if raw_segments:
+            segments = [
+                TranscriptionSegment(
+                    text=segment.get("text", ""),
+                    start=float(segment.get("start", 0.0)),
+                    end=float(segment.get("end", 0.0)),
+                    metadata={
+                        key: segment[key]
+                        for key in _MISTRAL_SEGMENT_METADATA_KEYS
+                        if key in segment
+                    }
+                    or None,
+                )
+                for segment in raw_segments
+            ]
+
+        duration_raw = response_data.get("duration")
+        duration = float(duration_raw) if duration_raw is not None else None
+
+        return TranscriptionResponse(
+            text=response_data["text"],
+            language=response_data.get("language"),
+            duration=duration,
+            usage=self._build_usage(response_data.get("usage")),
+            model=self.get_model_name(),
+            provider=self.provider,
+            segments=segments,
+        )
+
     def transcribe(
         self,
         audio_file: Union[str, BinaryIO],
@@ -102,12 +161,7 @@ class MistralSpeechToTextModel(SpeechToTextModel):
         self._handle_error(response)
         response_data = response.json()
 
-        return TranscriptionResponse(
-            text=response_data["text"],
-            language=response_data.get("language"),
-            model=self.get_model_name(),
-            provider=self.provider,
-        )
+        return self._build_response(response_data)
 
     async def atranscribe(
         self,
@@ -140,9 +194,4 @@ class MistralSpeechToTextModel(SpeechToTextModel):
         self._handle_error(response)
         response_data = response.json()
 
-        return TranscriptionResponse(
-            text=response_data["text"],
-            language=response_data.get("language"),
-            model=self.get_model_name(),
-            provider=self.provider,
-        )
+        return self._build_response(response_data)

--- a/src/esperanto/providers/stt/mistral.py
+++ b/src/esperanto/providers/stt/mistral.py
@@ -8,12 +8,12 @@ import httpx
 
 from esperanto.common_types import (
     TranscriptionResponse,
-    TranscriptionSegment,
     TranscriptionUsage,
 )
 from esperanto.providers.stt.base import (
     Model,
     SpeechToTextModel,
+    _build_transcription_response,
     _guess_audio_content_type,
 )
 
@@ -99,35 +99,12 @@ class MistralSpeechToTextModel(SpeechToTextModel):
 
     def _build_response(self, response_data: Dict[str, Any]) -> TranscriptionResponse:
         """Build a TranscriptionResponse from a Mistral Voxtral payload."""
-        raw_segments = response_data.get("segments") or []
-        segments: Optional[List[TranscriptionSegment]] = None
-        if raw_segments:
-            segments = [
-                TranscriptionSegment(
-                    text=segment.get("text", ""),
-                    start=float(segment.get("start", 0.0)),
-                    end=float(segment.get("end", 0.0)),
-                    metadata={
-                        key: segment[key]
-                        for key in _MISTRAL_SEGMENT_METADATA_KEYS
-                        if key in segment
-                    }
-                    or None,
-                )
-                for segment in raw_segments
-            ]
-
-        duration_raw = response_data.get("duration")
-        duration = float(duration_raw) if duration_raw is not None else None
-
-        return TranscriptionResponse(
-            text=response_data["text"],
-            language=response_data.get("language"),
-            duration=duration,
-            usage=self._build_usage(response_data.get("usage")),
+        return _build_transcription_response(
+            response_data,
             model=self.get_model_name(),
             provider=self.provider,
-            segments=segments,
+            metadata_keys=_MISTRAL_SEGMENT_METADATA_KEYS,
+            usage=self._build_usage(response_data.get("usage")),
         )
 
     def transcribe(

--- a/src/esperanto/providers/stt/openai.py
+++ b/src/esperanto/providers/stt/openai.py
@@ -6,27 +6,13 @@ from typing import Any, BinaryIO, Dict, List, Optional, Union
 
 import httpx
 
-from esperanto.common_types import (
-    TranscriptionResponse,
-    TranscriptionSegment,
-)
+from esperanto.common_types import TranscriptionResponse
 from esperanto.providers.stt.base import (
+    _WHISPER_SEGMENT_METADATA_KEYS,
     Model,
     SpeechToTextModel,
+    _build_transcription_response,
     _guess_audio_content_type,
-)
-
-# Whisper-specific per-segment fields that are surfaced via TranscriptionSegment.metadata
-# rather than promoted to first-class fields. See ARCHITECTURE.md
-# ("Per-item Metadata Escape Hatch").
-_WHISPER_SEGMENT_METADATA_KEYS = (
-    "id",
-    "seek",
-    "tokens",
-    "temperature",
-    "avg_logprob",
-    "compression_ratio",
-    "no_speech_prob",
 )
 
 
@@ -129,34 +115,12 @@ class OpenAISpeechToTextModel(SpeechToTextModel):
         language: Optional[str] = None,
     ) -> TranscriptionResponse:
         """Build a TranscriptionResponse from a Whisper ``verbose_json`` payload."""
-        raw_segments = response_data.get("segments") or []
-        segments: Optional[List[TranscriptionSegment]] = None
-        if raw_segments:
-            segments = [
-                TranscriptionSegment(
-                    text=segment.get("text", ""),
-                    start=float(segment.get("start", 0.0)),
-                    end=float(segment.get("end", 0.0)),
-                    metadata={
-                        key: segment[key]
-                        for key in _WHISPER_SEGMENT_METADATA_KEYS
-                        if key in segment
-                    }
-                    or None,
-                )
-                for segment in raw_segments
-            ]
-
-        duration_raw = response_data.get("duration")
-        duration = float(duration_raw) if duration_raw is not None else None
-
-        return TranscriptionResponse(
-            text=response_data["text"],
-            language=response_data.get("language") or language,
-            duration=duration,
+        return _build_transcription_response(
+            response_data,
             model=self.get_model_name(),
             provider=self.provider,
-            segments=segments,
+            metadata_keys=_WHISPER_SEGMENT_METADATA_KEYS,
+            language_fallback=language,
         )
 
     def transcribe(

--- a/src/esperanto/providers/stt/openai.py
+++ b/src/esperanto/providers/stt/openai.py
@@ -6,11 +6,27 @@ from typing import Any, BinaryIO, Dict, List, Optional, Union
 
 import httpx
 
-from esperanto.common_types import TranscriptionResponse
+from esperanto.common_types import (
+    TranscriptionResponse,
+    TranscriptionSegment,
+)
 from esperanto.providers.stt.base import (
     Model,
     SpeechToTextModel,
     _guess_audio_content_type,
+)
+
+# Whisper-specific per-segment fields that are surfaced via TranscriptionSegment.metadata
+# rather than promoted to first-class fields. See ARCHITECTURE.md
+# ("Per-item Metadata Escape Hatch").
+_WHISPER_SEGMENT_METADATA_KEYS = (
+    "id",
+    "seek",
+    "tokens",
+    "temperature",
+    "avg_logprob",
+    "compression_ratio",
+    "no_speech_prob",
 )
 
 
@@ -89,9 +105,15 @@ class OpenAISpeechToTextModel(SpeechToTextModel):
     def _get_api_kwargs(
         self, language: Optional[str] = None, prompt: Optional[str] = None
     ) -> Dict[str, Any]:
-        """Get kwargs for API calls."""
-        kwargs = {
+        """Get kwargs for API calls.
+
+        Always requests ``verbose_json`` so that segments and duration are returned,
+        per Esperanto's Hot-Swap-First Defaults principle. Users don't have to know
+        the per-provider response_format quirk to get consistent output.
+        """
+        kwargs: Dict[str, Any] = {
             "model": self.get_model_name(),
+            "response_format": "verbose_json",
         }
 
         if language:
@@ -100,6 +122,42 @@ class OpenAISpeechToTextModel(SpeechToTextModel):
             kwargs["prompt"] = prompt
 
         return kwargs
+
+    def _build_response(
+        self,
+        response_data: Dict[str, Any],
+        language: Optional[str] = None,
+    ) -> TranscriptionResponse:
+        """Build a TranscriptionResponse from a Whisper ``verbose_json`` payload."""
+        raw_segments = response_data.get("segments") or []
+        segments: Optional[List[TranscriptionSegment]] = None
+        if raw_segments:
+            segments = [
+                TranscriptionSegment(
+                    text=segment.get("text", ""),
+                    start=float(segment.get("start", 0.0)),
+                    end=float(segment.get("end", 0.0)),
+                    metadata={
+                        key: segment[key]
+                        for key in _WHISPER_SEGMENT_METADATA_KEYS
+                        if key in segment
+                    }
+                    or None,
+                )
+                for segment in raw_segments
+            ]
+
+        duration_raw = response_data.get("duration")
+        duration = float(duration_raw) if duration_raw is not None else None
+
+        return TranscriptionResponse(
+            text=response_data["text"],
+            language=response_data.get("language") or language,
+            duration=duration,
+            model=self.get_model_name(),
+            provider=self.provider,
+            segments=segments,
+        )
 
     def transcribe(
         self,
@@ -135,12 +193,7 @@ class OpenAISpeechToTextModel(SpeechToTextModel):
         self._handle_error(response)
         response_data = response.json()
 
-        return TranscriptionResponse(
-            text=response_data["text"],
-            language=language,  # OpenAI doesn't return detected language
-            model=self.get_model_name(),
-            provider=self.provider,
-        )
+        return self._build_response(response_data, language=language)
 
     async def atranscribe(
         self,
@@ -176,9 +229,4 @@ class OpenAISpeechToTextModel(SpeechToTextModel):
         self._handle_error(response)
         response_data = response.json()
 
-        return TranscriptionResponse(
-            text=response_data["text"],
-            language=language,  # OpenAI doesn't return detected language
-            model=self.get_model_name(),
-            provider=self.provider,
-        )
+        return self._build_response(response_data, language=language)

--- a/tests/common_types/test_stt.py
+++ b/tests/common_types/test_stt.py
@@ -1,0 +1,97 @@
+"""Tests for the speech-to-text common types."""
+
+import pytest
+from pydantic import ValidationError
+
+from esperanto.common_types import (
+    TranscriptionResponse,
+    TranscriptionSegment,
+    TranscriptionUsage,
+)
+
+
+def test_transcription_segment_required_fields():
+    """TranscriptionSegment requires text, start, end."""
+    segment = TranscriptionSegment(text="hello", start=0.0, end=1.5)
+    assert segment.text == "hello"
+    assert segment.start == 0.0
+    assert segment.end == 1.5
+    assert segment.metadata is None
+
+
+def test_transcription_segment_with_metadata():
+    """TranscriptionSegment accepts arbitrary provider-specific metadata."""
+    segment = TranscriptionSegment(
+        text="hello",
+        start=0.0,
+        end=1.5,
+        metadata={"avg_logprob": -0.25, "tokens": [50364, 50464]},
+    )
+    assert segment.metadata == {"avg_logprob": -0.25, "tokens": [50364, 50464]}
+
+
+def test_transcription_segment_is_frozen():
+    """TranscriptionSegment is immutable (Pydantic frozen=True)."""
+    segment = TranscriptionSegment(text="hello", start=0.0, end=1.5)
+    with pytest.raises(ValidationError):
+        segment.text = "modified"  # type: ignore[misc]
+
+
+def test_transcription_segment_missing_required_field():
+    """TranscriptionSegment raises on missing required fields."""
+    with pytest.raises(ValidationError):
+        TranscriptionSegment(text="hello", start=0.0)  # type: ignore[call-arg]
+
+
+def test_transcription_usage_all_optional():
+    """TranscriptionUsage has all-optional fields, defaulting to None."""
+    usage = TranscriptionUsage()
+    assert usage.input_seconds is None
+    assert usage.input_tokens is None
+    assert usage.output_tokens is None
+    assert usage.total_tokens is None
+
+
+def test_transcription_usage_partial_population():
+    """TranscriptionUsage accepts any subset of fields (e.g. audio-only providers)."""
+    usage = TranscriptionUsage(input_seconds=12.5)
+    assert usage.input_seconds == 12.5
+    assert usage.input_tokens is None
+    assert usage.output_tokens is None
+
+
+def test_transcription_usage_is_frozen():
+    """TranscriptionUsage is immutable (Pydantic frozen=True)."""
+    usage = TranscriptionUsage(input_seconds=10.0)
+    with pytest.raises(ValidationError):
+        usage.input_seconds = 20.0  # type: ignore[misc]
+
+
+def test_transcription_response_segments_default_none():
+    """TranscriptionResponse.segments defaults to None for backward compatibility."""
+    response = TranscriptionResponse(text="hello world")
+    assert response.segments is None
+    assert response.usage is None
+    assert response.duration is None
+
+
+def test_transcription_response_accepts_segments():
+    """TranscriptionResponse stores a list of TranscriptionSegment."""
+    segments = [
+        TranscriptionSegment(text="hello", start=0.0, end=0.5),
+        TranscriptionSegment(text="world", start=0.5, end=1.0),
+    ]
+    response = TranscriptionResponse(text="hello world", segments=segments)
+    assert response.segments is not None
+    assert len(response.segments) == 2
+    assert response.segments[0].text == "hello"
+    assert response.segments[1].start == 0.5
+
+
+def test_transcription_response_accepts_transcription_usage():
+    """TranscriptionResponse.usage accepts the new TranscriptionUsage type."""
+    usage = TranscriptionUsage(input_seconds=12.5, total_tokens=42)
+    response = TranscriptionResponse(text="hello", usage=usage)
+    assert response.usage is not None
+    assert response.usage.input_seconds == 12.5
+    assert response.usage.total_tokens == 42

--- a/tests/providers/stt/test_azure.py
+++ b/tests/providers/stt/test_azure.py
@@ -227,3 +227,171 @@ def test_azure_missing_api_key():
     with patch.dict(os.environ, {}, clear=True):
         with pytest.raises(ValueError, match="Azure OpenAI API key not found"):
             AzureSpeechToTextModel(api_key=None)
+
+
+# ---------------------------------------------------------------------------
+# verbose_json / segments tests (Azure parity with OpenAI)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_azure_verbose_response():
+    """Realistic Azure-OpenAI Whisper verbose_json payload."""
+    return {
+        "task": "transcribe",
+        "language": "english",
+        "duration": 4.2,
+        "text": "Hello from Azure.",
+        "segments": [
+            {
+                "id": 0,
+                "seek": 0,
+                "start": 0.0,
+                "end": 2.1,
+                "text": "Hello from",
+                "tokens": [50364, 2425, 490],
+                "temperature": 0.0,
+                "avg_logprob": -0.22,
+                "compression_ratio": 1.0,
+                "no_speech_prob": 0.01,
+            },
+            {
+                "id": 1,
+                "seek": 210,
+                "start": 2.1,
+                "end": 4.2,
+                "text": " Azure.",
+                "tokens": [50464, 21036, 13],
+                "temperature": 0.0,
+                "avg_logprob": -0.30,
+                "compression_ratio": 1.05,
+                "no_speech_prob": 0.02,
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def mock_verbose_httpx_clients(mock_azure_verbose_response):
+    """Mock httpx sync/async clients returning the verbose payload."""
+    client = Mock()
+    async_client = AsyncMock()
+
+    def make_response(status_code, data):
+        r = Mock()
+        r.status_code = status_code
+        r.json.return_value = data
+        return r
+
+    def make_async_response(status_code, data):
+        r = AsyncMock()
+        r.status_code = status_code
+        r.json = Mock(return_value=data)
+        return r
+
+    def post_side_effect(url, **kwargs):
+        if "audio/transcriptions" in url:
+            return make_response(200, mock_azure_verbose_response)
+        return make_response(404, {"error": {"message": "Not found"}})
+
+    async def async_post_side_effect(url, **kwargs):
+        if "audio/transcriptions" in url:
+            return make_async_response(200, mock_azure_verbose_response)
+        return make_async_response(404, {"error": {"message": "Not found"}})
+
+    client.post.side_effect = post_side_effect
+    async_client.post.side_effect = async_post_side_effect
+
+    return client, async_client
+
+
+def test_azure_transcribe_requests_verbose_json(audio_file, mock_httpx_clients):
+    """Azure auto-opts into response_format=verbose_json, like OpenAI."""
+    model = AzureSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    model.transcribe(audio_file)
+
+    call_args = model.client.post.call_args
+    assert call_args[1]["data"]["response_format"] == "verbose_json"
+
+
+@pytest.mark.asyncio
+async def test_azure_atranscribe_requests_verbose_json(audio_file, mock_httpx_clients):
+    """Async path also auto-opts into response_format=verbose_json."""
+    model = AzureSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    await model.atranscribe(audio_file)
+
+    call_args = model.async_client.post.call_args
+    assert call_args[1]["data"]["response_format"] == "verbose_json"
+
+
+def test_azure_transcribe_maps_segments(audio_file, mock_verbose_httpx_clients):
+    """Azure segments are mapped to TranscriptionSegment instances."""
+    model = AzureSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_verbose_httpx_clients
+
+    response = model.transcribe(audio_file)
+
+    assert response.segments is not None
+    assert len(response.segments) == 2
+    assert response.segments[0].text == "Hello from"
+    assert response.segments[0].start == 0.0
+    assert response.segments[0].end == 2.1
+
+
+def test_azure_transcribe_segment_metadata_extras(audio_file, mock_verbose_httpx_clients):
+    """Whisper-specific per-segment extras land in segment.metadata."""
+    model = AzureSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_verbose_httpx_clients
+
+    response = model.transcribe(audio_file)
+
+    assert response.segments is not None
+    md = response.segments[0].metadata
+    assert md is not None
+    assert md["avg_logprob"] == -0.22
+    assert md["compression_ratio"] == 1.0
+    assert md["no_speech_prob"] == 0.01
+    assert md["temperature"] == 0.0
+    assert md["tokens"] == [50364, 2425, 490]
+
+
+def test_azure_transcribe_populates_duration_and_language(
+    audio_file, mock_verbose_httpx_clients
+):
+    """Duration and detected language from verbose_json are mapped."""
+    model = AzureSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_verbose_httpx_clients
+
+    response = model.transcribe(audio_file)
+
+    assert response.duration == pytest.approx(4.2)
+    assert response.language == "english"
+
+
+def test_azure_transcribe_no_segments_in_response(audio_file, mock_httpx_clients):
+    """Plain {'text': ...} response leaves segments / duration as None."""
+    model = AzureSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    response = model.transcribe(audio_file)
+
+    assert response.segments is None
+    assert response.duration is None
+
+
+@pytest.mark.asyncio
+async def test_azure_atranscribe_maps_segments(audio_file, mock_verbose_httpx_clients):
+    """Async path also maps segments + duration + language."""
+    model = AzureSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_verbose_httpx_clients
+
+    response = await model.atranscribe(audio_file)
+
+    assert response.segments is not None
+    assert len(response.segments) == 2
+    assert response.duration == pytest.approx(4.2)
+    assert response.language == "english"

--- a/tests/providers/stt/test_groq.py
+++ b/tests/providers/stt/test_groq.py
@@ -176,3 +176,82 @@ def test_groq_transcribe_file_object():
         response = model.transcribe(f)
     assert isinstance(response, TranscriptionResponse)
     assert response.text == "This is a test transcription"
+
+
+# ---------------------------------------------------------------------------
+# verbose_json / segments tests (inherited from OpenAISpeechToTextModel)
+# ---------------------------------------------------------------------------
+
+
+def test_groq_transcribe_requests_verbose_json(audio_file):
+    """Groq inherits OpenAI's auto-opt-in to response_format=verbose_json."""
+    from unittest.mock import Mock
+
+    model = GroqSpeechToTextModel(api_key="test-key")
+
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"text": "hi"}
+
+    mock_client = Mock()
+    mock_client.post.return_value = mock_response
+    model.client = mock_client
+
+    model.transcribe(audio_file)
+
+    call_args = mock_client.post.call_args
+    # The provider posts to the Groq OpenAI-compatible /audio/transcriptions endpoint.
+    assert call_args[0][0] == "https://api.groq.com/openai/v1/audio/transcriptions"
+    assert call_args[1]["data"]["model"] == "whisper-large-v3"
+    assert call_args[1]["data"]["response_format"] == "verbose_json"
+
+
+def test_groq_transcribe_maps_segments(audio_file):
+    """Groq inherits segment mapping from OpenAISpeechToTextModel._build_response."""
+    from unittest.mock import Mock
+
+    model = GroqSpeechToTextModel(api_key="test-key")
+
+    verbose_payload = {
+        "task": "transcribe",
+        "language": "english",
+        "duration": 1.75,
+        "text": "Hello world.",
+        "segments": [
+            {
+                "id": 0,
+                "seek": 0,
+                "start": 0.0,
+                "end": 1.75,
+                "text": "Hello world.",
+                "tokens": [50364, 2425, 1002, 13],
+                "temperature": 0.0,
+                "avg_logprob": -0.3,
+                "compression_ratio": 1.0,
+                "no_speech_prob": 0.02,
+            }
+        ],
+    }
+
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = verbose_payload
+
+    mock_client = Mock()
+    mock_client.post.return_value = mock_response
+    model.client = mock_client
+
+    response = model.transcribe(audio_file)
+
+    assert response.segments is not None
+    assert len(response.segments) == 1
+    assert response.segments[0].text == "Hello world."
+    assert response.segments[0].start == 0.0
+    assert response.segments[0].end == 1.75
+    assert response.segments[0].metadata is not None
+    assert response.segments[0].metadata["avg_logprob"] == -0.3
+    assert response.duration == pytest.approx(1.75)
+    assert response.language == "english"
+    assert response.usage is None
+    assert response.provider == "groq"
+

--- a/tests/providers/stt/test_mistral.py
+++ b/tests/providers/stt/test_mistral.py
@@ -306,3 +306,165 @@ async def test_mistral_atranscribe_wav_content_type(wav_file, mock_httpx_clients
     content_type = call_args[1]["files"]["file"][2]
     assert content_type == _guess_audio_content_type(wav_file)
     assert content_type.startswith("audio/")
+
+
+# ---------------------------------------------------------------------------
+# segments / usage tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_mistral_verbose_response():
+    """Realistic Mistral transcription payload with segments and usage."""
+    return {
+        "text": "Bonjour le monde. Ceci est un test.",
+        "model": "voxtral-mini-latest",
+        "language": "fr",
+        "segments": [
+            {
+                "id": 0,
+                "start": 0.0,
+                "end": 1.4,
+                "text": "Bonjour le monde.",
+                "confidence": 0.97,
+                "speaker": "speaker_0",
+                "language": "fr",
+            },
+            {
+                "id": 1,
+                "start": 1.4,
+                "end": 3.2,
+                "text": " Ceci est un test.",
+                "confidence": 0.92,
+                "speaker": "speaker_0",
+                "language": "fr",
+            },
+        ],
+        "usage": {
+            "prompt_audio_seconds": 3.2,
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30,
+        },
+    }
+
+
+@pytest.fixture
+def mock_verbose_httpx_clients(mock_mistral_verbose_response):
+    """Mock httpx sync/async clients returning the verbose payload."""
+    client = Mock()
+    async_client = AsyncMock()
+
+    def make_response(status_code, data):
+        r = Mock()
+        r.status_code = status_code
+        r.json.return_value = data
+        return r
+
+    def make_async_response(status_code, data):
+        r = AsyncMock()
+        r.status_code = status_code
+        r.json = Mock(return_value=data)
+        return r
+
+    def post_side_effect(url, **kwargs):
+        if url.endswith("/audio/transcriptions"):
+            return make_response(200, mock_mistral_verbose_response)
+        return make_response(404, {"error": {"message": "Not found"}})
+
+    async def async_post_side_effect(url, **kwargs):
+        if url.endswith("/audio/transcriptions"):
+            return make_async_response(200, mock_mistral_verbose_response)
+        return make_async_response(404, {"error": {"message": "Not found"}})
+
+    client.post.side_effect = post_side_effect
+    async_client.post.side_effect = async_post_side_effect
+
+    return client, async_client
+
+
+def test_mistral_transcribe_does_not_request_verbose_json(audio_file, mock_httpx_clients):
+    """Mistral natively returns segments; we must NOT set response_format."""
+    model = MistralSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    model.transcribe(audio_file)
+
+    call_args = model.client.post.call_args
+    assert "response_format" not in call_args[1]["data"]
+
+
+def test_mistral_transcribe_maps_segments(audio_file, mock_verbose_httpx_clients):
+    """Segment list is mapped to TranscriptionSegment instances."""
+    model = MistralSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_verbose_httpx_clients
+
+    response = model.transcribe(audio_file)
+
+    assert response.segments is not None
+    assert len(response.segments) == 2
+    first = response.segments[0]
+    assert first.text == "Bonjour le monde."
+    assert first.start == 0.0
+    assert first.end == 1.4
+
+
+def test_mistral_transcribe_segment_metadata_extras(audio_file, mock_verbose_httpx_clients):
+    """Mistral-specific extras (confidence, speaker, language) land in metadata."""
+    model = MistralSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_verbose_httpx_clients
+
+    response = model.transcribe(audio_file)
+
+    assert response.segments is not None
+    md = response.segments[0].metadata
+    assert md is not None
+    assert md["confidence"] == 0.97
+    assert md["speaker"] == "speaker_0"
+    assert md["language"] == "fr"
+    assert md["id"] == 0
+
+
+def test_mistral_transcribe_populates_usage(audio_file, mock_verbose_httpx_clients):
+    """Usage is mapped to TranscriptionUsage with input_seconds + token counts."""
+    model = MistralSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_verbose_httpx_clients
+
+    response = model.transcribe(audio_file)
+
+    assert response.usage is not None
+    assert response.usage.input_seconds == pytest.approx(3.2)
+    assert response.usage.input_tokens == 10
+    assert response.usage.output_tokens == 20
+    assert response.usage.total_tokens == 30
+
+
+def test_mistral_transcribe_no_segments_in_response(audio_file, mock_httpx_clients):
+    """Existing legacy mock has empty segments list -> response.segments is None."""
+    # mock_transcription_response from the default fixture has "segments": [],
+    # which the provider should normalize to None.
+    model = MistralSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    response = model.transcribe(audio_file)
+
+    assert response.segments is None
+
+
+@pytest.mark.asyncio
+async def test_mistral_atranscribe_maps_segments_and_usage(
+    audio_file, mock_verbose_httpx_clients
+):
+    """Async path also maps segments + usage."""
+    model = MistralSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_verbose_httpx_clients
+
+    response = await model.atranscribe(audio_file)
+
+    assert response.segments is not None
+    assert len(response.segments) == 2
+    assert response.usage is not None
+    assert response.usage.input_seconds == pytest.approx(3.2)
+    # Negative: still no response_format override on the async path.
+    call_args = model.async_client.post.call_args
+    assert "response_format" not in call_args[1]["data"]

--- a/tests/providers/stt/test_openai.py
+++ b/tests/providers/stt/test_openai.py
@@ -164,7 +164,9 @@ def test_openai_transcribe(audio_file, mock_httpx_clients):
     assert "files" in call_args[1]
     assert "data" in call_args[1]
     assert call_args[1]["data"]["model"] == "whisper-1"
-    
+    # Verbose JSON is auto-requested so segments are returned.
+    assert call_args[1]["data"]["response_format"] == "verbose_json"
+
     # Check response
     assert isinstance(response, TranscriptionResponse)
     assert response.text == "This is a test transcription"
@@ -195,7 +197,8 @@ async def test_openai_atranscribe(audio_file, mock_httpx_clients):
     assert "files" in call_args[1]
     assert "data" in call_args[1]
     assert call_args[1]["data"]["model"] == "whisper-1"
-    
+    assert call_args[1]["data"]["response_format"] == "verbose_json"
+
     # Check response
     assert isinstance(response, TranscriptionResponse)
     assert response.text == "This is a test transcription"
@@ -354,3 +357,173 @@ async def test_openai_atranscribe_wav_content_type(wav_file, mock_httpx_clients)
     content_type = call_args[1]["files"]["file"][2]
     assert content_type == _guess_audio_content_type(wav_file)
     assert content_type.startswith("audio/")
+
+
+# ---------------------------------------------------------------------------
+# verbose_json / segments tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_openai_verbose_response():
+    """Realistic Whisper verbose_json payload with segments + duration."""
+    return {
+        "task": "transcribe",
+        "language": "english",
+        "duration": 3.14,
+        "text": "Hello world. This is a test.",
+        "segments": [
+            {
+                "id": 0,
+                "seek": 0,
+                "start": 0.0,
+                "end": 1.5,
+                "text": "Hello world.",
+                "tokens": [50364, 2425, 1002, 13, 50464],
+                "temperature": 0.0,
+                "avg_logprob": -0.25,
+                "compression_ratio": 1.1,
+                "no_speech_prob": 0.01,
+            },
+            {
+                "id": 1,
+                "seek": 150,
+                "start": 1.5,
+                "end": 3.14,
+                "text": " This is a test.",
+                "tokens": [50464, 639, 307, 257, 1500, 13, 50628],
+                "temperature": 0.0,
+                "avg_logprob": -0.18,
+                "compression_ratio": 1.05,
+                "no_speech_prob": 0.0,
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def mock_verbose_httpx_clients(mock_openai_verbose_response):
+    """Mock httpx clients returning the verbose_json payload."""
+    from unittest.mock import Mock
+
+    client = Mock()
+    async_client = AsyncMock()
+
+    def make_response(status_code, data):
+        response = Mock()
+        response.status_code = status_code
+        response.json.return_value = data
+        return response
+
+    def make_async_response(status_code, data):
+        response = AsyncMock()
+        response.status_code = status_code
+        response.json = Mock(return_value=data)
+        return response
+
+    def post_side_effect(url, **kwargs):
+        if url.endswith("/audio/transcriptions"):
+            return make_response(200, mock_openai_verbose_response)
+        return make_response(404, {"error": "Not found"})
+
+    async def async_post_side_effect(url, **kwargs):
+        if url.endswith("/audio/transcriptions"):
+            return make_async_response(200, mock_openai_verbose_response)
+        return make_async_response(404, {"error": "Not found"})
+
+    client.post.side_effect = post_side_effect
+    async_client.post.side_effect = async_post_side_effect
+
+    return client, async_client
+
+
+def test_openai_transcribe_maps_segments(audio_file, mock_verbose_httpx_clients):
+    """Verbose JSON segments are mapped to TranscriptionSegment instances."""
+    model = OpenAISpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_verbose_httpx_clients
+
+    response = model.transcribe(audio_file)
+
+    assert response.segments is not None
+    assert len(response.segments) == 2
+    first = response.segments[0]
+    assert first.text == "Hello world."
+    assert first.start == 0.0
+    assert first.end == 1.5
+
+
+def test_openai_transcribe_segment_metadata_extras(audio_file, mock_verbose_httpx_clients):
+    """Whisper-specific per-segment extras land in segment.metadata."""
+    model = OpenAISpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_verbose_httpx_clients
+
+    response = model.transcribe(audio_file)
+
+    assert response.segments is not None
+    first_metadata = response.segments[0].metadata
+    assert first_metadata is not None
+    assert first_metadata["avg_logprob"] == -0.25
+    assert first_metadata["compression_ratio"] == 1.1
+    assert first_metadata["no_speech_prob"] == 0.01
+    assert first_metadata["temperature"] == 0.0
+    assert first_metadata["tokens"] == [50364, 2425, 1002, 13, 50464]
+    assert first_metadata["id"] == 0
+    assert first_metadata["seek"] == 0
+
+
+def test_openai_transcribe_populates_duration(audio_file, mock_verbose_httpx_clients):
+    """Duration from verbose_json populates TranscriptionResponse.duration."""
+    model = OpenAISpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_verbose_httpx_clients
+
+    response = model.transcribe(audio_file)
+
+    assert response.duration == pytest.approx(3.14)
+
+
+def test_openai_transcribe_populates_language(audio_file, mock_verbose_httpx_clients):
+    """Detected language from verbose_json populates TranscriptionResponse.language."""
+    model = OpenAISpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_verbose_httpx_clients
+
+    response = model.transcribe(audio_file)
+
+    assert response.language == "english"
+
+
+def test_openai_transcribe_leaves_usage_none(audio_file, mock_verbose_httpx_clients):
+    """Whisper API does not return token usage; usage stays None."""
+    model = OpenAISpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_verbose_httpx_clients
+
+    response = model.transcribe(audio_file)
+
+    assert response.usage is None
+
+
+@pytest.mark.asyncio
+async def test_openai_atranscribe_maps_segments(audio_file, mock_verbose_httpx_clients):
+    """Async path also maps segments + duration + language."""
+    model = OpenAISpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_verbose_httpx_clients
+
+    response = await model.atranscribe(audio_file)
+
+    assert response.segments is not None
+    assert len(response.segments) == 2
+    assert response.duration == pytest.approx(3.14)
+    assert response.language == "english"
+    # Verbose JSON is still requested on the async path.
+    call_args = model.async_client.post.call_args
+    assert call_args[1]["data"]["response_format"] == "verbose_json"
+
+
+def test_openai_transcribe_no_segments_in_response(audio_file, mock_httpx_clients):
+    """When the provider returns no segments (legacy mock), segments stays None."""
+    model = OpenAISpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+
+    response = model.transcribe(audio_file)
+
+    assert response.segments is None
+    assert response.duration is None


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes: https://github.com/lfnovo/esperanto/issues/193
Fixes: https://github.com/lfnovo/esperanto/issues/146

#### What does this implement/fix? Explain your changes.
- Add segments data to the transcription response for models which return segments data
- Update usage data in the response
- Default response format is `verbose_json`


#### Any other comments?


<!--
Thanks for contributing!
-->