### PR TITLE
chore(release): bump to 2.22.0 and cut CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.22.0] - 2026-05-22
+
 ### Added
 
 - **STT segments + Whisper/Voxtral usage** — Speech-to-text responses now carry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esperanto"
-version = "2.21.0"
+version = "2.22.0"
 description = "A light-weight, production-ready, unified interface for various AI model providers"
 authors = [
     { name = "LUIS NOVO", email = "lfnovo@gmail.com" }

--- a/uv.lock
+++ b/uv.lock
@@ -497,7 +497,7 @@ wheels = [
 
 [[package]]
 name = "esperanto"
-version = "2.21.0"
+version = "2.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Bump version to 2.22.0 (minor — STT segments + new public types added in #200)
- Cut CHANGELOG `[Unreleased]` → `[2.22.0] - 2026-05-22`
- Refresh `uv.lock`

Headline change in this release: STT responses now carry timestamped `segments` and a new `TranscriptionUsage` type, with `verbose_json` auto-opt-in for Whisper-family providers (closes #146, #193 via #200).

## Test plan
- [x] `uv sync --all-extras` clean
- [ ] CI green (lint + test 3.10/3.11/3.12)
- [ ] Tag `v2.22.0` after merge
- [ ] GitHub release published (PyPI auto-publishes from the release workflow)