### PR TITLE
feat(cohere): add first-class Cohere provider (LLM, Embedding, Reranker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.23.0] - 2026-06-16
+
+### Added
+
+- **Cohere provider (LLM, Embedding, Reranker)** — Cohere is now a first-class
+  provider across three capabilities, integrated via its native v2 API
+  (`/v2/chat`, `/v2/embed`, `/v2/rerank`) rather than an OpenAI-compatible
+  profile, because its differentiators (`documents`-based RAG, citations,
+  `input_type` embeddings, native tool format) are not exposed on the
+  compatibility endpoint. Authentication is shared via `COHERE_API_KEY`.
+  - **LLM** (`AIFactory.create_language("cohere", "command-a-03-2025")`):
+    chat, streaming, and tool calling. Esperanto's `top_p` maps to Cohere's
+    `p`. Cohere-specific RAG fields (`documents`, `citation_options`,
+    `connectors`) pass through via `config` without changing the universal
+    `chat_complete` surface; returned citations are not surfaced on
+    `ChatCompletion` in this version (out of scope).
+  - **Embedding** (`AIFactory.create_embedding("cohere", "embed-v4.0")`):
+    `input_type`-aware (default `search_document`, configurable per-call), with
+    automatic batching to Cohere's 96-texts-per-request limit.
+  - **Reranker** (`AIFactory.create_reranker("cohere", "rerank-v4.0-pro")`):
+    maps `top_k` to Cohere's `top_n`, returns a normalized `RerankResponse`.
+  - **Model discovery**: `AIFactory.get_provider_models("cohere")` lists chat,
+    embed, and rerank models live via `/v1/models`, tagged by Esperanto type.
+  All three capabilities ship with mocked-API unit tests and documentation in
+  `docs/providers/cohere.md`. (#110)
+
 ## [2.22.0] - 2026-05-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Whether you're building a quick prototype or a production application serving mi
   - MiniMax (MiniMax-M2.5)
   - Voyage (Embeddings, Reranking)
   - Jina (Advanced embedding models with task optimization, Reranking)
+  - Cohere (LLM, Embeddings, Reranking)
 - **Embedding Support**: Multiple embedding providers for vector representations
 - **Reranking Support**: Universal reranking interface for improving search relevance
 - **Speech-to-Text Support**: Transcribe audio using multiple providers
@@ -150,6 +151,7 @@ pip install "langchain_deepseek>=0.1.3"
 | DeepSeek     | ✅          | ❌               | ❌                | ❌             | ❌             | ✅        |
 | Voyage       | ❌          | ✅               | ✅                | ❌             | ❌             | ❌        |
 | Jina         | ❌          | ✅               | ✅                | ❌             | ❌             | ❌        |
+| Cohere       | ✅          | ✅               | ✅                | ❌             | ❌             | ✅        |
 | xAI          | ✅          | ❌               | ❌                | ❌             | ❌             | ❌        |
 | DashScope    | ✅          | ❌               | ❌                | ❌             | ❌             | ✅        |
 | MiniMax      | ✅          | ❌               | ❌                | ❌             | ❌             | ✅        |
@@ -259,6 +261,7 @@ for model in local_models:
 - **Ollama** - Fetches locally available models
 - **Jina** - Returns hardcoded list of embedding/reranking models
 - **Voyage** - Returns hardcoded list of embedding/reranking models
+- **Cohere** - Fetches LLM/embedding/reranking models via API
 - **And more...**
 
 > **Note**: This is the recommended way to discover models. The `.models` property on provider instances is deprecated and will be removed in version 3.0.

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -24,6 +24,7 @@ Welcome to the Esperanto provider guide. This page helps you choose the right AI
 | [Transformers](./transformers.md) | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
 | [Jina](./jina.md) | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
 | [Voyage](./voyage.md) | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| [Cohere](./cohere.md) | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
 | [ElevenLabs](./elevenlabs.md) | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
 
 *⚠️ OpenAI-Compatible: JSON mode support depends on the specific endpoint implementation
@@ -135,12 +136,14 @@ Welcome to the Esperanto provider guide. This page helps you choose the right AI
 **Enterprise:**
 - **[Azure](./azure.md)**: text-embedding-3-large, text-embedding-3-small (private cloud)
 - **[Vertex AI](./vertex.md)**: text-embedding-004 (Google Cloud)
+- **[Cohere](./cohere.md)**: embed-v4.0 (input_type-aware, enterprise-grade)
 
 #### Reranking
 
 **All Reranking Providers:**
 - **[Jina](./jina.md)**: Multilingual (100+ languages), production-ready
 - **[Voyage](./voyage.md)**: rerank-2, rerank-1 (high accuracy)
+- **[Cohere](./cohere.md)**: rerank-v4.0-pro, rerank-v3.5 (high accuracy)
 - **[Transformers](./transformers.md)**: Universal support (any CrossEncoder model), local/offline
 
 **Best for Multilingual:**
@@ -315,6 +318,7 @@ Require API keys, pay-per-use:
 - [OpenRouter](./openrouter.md)
 - [Jina](./jina.md)
 - [Voyage](./voyage.md)
+- [Cohere](./cohere.md)
 - [ElevenLabs](./elevenlabs.md)
 
 ### Cloud Enterprise Providers

--- a/docs/providers/cohere.md
+++ b/docs/providers/cohere.md
@@ -1,0 +1,162 @@
+# Cohere
+
+## Overview
+
+Cohere provides enterprise-grade language, embedding, and reranking models. Esperanto integrates Cohere as a **first-class provider** via its native v2 API (`/v2/chat`, `/v2/embed`, `/v2/rerank`), because Cohere's differentiators — `documents`-based RAG, citations, and `input_type` for embeddings — are not exposed through its OpenAI-compatibility endpoint.
+
+**Supported Capabilities:**
+
+| Capability | Supported | Notes |
+|------------|-----------|-------|
+| Language Models (LLM) | ✅ | `command-a-03-2025` (default), chat, streaming, tool calling |
+| Embeddings | ✅ | `embed-v4.0` (default), `input_type` aware, auto-batched |
+| Reranking | ✅ | `rerank-v4.0-pro` (default), `rerank-v3.5` |
+| Speech-to-Text | ❌ | Not available |
+| Text-to-Speech | ❌ | Not available |
+
+**Official Documentation:** https://docs.cohere.com
+
+## Environment Variables
+
+```bash
+# Cohere API key (required), shared across all three capabilities
+COHERE_API_KEY="..."
+```
+
+**Variable Priority:**
+1. Direct parameter / config (`config={"api_key": "..."}`)
+2. Environment variable (`COHERE_API_KEY`)
+
+## Quick Start
+
+```python
+from esperanto.factory import AIFactory
+
+llm = AIFactory.create_language("cohere", "command-a-03-2025")
+embedder = AIFactory.create_embedding("cohere", "embed-v4.0")
+reranker = AIFactory.create_reranker("cohere", "rerank-v4.0-pro")
+```
+
+## Language Models
+
+```python
+llm = AIFactory.create_language("cohere", "command-a-03-2025")
+
+messages = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Explain RAG in one sentence."},
+]
+
+# Standard chat
+response = llm.chat_complete(messages)
+print(response.choices[0].message.content)
+
+# Streaming
+for chunk in llm.chat_complete(messages, stream=True):
+    print(chunk.choices[0].delta.content or "", end="")
+```
+
+### Tool Calling
+
+```python
+from esperanto.common_types import Tool, ToolFunction
+
+tools = [
+    Tool(
+        type="function",
+        function=ToolFunction(
+            name="get_weather",
+            description="Get weather for a city",
+            parameters={
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        ),
+    )
+]
+
+response = llm.chat_complete(
+    [{"role": "user", "content": "What's the weather in Tokyo?"}],
+    tools=tools,
+)
+for tc in response.choices[0].message.tool_calls or []:
+    print(tc.function.name, tc.function.arguments)
+```
+
+### Cohere-specific RAG (`documents` / `citations`)
+
+Cohere's built-in retrieval features ride along on the request via `config`. They have no analog on other Esperanto providers, so they are passed through without changing the universal `chat_complete` interface:
+
+```python
+llm = AIFactory.create_language(
+    "cohere",
+    "command-a-03-2025",
+    config={
+        "documents": [{"id": "doc1", "data": {"text": "Paris is the capital of France."}}],
+        "citation_options": {"mode": "ACCURATE"},
+    },
+)
+response = llm.chat_complete([{"role": "user", "content": "What is the capital of France?"}])
+```
+
+> **Note:** Citations returned by Cohere are **not** surfaced on the universal `ChatCompletion` response in this version (out of scope — see ARCHITECTURE.md). The `documents`/`citation_options`/`connectors` config fields only affect the request.
+
+> Cohere uses `p` for nucleus sampling — Esperanto's `top_p` parameter is mapped to `p` automatically.
+
+## Embeddings
+
+Cohere requires an `input_type`. Esperanto defaults to `search_document`; override via config or per call. Texts are automatically batched to respect Cohere's 96-texts-per-request limit.
+
+```python
+# For documents to be indexed
+embedder = AIFactory.create_embedding("cohere", "embed-v4.0")
+doc_vectors = embedder.embed(["First document.", "Second document."])
+
+# For a search query
+query_embedder = AIFactory.create_embedding(
+    "cohere", "embed-v4.0", config={"input_type": "search_query"}
+)
+query_vector = query_embedder.embed(["my search query"])
+
+# Per-call override
+vectors = embedder.embed(["classify me"], input_type="classification")
+```
+
+Valid `input_type` values: `search_document`, `search_query`, `classification`, `clustering`, `image`.
+
+## Reranking
+
+```python
+reranker = AIFactory.create_reranker("cohere", "rerank-v4.0-pro")
+
+result = reranker.rerank(
+    query="What is machine learning?",
+    documents=[
+        "Machine learning is a subset of AI.",
+        "The weather is nice today.",
+        "Neural networks are used in ML.",
+    ],
+    top_k=2,
+)
+for r in result.results:
+    print(r.index, r.relevance_score, r.document)
+```
+
+## Model Discovery
+
+```python
+from esperanto import AIFactory
+
+models = AIFactory.get_provider_models("cohere")  # uses COHERE_API_KEY
+for m in models:
+    print(m.id, m.type)
+```
+
+Discovery queries Cohere's live `/v1/models` endpoint and tags each model's type (`language`, `embedding`, `reranker`) from its supported endpoints. Results are cached for 1 hour.
+
+## Notes
+
+- No SDK dependency — integration is pure HTTP via `httpx`.
+- `to_langchain()` (LLM and embeddings) requires `langchain_cohere` (`pip install langchain_cohere`).
+- Non-float embedding types (`int8`, `binary`, etc.) are out of scope; embeddings default to `float`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esperanto"
-version = "2.22.0"
+version = "2.23.0"
 description = "A light-weight, production-ready, unified interface for various AI model providers"
 authors = [
     { name = "LUIS NOVO", email = "lfnovo@gmail.com" }
@@ -94,4 +94,5 @@ dev = [
     "langchain-groq>=1.1.1,<2.0.0",
     "langchain-mistralai>=1.1.1,<2.0.0",
     "langchain-deepseek>=1.0.1,<2.0.0",
+    "langchain-cohere>=0.4.0",
 ]

--- a/src/esperanto/__init__.py
+++ b/src/esperanto/__init__.py
@@ -126,6 +126,21 @@ try:
 except ImportError:
     DeepgramTextToSpeechModel = None  # type: ignore[assignment,misc]
 
+try:
+    from esperanto.providers.llm.cohere import CohereLanguageModel
+except ImportError:
+    CohereLanguageModel = None  # type: ignore[assignment,misc]
+
+try:
+    from esperanto.providers.embedding.cohere import CohereEmbeddingModel
+except ImportError:
+    CohereEmbeddingModel = None  # type: ignore[assignment,misc]
+
+try:
+    from esperanto.providers.reranker.cohere import CohereRerankerModel
+except ImportError:
+    CohereRerankerModel = None  # type: ignore[assignment,misc]
+
 # Store all provider classes
 __provider_classes = {
     'AnthropicLanguageModel': AnthropicLanguageModel,
@@ -149,6 +164,9 @@ __provider_classes = {
     "MistralTextToSpeechModel": MistralTextToSpeechModel,
     "MistralSpeechToTextModel": MistralSpeechToTextModel,
     "DeepgramTextToSpeechModel": DeepgramTextToSpeechModel,
+    "CohereLanguageModel": CohereLanguageModel,
+    "CohereEmbeddingModel": CohereEmbeddingModel,
+    "CohereRerankerModel": CohereRerankerModel,
 }
 
 # Get list of available provider classes (excluding None values)

--- a/src/esperanto/factory.py
+++ b/src/esperanto/factory.py
@@ -31,6 +31,7 @@ class AIFactory:
             "mistral": "esperanto.providers.llm.mistral:MistralLanguageModel",
             # deepseek: handled via OpenAICompatibleProfile (see profiles.py)
             "vertex": "esperanto.providers.llm.vertex:VertexLanguageModel",
+            "cohere": "esperanto.providers.llm.cohere:CohereLanguageModel",
         },
         "embedding": {
             "openai": "esperanto.providers.embedding.openai:OpenAIEmbeddingModel",
@@ -44,6 +45,7 @@ class AIFactory:
             "azure": "esperanto.providers.embedding.azure:AzureEmbeddingModel",
             "jina": "esperanto.providers.embedding.jina:JinaEmbeddingModel",
             "openrouter": "esperanto.providers.embedding.openrouter:OpenRouterEmbeddingModel",
+            "cohere": "esperanto.providers.embedding.cohere:CohereEmbeddingModel",
         },
         "speech_to_text": {
             "openai": "esperanto.providers.stt.openai:OpenAISpeechToTextModel",
@@ -69,6 +71,7 @@ class AIFactory:
             "jina": "esperanto.providers.reranker.jina:JinaRerankerModel",
             "voyage": "esperanto.providers.reranker.voyage:VoyageRerankerModel",
             "transformers": "esperanto.providers.reranker.transformers:TransformersRerankerModel",
+            "cohere": "esperanto.providers.reranker.cohere:CohereRerankerModel",
         },
     }
 

--- a/src/esperanto/model_discovery.py
+++ b/src/esperanto/model_discovery.py
@@ -6,7 +6,7 @@ models from providers without instantiating provider classes.
 
 import hashlib
 import os
-from typing import Callable, Dict, List, Literal, Optional
+from typing import Any, Callable, Dict, List, Literal, Optional
 
 import httpx
 
@@ -1044,41 +1044,53 @@ def get_cohere_models(
     }
 
     try:
-        response = httpx.get(
-            f"{base_url}/v1/models",
-            headers=headers,
-            params={"page_size": 1000},
-            timeout=60.0,
-        )
-
-        if response.status_code >= 400:
-            try:
-                error_data = response.json()
-                error_message = error_data.get("message", f"HTTP {response.status_code}")
-            except Exception:
-                error_message = f"HTTP {response.status_code}: {response.text}"
-            raise RuntimeError(f"Cohere API error: {error_message}")
-
-        models_data = response.json()
-
         all_models = []
-        for model in models_data.get("models", []):
-            model_id = model.get("name")
-            if not model_id:
-                continue
-            model_type = None
-            for endpoint in model.get("endpoints", []):
-                if endpoint in endpoint_to_type:
-                    model_type = endpoint_to_type[endpoint]
-                    break
-            all_models.append(
-                Model(
-                    id=model_id,
-                    owned_by="cohere",
-                    context_window=model.get("context_length"),
-                    type=model_type,
-                )
+        page_token = None
+
+        # Cohere paginates /v1/models via next_page_token; follow every page.
+        while True:
+            params: Dict[str, Any] = {"page_size": 1000}
+            if page_token:
+                params["page_token"] = page_token
+
+            response = httpx.get(
+                f"{base_url}/v1/models",
+                headers=headers,
+                params=params,
+                timeout=60.0,
             )
+
+            if response.status_code >= 400:
+                try:
+                    error_data = response.json()
+                    error_message = error_data.get("message", f"HTTP {response.status_code}")
+                except Exception:
+                    error_message = f"HTTP {response.status_code}: {response.text}"
+                raise RuntimeError(f"Cohere API error: {error_message}")
+
+            models_data = response.json()
+
+            for model in models_data.get("models", []):
+                model_id = model.get("name")
+                if not model_id:
+                    continue
+                model_type = None
+                for endpoint in model.get("endpoints", []):
+                    if endpoint in endpoint_to_type:
+                        model_type = endpoint_to_type[endpoint]
+                        break
+                all_models.append(
+                    Model(
+                        id=model_id,
+                        owned_by="cohere",
+                        context_window=model.get("context_length"),
+                        type=model_type,
+                    )
+                )
+
+            page_token = models_data.get("next_page_token")
+            if not page_token:
+                break
 
         _model_cache.set(cache_key, all_models)
         return all_models

--- a/src/esperanto/model_discovery.py
+++ b/src/esperanto/model_discovery.py
@@ -6,7 +6,7 @@ models from providers without instantiating provider classes.
 
 import hashlib
 import os
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Literal, Optional
 
 import httpx
 
@@ -993,6 +993,100 @@ def get_deepgram_models(
     return models
 
 
+def get_cohere_models(
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> List[Model]:
+    """Get available models from Cohere.
+
+    Covers all Cohere capabilities (chat, embed, rerank) via the /v1/models
+    endpoint. The ``endpoints`` array on each model is used to tag its Esperanto
+    type.
+
+    Args:
+        api_key: Cohere API key (or COHERE_API_KEY env var)
+        base_url: Base URL for API (default: https://api.cohere.com)
+
+    Returns:
+        List of available models
+
+    Raises:
+        ValueError: If API key is not provided
+        RuntimeError: If API request fails
+    """
+    api_key = api_key or os.getenv("COHERE_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "Cohere API key not found. Provide api_key or set COHERE_API_KEY environment variable."
+        )
+
+    base_url = (base_url or "https://api.cohere.com").rstrip("/")
+
+    cache_key = _create_cache_key("cohere", api_key=api_key, base_url=base_url)
+    cached_models = _model_cache.get(cache_key)
+    if cached_models is not None:
+        return cached_models
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    # Map a Cohere model's supported endpoints to an Esperanto model type.
+    endpoint_to_type: Dict[
+        str, Literal["language", "embedding", "text_to_speech", "speech_to_text", "reranker"]
+    ] = {
+        "chat": "language",
+        "embed": "embedding",
+        "rerank": "reranker",
+        "generate": "language",
+        "classify": "language",
+    }
+
+    try:
+        response = httpx.get(
+            f"{base_url}/v1/models",
+            headers=headers,
+            params={"page_size": 1000},
+            timeout=60.0,
+        )
+
+        if response.status_code >= 400:
+            try:
+                error_data = response.json()
+                error_message = error_data.get("message", f"HTTP {response.status_code}")
+            except Exception:
+                error_message = f"HTTP {response.status_code}: {response.text}"
+            raise RuntimeError(f"Cohere API error: {error_message}")
+
+        models_data = response.json()
+
+        all_models = []
+        for model in models_data.get("models", []):
+            model_id = model.get("name")
+            if not model_id:
+                continue
+            model_type = None
+            for endpoint in model.get("endpoints", []):
+                if endpoint in endpoint_to_type:
+                    model_type = endpoint_to_type[endpoint]
+                    break
+            all_models.append(
+                Model(
+                    id=model_id,
+                    owned_by="cohere",
+                    context_window=model.get("context_length"),
+                    type=model_type,
+                )
+            )
+
+        _model_cache.set(cache_key, all_models)
+        return all_models
+
+    except httpx.HTTPError as e:
+        raise RuntimeError(f"Failed to fetch Cohere models: {e}")
+
+
 # Provider registry mapping provider names to discovery functions
 PROVIDER_MODELS_REGISTRY: Dict[str, Callable[..., List[Model]]] = {
     "openai": get_openai_models,
@@ -1012,4 +1106,5 @@ PROVIDER_MODELS_REGISTRY: Dict[str, Callable[..., List[Model]]] = {
     "azure": get_azure_models,
     "transformers": get_transformers_models,
     "deepgram": get_deepgram_models,
+    "cohere": get_cohere_models,
 }

--- a/src/esperanto/providers/embedding/CLAUDE.md
+++ b/src/esperanto/providers/embedding/CLAUDE.md
@@ -12,6 +12,7 @@ Embedding provider implementations for text-to-vector conversion.
 - **`mistral.py`**: Mistral embedding models
 - **`jina.py`**: Jina AI embedding models
 - **`voyage.py`**: Voyage AI embedding models
+- **`cohere.py`**: Cohere embedding models (native v2 API, input_type-aware, 96-text auto-batching)
 - **`openrouter.py`**: OpenRouter embedding API
 - **`vertex.py`**: Google Vertex AI embeddings
 - **`transformers.py`**: Local HuggingFace transformers models (BERT, sentence-transformers, etc.)

--- a/src/esperanto/providers/embedding/cohere.py
+++ b/src/esperanto/providers/embedding/cohere.py
@@ -1,0 +1,190 @@
+"""Cohere embedding model provider (native v2 API)."""
+
+import os
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List
+
+import httpx
+
+from esperanto.providers.embedding.base import EmbeddingModel, Model
+from esperanto.utils import validate_and_decode_embedding
+
+if TYPE_CHECKING:
+    from langchain_cohere import CohereEmbeddings
+
+# Cohere's /v2/embed accepts a maximum of 96 texts per request.
+_VALID_INPUT_TYPES = (
+    "search_document",
+    "search_query",
+    "classification",
+    "clustering",
+    "image",
+)
+
+
+class CohereEmbeddingModel(EmbeddingModel):
+    """Cohere embedding model implementation using the native v2 embed API."""
+
+    MAX_BATCH_SIZE: ClassVar[int] = 96
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        # Get API key
+        self.api_key = self.api_key or os.getenv("COHERE_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "Cohere API key not found. Set the COHERE_API_KEY environment variable."
+            )
+
+        # Set base URL (endpoints carry their own version segment)
+        self.base_url = (self.base_url or "https://api.cohere.com").rstrip("/")
+
+        # input_type is required by Cohere; default to search_document.
+        self.input_type = self._config.get("input_type", "search_document")
+
+        if "model_name" in kwargs:
+            self._config["model_name"] = kwargs["model_name"]
+
+        # Initialize HTTP clients with configurable timeout
+        self._create_http_clients()
+
+    def _get_headers(self) -> Dict[str, str]:
+        """Get headers for Cohere API requests."""
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _handle_error(self, response: httpx.Response) -> None:
+        """Handle HTTP error responses."""
+        if response.status_code >= 400:
+            try:
+                error_data = response.json()
+                error_message = error_data.get("message") or error_data.get(
+                    "error", f"HTTP {response.status_code}"
+                )
+            except Exception:
+                error_message = f"HTTP {response.status_code}: {response.text}"
+            raise RuntimeError(f"Cohere API error: {error_message}")
+
+    def _build_payload(self, texts: List[str], **kwargs) -> Dict[str, Any]:
+        """Build the request payload for a single batch of texts."""
+        input_type = kwargs.pop("input_type", self.input_type)
+        payload: Dict[str, Any] = {
+            "model": self.get_model_name(),
+            "texts": texts,
+            "input_type": input_type,
+            "embedding_types": ["float"],
+        }
+        # embed-v4+ supports output_dimension; pass through when configured.
+        if self.output_dimensions:
+            payload["output_dimension"] = self.output_dimensions
+        payload.update(kwargs)
+        return payload
+
+    def embed(self, texts: List[str], **kwargs) -> List[List[float]]:
+        """Create embeddings for the given texts.
+
+        Texts are automatically batched in groups of ``MAX_BATCH_SIZE`` (96) to
+        respect Cohere's per-request limit.
+        """
+        texts = [self._clean_text(text) for text in texts]
+
+        results: List[List[float]] = []
+        for start in range(0, len(texts), self.MAX_BATCH_SIZE):
+            batch = texts[start : start + self.MAX_BATCH_SIZE]
+            payload = self._build_payload(batch, **kwargs)
+
+            response = self.client.post(
+                f"{self.base_url}/v2/embed",
+                headers=self._get_headers(),
+                json=payload,
+            )
+            self._handle_error(response)
+
+            results.extend(self._parse_response(response.json()))
+        return results
+
+    async def aembed(self, texts: List[str], **kwargs) -> List[List[float]]:
+        """Create embeddings for the given texts asynchronously."""
+        texts = [self._clean_text(text) for text in texts]
+
+        results: List[List[float]] = []
+        for start in range(0, len(texts), self.MAX_BATCH_SIZE):
+            batch = texts[start : start + self.MAX_BATCH_SIZE]
+            payload = self._build_payload(batch, **kwargs)
+
+            response = await self.async_client.post(
+                f"{self.base_url}/v2/embed",
+                headers=self._get_headers(),
+                json=payload,
+            )
+            self._handle_error(response)
+
+            results.extend(self._parse_response(response.json()))
+        return results
+
+    def _parse_response(self, response_data: Dict[str, Any]) -> List[List[float]]:
+        """Extract float embeddings from a Cohere embed response."""
+        float_embeddings = response_data.get("embeddings", {}).get("float", [])
+        return [
+            validate_and_decode_embedding(idx, raw)
+            for idx, raw in enumerate(float_embeddings)
+        ]
+
+    def _get_default_model(self) -> str:
+        """Get the default model name."""
+        return "embed-v4.0"
+
+    @property
+    def provider(self) -> str:
+        """Get the provider name."""
+        return "cohere"
+
+    def _get_models(self) -> List[Model]:
+        """List all available embedding models for this provider."""
+        try:
+            response = self.client.get(
+                f"{self.base_url}/v1/models",
+                headers=self._get_headers(),
+                params={"endpoint": "embed"},
+            )
+            self._handle_error(response)
+            models_data = response.json()
+            return [
+                Model(
+                    id=model["name"],
+                    owned_by="cohere",
+                    context_window=model.get("context_length"),
+                    type="embedding",
+                )
+                for model in models_data.get("models", [])
+            ]
+        except Exception:
+            return [
+                Model(
+                    id="embed-v4.0",
+                    owned_by="cohere",
+                    context_window=128000,
+                    type="embedding",
+                ),
+            ]
+
+    def to_langchain(self) -> "CohereEmbeddings":
+        """Convert to a LangChain embeddings model.
+
+        Raises:
+            ImportError: If langchain_cohere is not installed.
+        """
+        try:
+            from langchain_cohere import CohereEmbeddings
+        except ImportError as e:
+            raise ImportError(
+                "Langchain integration requires langchain_cohere. "
+                "Install with: uv add langchain_cohere or pip install langchain_cohere"
+            ) from e
+
+        return CohereEmbeddings(  # type: ignore[call-arg]
+            model=self.get_model_name(),
+            cohere_api_key=self.api_key,  # type: ignore[arg-type]
+        )

--- a/src/esperanto/providers/llm/CLAUDE.md
+++ b/src/esperanto/providers/llm/CLAUDE.md
@@ -17,6 +17,7 @@ Language model (LLM) provider implementations for chat completion APIs.
 - **`perplexity.py`**: Perplexity AI models
 - **`openrouter.py`**: OpenRouter unified API
 - **`vertex.py`**: Google Vertex AI
+- **`cohere.py`**: Cohere models (native v2 chat API, documents/citations passthrough)
 - **`openai_compatible.py`**: Generic OpenAI-compatible API provider (for custom endpoints)
 
 ## Patterns

--- a/src/esperanto/providers/llm/cohere.py
+++ b/src/esperanto/providers/llm/cohere.py
@@ -1,0 +1,643 @@
+"""Cohere language model implementation (native v2 API)."""
+
+import json
+import logging
+import os
+import time
+import uuid
+from dataclasses import dataclass
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncGenerator,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Union,
+)
+
+import httpx
+
+from esperanto.common_types import (
+    ChatCompletion,
+    ChatCompletionChunk,
+    Choice,
+    DeltaMessage,
+    FunctionCall,
+    Message,
+    Model,
+    StreamChoice,
+    Tool,
+    ToolCall,
+    Usage,
+)
+from esperanto.common_types.validation import (
+    validate_tool_calls as _validate_tool_calls,
+)
+from esperanto.providers.llm.base import LanguageModel
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from langchain_cohere import ChatCohere
+
+# Cohere-specific request fields that pass through from config without an analog
+# on other Esperanto providers (built-in RAG / citations / knowledge connectors).
+_COHERE_PASSTHROUGH_FIELDS = ("documents", "citation_options", "connectors")
+
+
+@dataclass
+class CohereLanguageModel(LanguageModel):
+    """Cohere language model implementation using the native v2 chat API."""
+
+    def __post_init__(self):
+        """Initialize HTTP clients."""
+        super().__post_init__()
+        self.api_key = self.api_key or os.getenv("COHERE_API_KEY")
+
+        if not self.api_key:
+            raise ValueError(
+                "Cohere API key not found. Set the COHERE_API_KEY environment variable."
+            )
+
+        # Set base URL (Cohere uses unversioned host; endpoints carry the version)
+        self.base_url = (self.base_url or "https://api.cohere.com").rstrip("/")
+
+        # Initialize HTTP clients with configurable timeout
+        self._create_http_clients()
+
+    def _get_headers(self) -> Dict[str, str]:
+        """Get headers for Cohere API requests."""
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _handle_error(self, response: httpx.Response) -> None:
+        """Handle HTTP error responses."""
+        if response.status_code >= 400:
+            try:
+                error_data = response.json()
+                error_message = error_data.get("message") or error_data.get(
+                    "error", f"HTTP {response.status_code}"
+                )
+            except Exception:
+                error_message = f"HTTP {response.status_code}: {response.text}"
+            raise RuntimeError(f"Cohere API error: {error_message}")
+
+    def _convert_tools_to_cohere(
+        self, tools: Optional[List[Tool]]
+    ) -> Optional[List[Dict[str, Any]]]:
+        """Convert Esperanto tools to Cohere v2 format.
+
+        Cohere v2 uses an OpenAI-style tool shape:
+        ``{"type": "function", "function": {name, description, parameters}}``.
+        """
+        if not tools:
+            return None
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": tool.function.name,
+                    "description": tool.function.description,
+                    "parameters": tool.function.parameters,
+                },
+            }
+            for tool in tools
+        ]
+
+    def _convert_tool_choice_to_cohere(
+        self, tool_choice: Optional[Union[str, Dict[str, Any]]]
+    ) -> Optional[str]:
+        """Convert tool_choice to Cohere format.
+
+        Cohere v2 only supports ``REQUIRED`` and ``NONE`` (uppercase). "auto" maps
+        to omitting the field (Cohere's default behavior). Specific-tool forcing is
+        not supported, so we fall back to ``REQUIRED``.
+        """
+        if tool_choice is None or tool_choice == "auto":
+            return None
+        if tool_choice == "required":
+            return "REQUIRED"
+        if tool_choice == "none":
+            return "NONE"
+        # Specific tool dict — Cohere can't force a named tool; require any tool.
+        if isinstance(tool_choice, dict):
+            return "REQUIRED"
+        return str(tool_choice).upper()
+
+    def _format_messages(
+        self, messages: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """Convert Esperanto/OpenAI messages to Cohere v2 messages.
+
+        Cohere v2 uses an OpenAI-compatible message shape, so most messages pass
+        through. Assistant tool calls and tool results need light normalization to
+        ensure arguments are JSON strings and roles map correctly.
+        """
+        formatted: List[Dict[str, Any]] = []
+
+        for msg in messages:
+            role = msg.get("role", "")
+
+            if role == "tool":
+                formatted.append({
+                    "role": "tool",
+                    "tool_call_id": msg.get("tool_call_id"),
+                    "content": msg.get("content", ""),
+                })
+
+            elif role == "assistant" and msg.get("tool_calls"):
+                tool_calls: List[Dict[str, Any]] = []
+                for tc in msg["tool_calls"]:
+                    if isinstance(tc, dict):
+                        tc_id = tc.get("id", "")
+                        func_info = tc.get("function", {})
+                        func_name = func_info.get("name", "")
+                        func_args = func_info.get("arguments", "{}")
+                    else:
+                        tc_id = tc.id
+                        func_name = tc.function.name
+                        func_args = tc.function.arguments
+
+                    # Cohere expects arguments as a JSON string (same as Esperanto).
+                    if not isinstance(func_args, str):
+                        func_args = json.dumps(func_args)
+
+                    tool_calls.append({
+                        "id": tc_id,
+                        "type": "function",
+                        "function": {"name": func_name, "arguments": func_args},
+                    })
+
+                assistant_msg: Dict[str, Any] = {
+                    "role": "assistant",
+                    "tool_calls": tool_calls,
+                }
+                # Cohere uses tool_plan to carry the assistant's pre-tool reasoning.
+                if msg.get("content"):
+                    assistant_msg["tool_plan"] = msg["content"]
+                formatted.append(assistant_msg)
+
+            else:
+                formatted.append({
+                    "role": "assistant" if role == "assistant" else role or "user",
+                    "content": msg.get("content", ""),
+                })
+
+        return formatted
+
+    def _create_request_payload(
+        self,
+        messages: List[Dict[str, Any]],
+        stream: bool = False,
+        tools: Optional[List[Tool]] = None,
+        tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Create request payload for the Cohere v2 chat API."""
+        effective_max_tokens = max_tokens if max_tokens is not None else self.max_tokens
+        effective_temperature = (
+            temperature if temperature is not None else self.temperature
+        )
+        effective_top_p = top_p if top_p is not None else self.top_p
+
+        payload: Dict[str, Any] = {
+            "model": self.get_model_name(),
+            "messages": self._format_messages(messages),
+        }
+
+        if effective_max_tokens is not None:
+            payload["max_tokens"] = int(effective_max_tokens)
+        if effective_temperature is not None:
+            payload["temperature"] = float(effective_temperature)
+        # Cohere uses "p" for nucleus sampling (not "top_p").
+        if effective_top_p is not None:
+            payload["p"] = float(effective_top_p)
+
+        if stream:
+            payload["stream"] = True
+
+        if tools:
+            payload["tools"] = self._convert_tools_to_cohere(tools)
+            cohere_tool_choice = self._convert_tool_choice_to_cohere(tool_choice)
+            if cohere_tool_choice:
+                payload["tool_choice"] = cohere_tool_choice
+
+        # JSON mode via structured output config.
+        if self.structured and self.structured.get("type") in ("json", "json_object"):
+            payload["response_format"] = {"type": "json_object"}
+
+        # Pass through Cohere-specific fields (documents/citations/connectors) from
+        # config without altering the universal chat_complete signature.
+        for field in _COHERE_PASSTHROUGH_FIELDS:
+            if field in self._config and self._config[field] is not None:
+                payload[field] = self._config[field]
+
+        return payload
+
+    def _normalize_response(self, response_data: Dict[str, Any]) -> ChatCompletion:
+        """Normalize a Cohere v2 chat response into a ChatCompletion."""
+        created = int(time.time())
+        message_data = response_data.get("message", {})
+        content_blocks = message_data.get("content", []) or []
+
+        text_parts: List[str] = []
+        for block in content_blocks:
+            if block.get("type") == "text":
+                text_parts.append(block.get("text", ""))
+
+        tool_calls: List[ToolCall] = []
+        for tc in message_data.get("tool_calls", []) or []:
+            func = tc.get("function", {})
+            arguments = func.get("arguments", "")
+            if not isinstance(arguments, str):
+                arguments = json.dumps(arguments)
+            tool_calls.append(
+                ToolCall(
+                    id=tc.get("id", str(uuid.uuid4())),
+                    type="function",
+                    function=FunctionCall(
+                        name=func.get("name", ""),
+                        arguments=arguments,
+                    ),
+                )
+            )
+
+        content_text = "".join(text_parts) if text_parts else None
+        finish_reason = self._map_finish_reason(response_data.get("finish_reason"))
+
+        usage_data = response_data.get("usage", {}).get("tokens", {}) or {}
+        prompt_tokens = int(usage_data.get("input_tokens", 0) or 0)
+        completion_tokens = int(usage_data.get("output_tokens", 0) or 0)
+
+        return ChatCompletion(
+            id=response_data.get("id", str(uuid.uuid4())),
+            choices=[
+                Choice(
+                    index=0,
+                    message=Message(
+                        content=content_text,
+                        role="assistant",
+                        tool_calls=tool_calls if tool_calls else None,
+                    ),
+                    finish_reason=finish_reason,
+                )
+            ],
+            created=created,
+            model=self.get_model_name(),
+            provider=self.provider,
+            usage=Usage(
+                completion_tokens=completion_tokens,
+                prompt_tokens=prompt_tokens,
+                total_tokens=prompt_tokens + completion_tokens,
+            ),
+        )
+
+    @staticmethod
+    def _map_finish_reason(cohere_reason: Optional[str]) -> str:
+        """Map a Cohere finish_reason to the Esperanto convention."""
+        mapping = {
+            "COMPLETE": "stop",
+            "STOP_SEQUENCE": "stop",
+            "MAX_TOKENS": "length",
+            "TOOL_CALL": "tool_calls",
+        }
+        if not cohere_reason:
+            return "stop"
+        return mapping.get(cohere_reason, cohere_reason.lower())
+
+    def _parse_sse_stream(
+        self, response: httpx.Response
+    ) -> Generator[Dict[str, Any], None, None]:
+        """Parse the Cohere SSE stream into event dicts."""
+        for chunk in response.iter_text():
+            for line in chunk.split("\n"):
+                line = line.strip()
+                if not line or not line.startswith("data: "):
+                    continue
+                data = line[6:]
+                if data.strip() == "[DONE]":
+                    return
+                try:
+                    yield json.loads(data)
+                except json.JSONDecodeError:
+                    continue
+
+    async def _parse_sse_stream_async(
+        self, response: httpx.Response
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        """Parse the Cohere SSE stream asynchronously into event dicts."""
+        async for chunk in response.aiter_text():
+            for line in chunk.split("\n"):
+                line = line.strip()
+                if not line or not line.startswith("data: "):
+                    continue
+                data = line[6:]
+                if data.strip() == "[DONE]":
+                    return
+                try:
+                    yield json.loads(data)
+                except json.JSONDecodeError:
+                    continue
+
+    def _normalize_stream_event(
+        self, event_data: Dict[str, Any]
+    ) -> Optional[ChatCompletionChunk]:
+        """Normalize a Cohere stream event into a ChatCompletionChunk.
+
+        Handles:
+        - content-delta: text token (delta.message.content.text)
+        - tool-call-start: start of a tool call (delta.message.tool_calls)
+        - tool-call-delta: tool argument chunks (delta.message.tool_calls.function.arguments)
+        - message-end: completion with finish_reason (delta.finish_reason)
+        """
+        event_type = event_data.get("type")
+        delta = event_data.get("delta", {}) or {}
+        message = delta.get("message", {}) or {}
+        index = event_data.get("index", 0)
+
+        if event_type == "content-delta":
+            text_content = message.get("content", {}).get("text", "")
+            return self._text_chunk(text_content)
+
+        if event_type == "tool-call-start":
+            tc = message.get("tool_calls", {}) or {}
+            func = tc.get("function", {}) or {}
+            return self._tool_chunk(
+                tc_id=tc.get("id", ""),
+                name=func.get("name", ""),
+                arguments=func.get("arguments", ""),
+                index=index,
+            )
+
+        if event_type == "tool-call-delta":
+            func = message.get("tool_calls", {}).get("function", {}) or {}
+            return self._tool_chunk(
+                tc_id="",
+                name="",
+                arguments=func.get("arguments", ""),
+                index=index,
+            )
+
+        if event_type == "message-end":
+            finish_reason = self._map_finish_reason(delta.get("finish_reason"))
+            return ChatCompletionChunk(
+                id=str(uuid.uuid4()),
+                choices=[
+                    StreamChoice(
+                        index=0,
+                        delta=DeltaMessage(content=None, role="assistant"),
+                        finish_reason=finish_reason,
+                    )
+                ],
+                created=int(time.time()),
+                model=self.get_model_name(),
+            )
+
+        # Ignore message-start, content-start, content-end, tool-call-end, etc.
+        return None
+
+    def _text_chunk(self, text_content: str) -> ChatCompletionChunk:
+        """Build a text-delta streaming chunk."""
+        return ChatCompletionChunk(
+            id=str(uuid.uuid4()),
+            choices=[
+                StreamChoice(
+                    index=0,
+                    delta=DeltaMessage(content=text_content, role="assistant"),
+                    finish_reason=None,
+                )
+            ],
+            created=int(time.time()),
+            model=self.get_model_name(),
+        )
+
+    def _tool_chunk(
+        self, tc_id: str, name: str, arguments: str, index: int
+    ) -> ChatCompletionChunk:
+        """Build a tool-call streaming chunk."""
+        return ChatCompletionChunk(
+            id=str(uuid.uuid4()),
+            choices=[
+                StreamChoice(
+                    index=0,
+                    delta=DeltaMessage(
+                        content=None,
+                        role="assistant",
+                        tool_calls=[
+                            ToolCall(
+                                id=tc_id,
+                                type="function",
+                                function=FunctionCall(
+                                    name=name, arguments=arguments
+                                ),
+                                index=index,
+                            )
+                        ],
+                    ),
+                    finish_reason=None,
+                )
+            ],
+            created=int(time.time()),
+            model=self.get_model_name(),
+        )
+
+    def get_model_name(self) -> str:
+        """Get the model name to use."""
+        return self.model_name or self._get_default_model()
+
+    def _get_default_model(self) -> str:
+        """Get the default model name."""
+        return "command-a-03-2025"
+
+    @property
+    def provider(self) -> str:
+        """Get the provider name."""
+        return "cohere"
+
+    def _get_models(self) -> List[Model]:
+        """List all available language models for this provider."""
+        try:
+            response = self.client.get(
+                f"{self.base_url}/v1/models",
+                headers=self._get_headers(),
+                params={"endpoint": "chat"},
+            )
+            self._handle_error(response)
+            models_data = response.json()
+            return [
+                Model(
+                    id=model["name"],
+                    owned_by="cohere",
+                    context_window=model.get("context_length"),
+                    type="language",
+                )
+                for model in models_data.get("models", [])
+            ]
+        except Exception:
+            return [
+                Model(
+                    id="command-a-03-2025",
+                    owned_by="cohere",
+                    context_window=256000,
+                    type="language",
+                ),
+            ]
+
+    def chat_complete(
+        self,
+        messages: List[Dict[str, Any]],
+        stream: Optional[bool] = None,
+        tools: Optional[List[Tool]] = None,
+        tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
+        parallel_tool_calls: Optional[bool] = None,
+        validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+    ) -> Union[ChatCompletion, Generator[ChatCompletionChunk, None, None]]:
+        """Send a chat completion request to the Cohere v2 chat API.
+
+        Cohere-specific RAG features (``documents``, ``citation_options``,
+        ``connectors``) are supplied via ``config`` and ride along on the request.
+        Citations returned by Cohere are not surfaced on the universal
+        ``ChatCompletion`` response (out of scope for v1).
+        """
+        self._warn_if_validate_with_streaming(validate_tool_calls, stream)
+
+        should_stream = stream if stream is not None else self.streaming
+
+        effective_max_tokens = self._resolve_max_tokens(max_tokens)
+        effective_temperature = self._resolve_temperature(temperature)
+        effective_top_p = self._resolve_top_p(top_p)
+
+        resolved_tools = self._resolve_tools(tools)
+        resolved_tool_choice = self._resolve_tool_choice(tool_choice)
+
+        payload = self._create_request_payload(
+            messages,
+            should_stream,
+            tools=resolved_tools,
+            tool_choice=resolved_tool_choice,
+            max_tokens=effective_max_tokens,
+            temperature=effective_temperature,
+            top_p=effective_top_p,
+        )
+
+        response = self.client.post(
+            f"{self.base_url}/v2/chat",
+            headers=self._get_headers(),
+            json=payload,
+        )
+        self._handle_error(response)
+
+        if should_stream:
+            def generate():
+                for event_data in self._parse_sse_stream(response):
+                    chunk = self._normalize_stream_event(event_data)
+                    if chunk:
+                        yield chunk
+            return generate()
+
+        response_data = response.json()
+        result = self._normalize_response(response_data)
+
+        if validate_tool_calls and resolved_tools:
+            for choice in result.choices:
+                if choice.message.tool_calls:
+                    _validate_tool_calls(choice.message.tool_calls, resolved_tools)
+
+        return result
+
+    async def achat_complete(
+        self,
+        messages: List[Dict[str, Any]],
+        stream: Optional[bool] = None,
+        tools: Optional[List[Tool]] = None,
+        tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
+        parallel_tool_calls: Optional[bool] = None,
+        validate_tool_calls: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+    ) -> Union[ChatCompletion, AsyncGenerator[ChatCompletionChunk, None]]:
+        """Send an async chat completion request to the Cohere v2 chat API."""
+        self._warn_if_validate_with_streaming(validate_tool_calls, stream)
+
+        should_stream = stream if stream is not None else self.streaming
+
+        effective_max_tokens = self._resolve_max_tokens(max_tokens)
+        effective_temperature = self._resolve_temperature(temperature)
+        effective_top_p = self._resolve_top_p(top_p)
+
+        resolved_tools = self._resolve_tools(tools)
+        resolved_tool_choice = self._resolve_tool_choice(tool_choice)
+
+        payload = self._create_request_payload(
+            messages,
+            should_stream,
+            tools=resolved_tools,
+            tool_choice=resolved_tool_choice,
+            max_tokens=effective_max_tokens,
+            temperature=effective_temperature,
+            top_p=effective_top_p,
+        )
+
+        response = await self.async_client.post(
+            f"{self.base_url}/v2/chat",
+            headers=self._get_headers(),
+            json=payload,
+        )
+        self._handle_error(response)
+
+        if should_stream:
+            async def generate():
+                async for event_data in self._parse_sse_stream_async(response):
+                    chunk = self._normalize_stream_event(event_data)
+                    if chunk:
+                        yield chunk
+            return generate()
+
+        response_data = response.json()
+        result = self._normalize_response(response_data)
+
+        if validate_tool_calls and resolved_tools:
+            for choice in result.choices:
+                if choice.message.tool_calls:
+                    _validate_tool_calls(choice.message.tool_calls, resolved_tools)
+
+        return result
+
+    def to_langchain(self) -> "ChatCohere":
+        """Convert to a LangChain chat model.
+
+        Raises:
+            ImportError: If langchain_cohere is not installed.
+        """
+        try:
+            from langchain_cohere import ChatCohere
+        except ImportError as e:
+            raise ImportError(
+                "Langchain integration requires langchain_cohere. "
+                "Install with: uv add langchain_cohere or pip install langchain_cohere"
+            ) from e
+
+        model_name = self.get_model_name()
+        if not model_name:
+            raise ValueError("Model name is required for Langchain integration.")
+
+        kwargs: Dict[str, Any] = {
+            "model": model_name,
+            "cohere_api_key": self.api_key,
+        }
+        if self.max_tokens is not None:
+            kwargs["max_tokens"] = self.max_tokens
+        if self.temperature is not None:
+            kwargs["temperature"] = self.temperature
+
+        return ChatCohere(**kwargs)  # type: ignore[arg-type]

--- a/src/esperanto/providers/reranker/CLAUDE.md
+++ b/src/esperanto/providers/reranker/CLAUDE.md
@@ -7,6 +7,7 @@ Reranker provider implementations for relevance-based document ranking.
 - **`base.py`**: Abstract base class `RerankerModel` defining the interface
 - **`jina.py`**: Jina AI reranker models
 - **`voyage.py`**: Voyage AI reranker models
+- **`cohere.py`**: Cohere reranker models (native v2 API)
 - **`transformers.py`**: Local HuggingFace transformers reranker models
 
 ## Patterns

--- a/src/esperanto/providers/reranker/cohere.py
+++ b/src/esperanto/providers/reranker/cohere.py
@@ -1,0 +1,257 @@
+"""Cohere reranker provider implementation (native v2 API)."""
+
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from esperanto.common_types import Model
+from esperanto.common_types.reranker import RerankResponse, RerankResult
+from esperanto.common_types.response import Usage
+
+from .base import RerankerModel
+
+
+@dataclass
+class CohereRerankerModel(RerankerModel):
+    """Cohere reranker provider using the native v2 rerank API."""
+
+    def __post_init__(self):
+        """Initialize Cohere reranker after dataclass initialization."""
+        super().__post_init__()
+
+        # Authentication
+        self.api_key = self.api_key or os.getenv("COHERE_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "Cohere API key not found. Set the COHERE_API_KEY environment variable."
+            )
+
+        # API configuration (endpoints carry their own version segment)
+        self.base_url = (self.base_url or "https://api.cohere.com").rstrip("/")
+
+        # Initialize HTTP clients with configurable timeout
+        self._create_http_clients()
+
+    def _get_headers(self) -> Dict[str, str]:
+        """Get request headers for Cohere API."""
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _build_request_payload(
+        self, query: str, documents: List[str], top_k: int, **kwargs
+    ) -> Dict[str, Any]:
+        """Build request payload for the Cohere rerank API.
+
+        Cohere uses ``top_n`` (not ``top_k``) to cap the number of results.
+        """
+        payload = {
+            "model": self.get_model_name(),
+            "query": query,
+            "documents": documents,
+            "top_n": top_k,
+        }
+        payload.update(kwargs)
+        return payload
+
+    def _handle_error(self, response: httpx.Response) -> None:
+        """Handle error responses from Cohere API."""
+        try:
+            error_data = response.json()
+            error_message = error_data.get("message") or error_data.get(
+                "error", "Unknown error"
+            )
+            raise RuntimeError(f"Cohere API error: {error_message}")
+        except (KeyError, ValueError):
+            raise RuntimeError(
+                f"Cohere API error: {response.status_code} - {response.text}"
+            )
+
+    def _parse_response(
+        self, response_data: Dict[str, Any], documents: List[str]
+    ) -> RerankResponse:
+        """Parse Cohere API response into the standardized format.
+
+        Cohere returns results already sorted by relevance (descending) with
+        ``index`` and ``relevance_score``. Documents are attached from the
+        original list by index (Cohere v2 does not echo them back).
+        """
+        results = []
+        raw_results = response_data.get("results", [])
+
+        raw_scores = [result.get("relevance_score", 0.0) for result in raw_results]
+        normalized_scores = self._normalize_scores(raw_scores)
+
+        for i, result in enumerate(raw_results):
+            index = result.get("index", i)
+            document = documents[index] if index < len(documents) else ""
+
+            results.append(
+                RerankResult(
+                    index=index,
+                    document=document,
+                    relevance_score=(
+                        normalized_scores[i] if i < len(normalized_scores) else 0.0
+                    ),
+                )
+            )
+
+        usage = None
+        billed = response_data.get("meta", {}).get("billed_units")
+        if billed:
+            usage = Usage(
+                prompt_tokens=billed.get("input_tokens", 0),
+                completion_tokens=billed.get("output_tokens", 0),
+                total_tokens=billed.get("input_tokens", 0)
+                + billed.get("output_tokens", 0),
+            )
+
+        return RerankResponse(
+            results=results,
+            model=self.get_model_name(),
+            usage=usage,
+        )
+
+    def rerank(
+        self,
+        query: str,
+        documents: List[str],
+        top_k: Optional[int] = None,
+        **kwargs,
+    ) -> RerankResponse:
+        """Rerank documents using the Cohere API."""
+        query, documents, top_k = self._validate_inputs(query, documents, top_k)
+        payload = self._build_request_payload(query, documents, top_k, **kwargs)
+
+        try:
+            response = self.client.post(
+                f"{self.base_url}/v2/rerank",
+                json=payload,
+                headers=self._get_headers(),
+            )
+
+            if response.status_code != 200:
+                self._handle_error(response)
+
+            return self._parse_response(response.json(), documents)
+
+        except httpx.TimeoutException:
+            raise RuntimeError("Request to Cohere API timed out")
+        except httpx.RequestError as e:
+            raise RuntimeError(f"Network error calling Cohere API: {str(e)}")
+
+    async def arerank(
+        self,
+        query: str,
+        documents: List[str],
+        top_k: Optional[int] = None,
+        **kwargs,
+    ) -> RerankResponse:
+        """Async rerank documents using the Cohere API."""
+        query, documents, top_k = self._validate_inputs(query, documents, top_k)
+        payload = self._build_request_payload(query, documents, top_k, **kwargs)
+
+        try:
+            response = await self.async_client.post(
+                f"{self.base_url}/v2/rerank",
+                json=payload,
+                headers=self._get_headers(),
+            )
+
+            if response.status_code != 200:
+                self._handle_error(response)
+
+            return self._parse_response(response.json(), documents)
+
+        except httpx.TimeoutException:
+            raise RuntimeError("Request to Cohere API timed out")
+        except httpx.RequestError as e:
+            raise RuntimeError(f"Network error calling Cohere API: {str(e)}")
+
+    def to_langchain(self):
+        """Convert to a LangChain-compatible reranker."""
+        try:
+            from langchain_core.callbacks.manager import Callbacks
+            from langchain_core.documents import Document
+        except ImportError:
+            raise ImportError(
+                "LangChain not installed. Install with: pip install langchain"
+            )
+
+        class LangChainCohereReranker:
+            def __init__(self, cohere_reranker):
+                self.cohere_reranker = cohere_reranker
+
+            def compress_documents(
+                self,
+                documents: List[Document],
+                query: str,
+                callbacks: Optional[Callbacks] = None,
+            ) -> List[Document]:
+                """Compress documents using the Cohere reranker."""
+                texts = [doc.page_content for doc in documents]
+                rerank_response = self.cohere_reranker.rerank(query, texts)
+
+                reranked_docs = []
+                for result in rerank_response.results:
+                    if result.index < len(documents):
+                        original_doc = documents[result.index]
+                        new_metadata = original_doc.metadata.copy()
+                        new_metadata["relevance_score"] = result.relevance_score
+                        reranked_docs.append(
+                            Document(
+                                page_content=original_doc.page_content,
+                                metadata=new_metadata,
+                            )
+                        )
+                return reranked_docs
+
+        return LangChainCohereReranker(self)
+
+    def _get_default_model(self) -> str:
+        """Get the default Cohere reranker model."""
+        return "rerank-v4.0-pro"
+
+    @property
+    def provider(self) -> str:
+        """Provider name."""
+        return "cohere"
+
+    def _get_models(self) -> List[Model]:
+        """Available Cohere reranker models."""
+        try:
+            response = self.client.get(
+                f"{self.base_url}/v1/models",
+                headers=self._get_headers(),
+                params={"endpoint": "rerank"},
+            )
+            if response.status_code != 200:
+                self._handle_error(response)
+            models_data = response.json()
+            return [
+                Model(
+                    id=model["name"],
+                    owned_by="cohere",
+                    context_window=model.get("context_length"),
+                    type="reranker",
+                )
+                for model in models_data.get("models", [])
+            ]
+        except Exception:
+            return [
+                Model(
+                    id="rerank-v4.0-pro",
+                    owned_by="cohere",
+                    context_window=4096,
+                    type="reranker",
+                ),
+                Model(
+                    id="rerank-v3.5",
+                    owned_by="cohere",
+                    context_window=4096,
+                    type="reranker",
+                ),
+            ]

--- a/tests/providers/embedding/test_cohere.py
+++ b/tests/providers/embedding/test_cohere.py
@@ -1,0 +1,122 @@
+"""Test cases for Cohere embedding provider."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from esperanto.providers.embedding.cohere import CohereEmbeddingModel
+
+
+def _embed_response(vectors):
+    return {
+        "embeddings": {"float": vectors},
+        "meta": {"billed_units": {"input_tokens": 10}},
+    }
+
+
+def _make_model(config=None, batches=None):
+    """Create a model whose POST returns one batch response per call.
+
+    ``batches`` is a list of vector-lists; each successive POST returns the next
+    one. Defaults to a single 2-vector response.
+    """
+    if batches is None:
+        batches = [[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]]
+    model = CohereEmbeddingModel(model_name="embed-v4.0", api_key="test-key", config=config or {})
+
+    sync_calls = {"i": 0}
+    async_calls = {"i": 0}
+
+    def post(url, **kwargs):
+        resp = Mock()
+        resp.status_code = 200
+        resp.json.return_value = _embed_response(batches[sync_calls["i"]])
+        sync_calls["i"] += 1
+        return resp
+
+    async def apost(url, **kwargs):
+        resp = Mock()
+        resp.status_code = 200
+        resp.json.return_value = _embed_response(batches[async_calls["i"]])
+        async_calls["i"] += 1
+        return resp
+
+    mock_client = Mock()
+    mock_async_client = AsyncMock()
+    mock_client.post.side_effect = post
+    mock_async_client.post.side_effect = apost
+    model.client = mock_client
+    model.async_client = mock_async_client
+    return model
+
+
+class TestCohereEmbedding:
+    def test_initialization_with_api_key(self):
+        model = CohereEmbeddingModel(model_name="embed-v4.0", api_key="test-key", config={})
+        assert model.api_key == "test-key"
+        assert model.provider == "cohere"
+        assert model.base_url == "https://api.cohere.com"
+        assert model.input_type == "search_document"
+
+    def test_missing_api_key(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValueError, match="Cohere API key not found"):
+                CohereEmbeddingModel(model_name="embed-v4.0", api_key=None, config={})
+
+    def test_initialization_with_env_var(self):
+        with patch.dict("os.environ", {"COHERE_API_KEY": "env-key"}):
+            model = CohereEmbeddingModel(model_name="embed-v4.0", api_key=None, config={})
+            assert model.api_key == "env-key"
+
+    def test_default_model(self):
+        model = CohereEmbeddingModel(api_key="test-key", config={})
+        assert model.get_model_name() == "embed-v4.0"
+
+    def test_input_type_from_config(self):
+        model = CohereEmbeddingModel(
+            model_name="embed-v4.0", api_key="test-key", config={"input_type": "search_query"}
+        )
+        assert model.input_type == "search_query"
+
+    def test_payload_shape(self):
+        model = CohereEmbeddingModel(model_name="embed-v4.0", api_key="test-key", config={})
+        payload = model._build_payload(["hello"])
+        assert payload["model"] == "embed-v4.0"
+        assert payload["texts"] == ["hello"]
+        assert payload["input_type"] == "search_document"
+        assert payload["embedding_types"] == ["float"]
+
+    def test_embed(self):
+        model = _make_model()
+        result = model.embed(["Hello", "World"])
+        assert result == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+        url = model.client.post.call_args[0][0]
+        assert url == "https://api.cohere.com/v2/embed"
+        payload = model.client.post.call_args[1]["json"]
+        assert payload["input_type"] == "search_document"
+
+    def test_embed_per_call_input_type(self):
+        model = _make_model()
+        model.embed(["Hello"], input_type="search_query")
+        payload = model.client.post.call_args[1]["json"]
+        assert payload["input_type"] == "search_query"
+
+    def test_batching_over_96(self):
+        # 200 texts -> 96 + 96 + 8 == 3 batches/POSTs.
+        batches = [
+            [[float(i)] for i in range(96)],
+            [[float(i)] for i in range(96)],
+            [[float(i)] for i in range(8)],
+        ]
+        model = _make_model(batches=batches)
+        texts = [f"t{i}" for i in range(200)]
+        result = model.embed(texts)
+        assert model.client.post.call_count == 3
+        assert len(result) == 200
+
+    @pytest.mark.asyncio
+    async def test_aembed(self):
+        model = _make_model()
+        result = await model.aembed(["Hello", "World"])
+        assert result == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+        model.async_client.post.assert_awaited_once()

--- a/tests/providers/embedding/test_cohere.py
+++ b/tests/providers/embedding/test_cohere.py
@@ -22,7 +22,11 @@ def _make_model(config=None, batches=None):
     """
     if batches is None:
         batches = [[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]]
-    model = CohereEmbeddingModel(model_name="embed-v4.0", api_key="test-key", config=config or {})
+    # Avoid creating real httpx clients we immediately discard for mocks.
+    with patch.object(CohereEmbeddingModel, "_create_http_clients", lambda self: None):
+        model = CohereEmbeddingModel(
+            model_name="embed-v4.0", api_key="test-key", config=config or {}
+        )
 
     sync_calls = {"i": 0}
     async_calls = {"i": 0}

--- a/tests/providers/llm/test_cohere.py
+++ b/tests/providers/llm/test_cohere.py
@@ -1,0 +1,229 @@
+"""Test cases for the Cohere language model provider."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from esperanto.common_types import (
+    ChatCompletion,
+    ChatCompletionChunk,
+    Tool,
+    ToolFunction,
+)
+from esperanto.providers.llm.cohere import CohereLanguageModel
+
+NON_STREAM_RESPONSE = {
+    "id": "chat-123",
+    "message": {
+        "role": "assistant",
+        "content": [{"type": "text", "text": "Hello there!"}],
+    },
+    "finish_reason": "COMPLETE",
+    "usage": {"tokens": {"input_tokens": 12, "output_tokens": 5}},
+}
+
+TOOL_RESPONSE = {
+    "id": "chat-456",
+    "message": {
+        "role": "assistant",
+        "tool_plan": "I will check the weather.",
+        "tool_calls": [
+            {
+                "id": "tc-1",
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": '{"city": "Tokyo"}'},
+            }
+        ],
+    },
+    "finish_reason": "TOOL_CALL",
+    "usage": {"tokens": {"input_tokens": 20, "output_tokens": 8}},
+}
+
+STREAM_LINES = [
+    'data: {"type":"message-start","id":"chat-789"}\n',
+    'data: {"type":"content-start","index":0,"delta":{"message":{"content":{"type":"text","text":""}}}}\n',
+    'data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"Hello"}}}}\n',
+    'data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":" world"}}}}\n',
+    'data: {"type":"content-end","index":0}\n',
+    'data: {"type":"message-end","delta":{"finish_reason":"COMPLETE"}}\n',
+]
+
+
+def _make_model(response_data=NON_STREAM_RESPONSE, config=None):
+    model = CohereLanguageModel(model_name="command-a-03-2025", api_key="test-key", config=config or {})
+
+    def post(url, **kwargs):
+        resp = Mock()
+        resp.status_code = 200
+        resp.json.return_value = response_data
+        resp.iter_text = Mock(return_value=iter(STREAM_LINES))
+
+        async def aiter_text():
+            for line in STREAM_LINES:
+                yield line
+
+        resp.aiter_text = Mock(return_value=aiter_text())
+        return resp
+
+    async def apost(url, **kwargs):
+        return post(url, **kwargs)
+
+    mock_client = Mock()
+    mock_async_client = AsyncMock()
+    mock_client.post.side_effect = post
+    mock_async_client.post.side_effect = apost
+    model.client = mock_client
+    model.async_client = mock_async_client
+    return model
+
+
+def _weather_tool():
+    return Tool(
+        type="function",
+        function=ToolFunction(
+            name="get_weather",
+            description="Get weather for a city",
+            parameters={
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        ),
+    )
+
+
+class TestCohereLanguageModel:
+    def test_initialization(self):
+        model = CohereLanguageModel(model_name="command-a-03-2025", api_key="test-key", config={})
+        assert model.api_key == "test-key"
+        assert model.provider == "cohere"
+        assert model.base_url == "https://api.cohere.com"
+
+    def test_missing_api_key(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValueError, match="Cohere API key not found"):
+                CohereLanguageModel(model_name="command-a-03-2025", api_key=None, config={})
+
+    def test_env_var(self):
+        with patch.dict("os.environ", {"COHERE_API_KEY": "env-key"}):
+            model = CohereLanguageModel(model_name="command-a-03-2025", api_key=None, config={})
+            assert model.api_key == "env-key"
+
+    def test_default_model(self):
+        model = CohereLanguageModel(api_key="test-key", config={})
+        assert model.get_model_name() == "command-a-03-2025"
+
+    def test_headers(self):
+        model = CohereLanguageModel(model_name="command-a-03-2025", api_key="secret", config={})
+        headers = model._get_headers()
+        assert headers["Authorization"] == "Bearer secret"
+
+    def test_chat_complete(self):
+        model = _make_model()
+        response = model.chat_complete([{"role": "user", "content": "Hi"}])
+
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content == "Hello there!"
+        assert response.choices[0].finish_reason == "stop"
+        assert response.usage.prompt_tokens == 12
+        assert response.usage.completion_tokens == 5
+
+        url = model.client.post.call_args[0][0]
+        assert url == "https://api.cohere.com/v2/chat"
+
+    def test_payload_uses_p_not_top_p(self):
+        model = _make_model()
+        model.chat_complete(
+            [{"role": "user", "content": "Hi"}], temperature=0.5, top_p=0.8, max_tokens=100
+        )
+        payload = model.client.post.call_args[1]["json"]
+        assert payload["model"] == "command-a-03-2025"
+        assert payload["temperature"] == 0.5
+        assert payload["p"] == 0.8
+        assert "top_p" not in payload
+        assert payload["max_tokens"] == 100
+
+    def test_documents_passthrough(self):
+        docs = [{"id": "doc1", "data": {"text": "Paris is in France"}}]
+        model = _make_model(config={"documents": docs})
+        model.chat_complete([{"role": "user", "content": "Where is Paris?"}])
+        payload = model.client.post.call_args[1]["json"]
+        assert payload["documents"] == docs
+
+    def test_tool_conversion(self):
+        model = _make_model()
+        cohere_tools = model._convert_tools_to_cohere([_weather_tool()])
+        assert cohere_tools[0]["type"] == "function"
+        assert cohere_tools[0]["function"]["name"] == "get_weather"
+        assert "parameters" in cohere_tools[0]["function"]
+
+    def test_tool_choice_conversion(self):
+        model = _make_model()
+        assert model._convert_tool_choice_to_cohere("auto") is None
+        assert model._convert_tool_choice_to_cohere("required") == "REQUIRED"
+        assert model._convert_tool_choice_to_cohere("none") == "NONE"
+
+    def test_tool_calling_response(self):
+        model = _make_model(response_data=TOOL_RESPONSE)
+        response = model.chat_complete(
+            [{"role": "user", "content": "Weather in Tokyo?"}], tools=[_weather_tool()]
+        )
+        tool_calls = response.choices[0].message.tool_calls
+        assert tool_calls is not None
+        assert tool_calls[0].function.name == "get_weather"
+        assert tool_calls[0].function.arguments == '{"city": "Tokyo"}'
+        assert response.choices[0].finish_reason == "tool_calls"
+
+    def test_finish_reason_mapping(self):
+        model = _make_model()
+        assert model._map_finish_reason("COMPLETE") == "stop"
+        assert model._map_finish_reason("MAX_TOKENS") == "length"
+        assert model._map_finish_reason("TOOL_CALL") == "tool_calls"
+        assert model._map_finish_reason("STOP_SEQUENCE") == "stop"
+        assert model._map_finish_reason(None) == "stop"
+
+    def test_streaming(self):
+        model = _make_model()
+        chunks = list(model.chat_complete([{"role": "user", "content": "Hi"}], stream=True))
+        assert all(isinstance(c, ChatCompletionChunk) for c in chunks)
+        text = "".join(
+            c.choices[0].delta.content or "" for c in chunks
+        )
+        assert text == "Hello world"
+        assert chunks[-1].choices[0].finish_reason == "stop"
+
+    def test_tool_message_formatting(self):
+        model = _make_model()
+        messages = [
+            {"role": "user", "content": "Weather?"},
+            {
+                "role": "assistant",
+                "content": "checking",
+                "tool_calls": [
+                    {"id": "tc-1", "type": "function", "function": {"name": "get_weather", "arguments": '{"city":"Tokyo"}'}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc-1", "content": "Sunny"},
+        ]
+        formatted = model._format_messages(messages)
+        assert formatted[1]["role"] == "assistant"
+        assert formatted[1]["tool_plan"] == "checking"
+        assert formatted[1]["tool_calls"][0]["function"]["arguments"] == '{"city":"Tokyo"}'
+        assert formatted[2]["role"] == "tool"
+        assert formatted[2]["tool_call_id"] == "tc-1"
+
+    @pytest.mark.asyncio
+    async def test_achat_complete(self):
+        model = _make_model()
+        response = await model.achat_complete([{"role": "user", "content": "Hi"}])
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content == "Hello there!"
+        model.async_client.post.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_async_streaming(self):
+        model = _make_model()
+        gen = await model.achat_complete([{"role": "user", "content": "Hi"}], stream=True)
+        chunks = [c async for c in gen]
+        text = "".join(c.choices[0].delta.content or "" for c in chunks)
+        assert text == "Hello world"

--- a/tests/providers/llm/test_cohere.py
+++ b/tests/providers/llm/test_cohere.py
@@ -50,7 +50,11 @@ STREAM_LINES = [
 
 
 def _make_model(response_data=NON_STREAM_RESPONSE, config=None):
-    model = CohereLanguageModel(model_name="command-a-03-2025", api_key="test-key", config=config or {})
+    # Avoid creating real httpx clients we immediately discard for mocks.
+    with patch.object(CohereLanguageModel, "_create_http_clients", lambda self: None):
+        model = CohereLanguageModel(
+            model_name="command-a-03-2025", api_key="test-key", config=config or {}
+        )
 
     def post(url, **kwargs):
         resp = Mock()

--- a/tests/providers/reranker/test_cohere.py
+++ b/tests/providers/reranker/test_cohere.py
@@ -20,9 +20,11 @@ def _mock_rerank_response():
 
 
 def _make_model(config=None):
-    model = CohereRerankerModel(
-        model_name="rerank-v4.0-pro", api_key="test-key", config=config or {}
-    )
+    # Avoid creating real httpx clients we immediately discard for mocks.
+    with patch.object(CohereRerankerModel, "_create_http_clients", lambda self: None):
+        model = CohereRerankerModel(
+            model_name="rerank-v4.0-pro", api_key="test-key", config=config or {}
+        )
     mock_client = Mock()
     mock_async_client = AsyncMock()
 
@@ -120,4 +122,8 @@ class TestCohereReranker:
         result = await reranker.arerank("query", ["best match", "worst match", "middle match"])
         assert isinstance(result, RerankResponse)
         assert len(result.results) == 3
+        # Async parsing must map documents from the original list by index.
+        assert result.results[0].document == "best match"
+        assert result.results[1].document == "middle match"
+        assert result.results[2].document == "worst match"
         reranker.async_client.post.assert_awaited_once()

--- a/tests/providers/reranker/test_cohere.py
+++ b/tests/providers/reranker/test_cohere.py
@@ -1,0 +1,123 @@
+"""Test cases for Cohere reranker provider."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from esperanto.common_types.reranker import RerankResponse
+from esperanto.providers.reranker.cohere import CohereRerankerModel
+
+
+def _mock_rerank_response():
+    return {
+        "results": [
+            {"index": 0, "relevance_score": 0.95},
+            {"index": 2, "relevance_score": 0.42},
+            {"index": 1, "relevance_score": 0.10},
+        ],
+        "meta": {"billed_units": {"search_units": 1}},
+    }
+
+
+def _make_model(config=None):
+    model = CohereRerankerModel(
+        model_name="rerank-v4.0-pro", api_key="test-key", config=config or {}
+    )
+    mock_client = Mock()
+    mock_async_client = AsyncMock()
+
+    def post(url, **kwargs):
+        resp = Mock()
+        resp.status_code = 200
+        resp.json.return_value = _mock_rerank_response()
+        return resp
+
+    async def apost(url, **kwargs):
+        resp = Mock()
+        resp.status_code = 200
+        resp.json.return_value = _mock_rerank_response()
+        return resp
+
+    mock_client.post.side_effect = post
+    mock_async_client.post.side_effect = apost
+    model.client = mock_client
+    model.async_client = mock_async_client
+    return model
+
+
+class TestCohereReranker:
+    def test_initialization_with_api_key(self):
+        reranker = CohereRerankerModel(
+            model_name="rerank-v4.0-pro", api_key="test-api-key", config={}
+        )
+        assert reranker.api_key == "test-api-key"
+        assert reranker.provider == "cohere"
+        assert reranker.base_url == "https://api.cohere.com"
+
+    def test_missing_api_key(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValueError, match="Cohere API key not found"):
+                CohereRerankerModel(model_name="rerank-v4.0-pro", api_key=None, config={})
+
+    def test_initialization_with_env_var(self):
+        with patch.dict("os.environ", {"COHERE_API_KEY": "env-api-key"}):
+            reranker = CohereRerankerModel(model_name="rerank-v4.0-pro", api_key=None, config={})
+            assert reranker.api_key == "env-api-key"
+
+    def test_default_model(self):
+        reranker = CohereRerankerModel(model_name=None, api_key="test-key", config={})
+        assert reranker.get_model_name() == "rerank-v4.0-pro"
+
+    def test_headers(self):
+        reranker = CohereRerankerModel(model_name="rerank-v4.0-pro", api_key="secret", config={})
+        headers = reranker._get_headers()
+        assert headers["Authorization"] == "Bearer secret"
+        assert headers["Content-Type"] == "application/json"
+
+    def test_payload_uses_top_n(self):
+        reranker = CohereRerankerModel(model_name="rerank-v4.0-pro", api_key="test-key", config={})
+        payload = reranker._build_request_payload("q", ["a", "b"], 1)
+        assert payload["query"] == "q"
+        assert payload["documents"] == ["a", "b"]
+        assert payload["model"] == "rerank-v4.0-pro"
+        assert payload["top_n"] == 1
+        assert "top_k" not in payload
+
+    def test_validation_errors(self):
+        reranker = CohereRerankerModel(model_name="rerank-v4.0-pro", api_key="test-key", config={})
+        with pytest.raises(ValueError, match="Query cannot be empty"):
+            reranker.rerank("", ["doc1"])
+        with pytest.raises(ValueError, match="Documents list cannot be empty"):
+            reranker.rerank("query", [])
+        with pytest.raises(ValueError, match="top_k must be positive"):
+            reranker.rerank("query", ["doc1"], top_k=0)
+
+    def test_rerank(self):
+        reranker = _make_model()
+        documents = ["best match", "worst match", "middle match"]
+        result = reranker.rerank("query", documents)
+
+        assert isinstance(result, RerankResponse)
+        assert len(result.results) == 3
+        # Documents are attached from the original list by index.
+        assert result.results[0].document == "best match"
+        assert result.results[1].document == "middle match"
+        assert result.results[2].document == "worst match"
+        # Verify the request hit the v2 rerank endpoint.
+        url = reranker.client.post.call_args[0][0]
+        assert url == "https://api.cohere.com/v2/rerank"
+
+    def test_response_parsing(self):
+        reranker = CohereRerankerModel(model_name="rerank-v4.0-pro", api_key="test-key", config={})
+        result = reranker._parse_response(_mock_rerank_response(), ["d0", "d1", "d2"])
+        assert isinstance(result, RerankResponse)
+        assert result.results[0].index == 0
+        assert result.results[1].index == 2
+
+    @pytest.mark.asyncio
+    async def test_arerank(self):
+        reranker = _make_model()
+        result = await reranker.arerank("query", ["best match", "worst match", "middle match"])
+        assert isinstance(result, RerankResponse)
+        assert len(result.results) == 3
+        reranker.async_client.post.assert_awaited_once()

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -293,7 +293,7 @@ class TestCohereDiscovery:
 
     @patch("esperanto.model_discovery.httpx.get")
     def test_get_cohere_models_with_env_var(self, mock_get):
-        """Test that Cohere API key can come from environment."""
+        """Test that the Cohere API key from the environment reaches the request."""
         _model_cache.clear()
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -302,6 +302,33 @@ class TestCohereDiscovery:
 
         with patch.dict(os.environ, {"COHERE_API_KEY": "env-key"}):
             get_cohere_models()
+
+        headers = mock_get.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer env-key"
+
+    @patch("esperanto.model_discovery.httpx.get")
+    def test_get_cohere_models_paginates(self, mock_get):
+        """Test that all pages are followed via next_page_token."""
+        _model_cache.clear()
+        page1 = MagicMock()
+        page1.status_code = 200
+        page1.json.return_value = {
+            "models": [{"name": "command-a-03-2025", "endpoints": ["chat"]}],
+            "next_page_token": "tok2",
+        }
+        page2 = MagicMock()
+        page2.status_code = 200
+        page2.json.return_value = {
+            "models": [{"name": "embed-v4.0", "endpoints": ["embed"]}],
+        }
+        mock_get.side_effect = [page1, page2]
+
+        models = get_cohere_models(api_key="test-key")
+
+        assert mock_get.call_count == 2
+        assert {m.id for m in models} == {"command-a-03-2025", "embed-v4.0"}
+        # Second call carries the page token from the first response.
+        assert mock_get.call_args_list[1].kwargs["params"]["page_token"] == "tok2"
 
     @patch("esperanto.model_discovery.httpx.get")
     def test_get_google_models_with_env_var(self, mock_get):

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -15,6 +15,7 @@ from esperanto.model_discovery import (
     _create_cache_key,
     _model_cache,
     get_anthropic_models,
+    get_cohere_models,
     get_google_models,
     get_openai_compatible_models,
     get_openai_models,
@@ -255,6 +256,52 @@ class TestGoogleDiscovery:
         with patch.dict(os.environ, {}, clear=True):
             with pytest.raises(ValueError, match="Google API key not found"):
                 get_google_models()
+
+
+class TestCohereDiscovery:
+    """Test Cohere model discovery."""
+
+    @patch("esperanto.model_discovery.httpx.get")
+    def test_get_cohere_models_success(self, mock_get):
+        """Test successful Cohere model discovery with endpoint-based typing."""
+        _model_cache.clear()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "models": [
+                {"name": "command-a-03-2025", "endpoints": ["chat"], "context_length": 256000},
+                {"name": "embed-v4.0", "endpoints": ["embed"]},
+                {"name": "rerank-v4.0-pro", "endpoints": ["rerank"]},
+            ]
+        }
+        mock_get.return_value = mock_response
+
+        models = get_cohere_models(api_key="test-key")
+
+        assert len(models) == 3
+        assert all(isinstance(m, Model) for m in models)
+        by_id = {m.id: m for m in models}
+        assert by_id["command-a-03-2025"].type == "language"
+        assert by_id["embed-v4.0"].type == "embedding"
+        assert by_id["rerank-v4.0-pro"].type == "reranker"
+
+    def test_get_cohere_models_no_api_key(self):
+        """Test that ValueError is raised when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="Cohere API key not found"):
+                get_cohere_models()
+
+    @patch("esperanto.model_discovery.httpx.get")
+    def test_get_cohere_models_with_env_var(self, mock_get):
+        """Test that Cohere API key can come from environment."""
+        _model_cache.clear()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"models": []}
+        mock_get.return_value = mock_response
+
+        with patch.dict(os.environ, {"COHERE_API_KEY": "env-key"}):
+            get_cohere_models()
 
     @patch("esperanto.model_discovery.httpx.get")
     def test_get_google_models_with_env_var(self, mock_get):

--- a/uv.lock
+++ b/uv.lock
@@ -516,7 +516,7 @@ wheels = [
 
 [[package]]
 name = "esperanto"
-version = "2.22.0"
+version = "2.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -273,6 +273,25 @@ wheels = [
 ]
 
 [[package]]
+name = "cohere"
+version = "5.21.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastavro" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "requests" },
+    { name = "tokenizers" },
+    { name = "types-requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/75/4c346f6e2322e545f8452692304bd4eca15a2a0209ab9af6a0d1a7810b67/cohere-5.21.1.tar.gz", hash = "sha256:e5ade4423b928b01ff2038980e1b62b2a5bb412c8ab83e30882753b810a5509f", size = 191272, upload-time = "2026-03-26T15:09:27.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/50/5538f02ec6d10fbb84f29c1b18c68ff2a03d7877926a80275efdf8755a9f/cohere-5.21.1-py3-none-any.whl", hash = "sha256:f15592ec60d8cf12f01563db94ec28c388c61269d9617f23c2d6d910e505344e", size = 334262, upload-time = "2026-03-26T15:09:26.284Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -528,6 +547,7 @@ dev = [
     { name = "ipywidgets" },
     { name = "langchain" },
     { name = "langchain-anthropic" },
+    { name = "langchain-cohere" },
     { name = "langchain-core" },
     { name = "langchain-deepseek" },
     { name = "langchain-google-genai" },
@@ -571,6 +591,7 @@ dev = [
     { name = "ipywidgets", specifier = ">=8.1.5" },
     { name = "langchain", specifier = ">=1.2.4,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.3.1,<2.0.0" },
+    { name = "langchain-cohere", specifier = ">=0.4.0" },
     { name = "langchain-core", specifier = ">=1.2.7,<2.0.0" },
     { name = "langchain-deepseek", specifier = ">=1.0.1,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.0,<5.0.0" },
@@ -610,6 +631,46 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "fastavro"
+version = "1.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/5b/ccb338db71f347e3bc031d268bf6dc41e5ead63b6997b8e72af92f05e18e/fastavro-1.12.2.tar.gz", hash = "sha256:3c79502d56cf6b76210032e1c53494ddfbc73c140bccf2ef4092b3f0825323ab", size = 1030127, upload-time = "2026-04-24T14:36:01.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/91/16c3508447e7cf9f413a6a01792a990ed94d17505fc80a7fb76027078aed/fastavro-1.12.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c7c6d26c731a0e1e8e7d4ae8f13ae524eb6ec0e90d99c8147a19fdbae14eb807", size = 976824, upload-time = "2026-04-24T14:36:04.233Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/3a/97534561a1b4615366345ac066ad1f54698a59aa510eece3153c3a603d29/fastavro-1.12.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7caeecf519eff50f007ca4bee16b6e0a8252e5fe682c94432192a20867239888", size = 3185186, upload-time = "2026-04-24T14:36:06.395Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e4/26512b52f58305b9d2194169de2e82c16d5131f0a0b6359e50d34faf4021/fastavro-1.12.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:731aefe6c4bf2bafa0798ef83927676d06e44d1d18202cfb56d63b40422ab900", size = 3196799, upload-time = "2026-04-24T14:36:09.028Z" },
+    { url = "https://files.pythonhosted.org/packages/58/69/22f3b29a4555eb805a26f209f12532df8aafa48685d1cd1879aa42758d04/fastavro-1.12.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f089f24225a28ddafa5cfad7c41cfa84db1a55f2d473370769a95c0e3bac60c9", size = 3112396, upload-time = "2026-04-24T14:36:11.401Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/2a/fc61ef522050e1079ccf1aee07192881f3b11129f5e2b76811fd4fc3bb2f/fastavro-1.12.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:653c4f90dd21d8a1e74309919e08934e420d9aef51d051d14bf5a1c0e8293c22", size = 3180452, upload-time = "2026-04-24T14:36:13.634Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/6a/43ce9d713e9f1122e19c80d94d0dc0a356b8562d33eea90081dac781dd97/fastavro-1.12.2-cp310-cp310-win_amd64.whl", hash = "sha256:030f17eb4c7978538a31b55dea451ceace851a88dc9816b1923f8fb8a260db4c", size = 445396, upload-time = "2026-04-24T14:36:15.243Z" },
+    { url = "https://files.pythonhosted.org/packages/89/77/058f3c93348624cb695399b27f3f0c1c3d1190586065797e4a48f75d4147/fastavro-1.12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d48cd7094598a7e9d4297e8bf4bbe0dc9dc2ba4367d83dbb603e3b3c6aa35566", size = 974559, upload-time = "2026-04-24T14:36:17.172Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ef/08bbfa643addd2b98a9ce536613e2098928aa5e3ca098fd5b74f3c03b96a/fastavro-1.12.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:070c6134604bd7b6fd44409406ac50445339682b2e872885db2e859f92d22e93", size = 3352777, upload-time = "2026-04-24T14:36:19.679Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ec/55c11108529bdb59e635899f737651f729485ea5af36e128fb6560969c3d/fastavro-1.12.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2b73d50978d5e57416fa68461f9f3c8f39ea39e761cb1e12f919745adefe26a7", size = 3387036, upload-time = "2026-04-24T14:36:21.794Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b3/4459f7c61804e9b42b49f02fba8fbbb041af76c7cab43cee4018532ecd00/fastavro-1.12.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c57a9920400166398695d92580eca21fd7a79f3c67d691ac7e20a7d1b5300735", size = 3284780, upload-time = "2026-04-24T14:36:24.193Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e3/d7f510b9b8c7b73409a6232a9a8d282faa8560f85d024d7212e4c5dff3df/fastavro-1.12.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:81f6108f3ac292fb6cd05758c9e531389d8fc5e94e8c949b9298f4fb0a239662", size = 3368557, upload-time = "2026-04-24T14:36:26.667Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/10/14fa0abf8e7da07258393ae2b783dd4bb60d1fb93ad790296d27561f33ce/fastavro-1.12.2-cp311-cp311-win_amd64.whl", hash = "sha256:eec44256856fd59d29d1f1d0950ace18a58e4228e7d49de5d5e1b1875b227dde", size = 446499, upload-time = "2026-04-24T14:36:28.547Z" },
+    { url = "https://files.pythonhosted.org/packages/86/d2/c36f646296794c05d29a07bec84a6c56bfd285203e389a8954987ec1c515/fastavro-1.12.2-cp311-cp311-win_arm64.whl", hash = "sha256:ecd1b23ea7f9af09c865ac8503d07afd7e6bf782d76bb83cbbdba15b7a0db807", size = 388198, upload-time = "2026-04-24T14:36:29.791Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/bc/fe5731d6724d978694fbd3196bc1c0d7cab3fd0766e9551c40c39f798b52/fastavro-1.12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0e331896e8efffc72fa03e63b87ebfc37960113127da8e0f5152d91664ffed68", size = 964331, upload-time = "2026-04-24T14:36:31.297Z" },
+    { url = "https://files.pythonhosted.org/packages/98/36/50abf1145e4f1c4f418cd4b5f2ac806643d0b14e360b60e953826edf1b34/fastavro-1.12.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7f01ebaada59d74fdf6d28e5031a961a413b3752e9edb0c03866fa18480cf4c8", size = 3340170, upload-time = "2026-04-24T14:36:33.364Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8c/76ef4641e6c1c1aa3e6bb3c9efb5533ffda5dd975c8b5ae54e794322d9e3/fastavro-1.12.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25ef6855935f67582740ffa6bb978e40ec51be876117a3555c36fa2488dcdf25", size = 3425061, upload-time = "2026-04-24T14:36:35.497Z" },
+    { url = "https://files.pythonhosted.org/packages/31/10/379ff23425b2b470d5209cbc6736a6e5cbc34392ff17bb7355b8fd4aa0ca/fastavro-1.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:84a4f76a0aece0aa72b5ed8162ba2ff8c78908b8361b5a5d92ddd161977ccb74", size = 3243618, upload-time = "2026-04-24T14:36:37.969Z" },
+    { url = "https://files.pythonhosted.org/packages/88/29/4c8f9e7cd78f932f0d82823899e67a6d7f7e8f2524992db03956f9d9f5ef/fastavro-1.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:81e8da77d201916f6771fc357fda8267c2a256d7aa11923d43bc5f2fc155878b", size = 3378427, upload-time = "2026-04-24T14:36:40.278Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a1/eafeb302aaaea6055d4a9c11272b4aeaf713e43fe8eaf782f43a1fee2b44/fastavro-1.12.2-cp312-cp312-win_amd64.whl", hash = "sha256:1924349c74666c89417bd5cc2749f598e2f15f1d56ee81428b2317ab02c88aae", size = 441077, upload-time = "2026-04-24T14:36:41.791Z" },
+    { url = "https://files.pythonhosted.org/packages/56/9d/67e831041ba8efc16265c65bd71ba92e1095bba19b91be99e102f19d9be6/fastavro-1.12.2-cp312-cp312-win_arm64.whl", hash = "sha256:4c346cf449baf3b113e997c34151ad205e7135bc429469b005b180ade7e65e28", size = 378205, upload-time = "2026-04-24T14:36:43.679Z" },
+    { url = "https://files.pythonhosted.org/packages/83/39/f489a441d41cc9c0a8449fb1325d7a9c9eb57a5634e6ab19dfb0a1105324/fastavro-1.12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:57bb6b908cb2e05baab63b04c3a31be3b4545a10bfab9748b8763016b5256704", size = 958566, upload-time = "2026-04-24T14:36:45.49Z" },
+    { url = "https://files.pythonhosted.org/packages/31/69/776cc025aee2d02acacb734cf690d2fbc295eaadde1b5d47caf8c77a6a2b/fastavro-1.12.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a007f95cc682f56e6d83f1d17c29c00bf719d6fe8e003282b535af3a1ba09c0", size = 3276390, upload-time = "2026-04-24T14:36:47.875Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bc/b7e15fa788f42cbe65827af2ec06c9ad91bb9f72c213110dbef61b53a5b0/fastavro-1.12.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e90460b0cd21f62be3cb26087e706e2cebb7b3fcef9e05b4473b61bb0415b5e", size = 3372779, upload-time = "2026-04-24T14:36:50.122Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c2/98993ca810231fc1397212f48c3d46626983722a24bbaaa5c27ee0963751/fastavro-1.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7ccd15966b8218d41b06ec3e7c2556be89a8a693026c771e6564d2e40bbaf8ea", size = 3187591, upload-time = "2026-04-24T14:36:52.451Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/bb/c180f340eba6478f1b20deccdd17e2b4a4d5074dafd812e3c4254fd035f7/fastavro-1.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:06b6971d3dae10cb34353b857d16ad21ebd6f0ea394e86c96abdcad109005d6e", size = 3320589, upload-time = "2026-04-24T14:36:54.647Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/e9/aca0456216b5b8992e7b0a8542711b66799c05bfe24c8e32ef6f56e7eb93/fastavro-1.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:98dfcdfaf1498ae2f0e2fafe900a82e8320cc81d8ae5a95b8b8879eaa3298c39", size = 440883, upload-time = "2026-04-24T14:36:56.585Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7e/984896e716af504927be71b80a1e9661aa96c6f9e1e777d52823aacb99f2/fastavro-1.12.2-cp313-cp313-win_arm64.whl", hash = "sha256:3888ef7a51adc77cdf07251bc762566a1be36211e1cff689f13980f3776a2f36", size = 377536, upload-time = "2026-04-24T14:36:58.274Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/42/09a1e1f8d9998d73848a6ff0aad6713ae6abf0dbf99918776f8ef33344a7/fastavro-1.12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:283dcd3129b632021894425974bedd0eb6db3bbf5994e448ccad10db4d803d31", size = 1049506, upload-time = "2026-04-24T14:36:59.797Z" },
+    { url = "https://files.pythonhosted.org/packages/52/ef/80cc16f43919d532f25a707f34b275cccc09dca87a05b000fbbfc8e8f255/fastavro-1.12.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d125e210d5a0a1f701f12c0ecad9a03f1b04b5eddbce6ca36a1fc217da977ef", size = 3495899, upload-time = "2026-04-24T14:37:02.306Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/54/a0817d1d0236e9e0233f5c996f450cc795b056b8e06edb531f24b9df82ed/fastavro-1.12.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2d4d66afad78e8f47feaa307728a6b71fe3effc63ba2b9eeb109ee687c9bd397", size = 3399232, upload-time = "2026-04-24T14:37:04.837Z" },
+    { url = "https://files.pythonhosted.org/packages/38/0a/650f256c15f5875b6081544b9ba7ed8254329213e7e49e3db0aec68b5bee/fastavro-1.12.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2328ec07925c04c89719e3971c9068a165c7fd474ea87675b1204de0440e71ff", size = 3320222, upload-time = "2026-04-24T14:37:07.281Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/54/8351d388f94fbb0870e8cffaae41d3cc607acc8d6a8a6a217e2794829593/fastavro-1.12.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:55dea7e74b834d4b70467fc19c5b9ccb5509fe39abc4d26891187c1b22176423", size = 3337096, upload-time = "2026-04-24T14:37:09.452Z" },
 ]
 
 [[package]]
@@ -1213,11 +1274,27 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-cohere"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cohere" },
+    { name = "langchain-core" },
+    { name = "pydantic" },
+    { name = "types-pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/11/de374cbd215d49185c5f70228528887da5253f681291adaad9b86ef52522/langchain_cohere-0.6.0.tar.gz", hash = "sha256:5e45b56d0a5cc6f3de9f61bcd4fd449b9f3ece85e6b569c3d7c304992808bb0c", size = 39408, upload-time = "2026-06-01T15:55:41.954Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/5e/90f88e0316411fedf2dfdb7c5d53b106ac0186b2e432b93980acdf2ee250/langchain_cohere-0.6.0-py3-none-any.whl", hash = "sha256:524bc2f390b96a0b1bb98ec6e97f209fe7cd1654e6608e6e89db2e78b6c75838", size = 45108, upload-time = "2026-06-01T15:55:41.037Z" },
+]
+
+[[package]]
 name = "langchain-core"
-version = "1.2.7"
+version = "1.4.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
+    { name = "langchain-protocol" },
     { name = "langsmith" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -1226,9 +1303,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/0e/664d8d81b3493e09cbab72448d2f9d693d1fa5aa2bcc488602203a9b6da0/langchain_core-1.2.7.tar.gz", hash = "sha256:e1460639f96c352b4a41c375f25aeb8d16ffc1769499fb1c20503aad59305ced", size = 837039, upload-time = "2026-01-09T17:44:25.505Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/2b/fffaff399d20a56d40b9562fa19701e91abd72d8c9d9bc8c2673077b56b6/langchain_core-1.4.7.tar.gz", hash = "sha256:7a825d77de0a3f39adbd9d09612a75e85527e14a52c1601089bcc062972d9f2b", size = 952522, upload-time = "2026-06-12T19:23:57.588Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/6f/34a9fba14d191a67f7e2ee3dbce3e9b86d2fa7310e2c7f2c713583481bd2/langchain_core-1.2.7-py3-none-any.whl", hash = "sha256:452f4fef7a3d883357b22600788d37e3d8854ef29da345b7ac7099f33c31828b", size = 490232, upload-time = "2026-01-09T17:44:24.236Z" },
+    { url = "https://files.pythonhosted.org/packages/de/3e/dcdffa60078ae7b3a00ebb4cbbf1a204a14c3609983c604886523a7d4418/langchain_core-1.4.7-py3-none-any.whl", hash = "sha256:bcadd51951140ecdcba98311dbd931ba5de02a5ba8a2288dad5069c1eea2a13d", size = 554941, upload-time = "2026-06-12T19:23:55.826Z" },
 ]
 
 [[package]]
@@ -1313,6 +1390,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/b7/30bfc4d1b658a9ee524bcce3b0b2ec9c45a11c853a13c4f0c9da9882784b/langchain_openai-1.1.7.tar.gz", hash = "sha256:f5ec31961ed24777548b63a5fe313548bc6e0eb9730d6552b8c6418765254c81", size = 1039134, upload-time = "2026-01-07T19:44:59.728Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/a1/50e7596aca775d8c3883eceeaf47489fac26c57c1abe243c00174f715a8a/langchain_openai-1.1.7-py3-none-any.whl", hash = "sha256:34e9cd686aac1a120d6472804422792bf8080a2103b5d21ee450c9e42d053815", size = 84753, upload-time = "2026-01-07T19:44:58.629Z" },
+]
+
+[[package]]
+name = "langchain-protocol"
+version = "0.0.17"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/b3/4e2429876c7a35585618caa2b9f9089f7162a6b50562b614ad82ac11c17e/langchain_protocol-0.0.17.tar.gz", hash = "sha256:e7cbe58c205df4b4fd87dc6d5bb23f10e13b236d0e2e1b0b9d05bc2b648f3eea", size = 6026, upload-time = "2026-06-12T18:39:51.923Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/0a/a1bfe72c6ec856e99773bbd96c8086421e554b3693d0142b9ea009c6ac92/langchain_protocol-0.0.17-py3-none-any.whl", hash = "sha256:982a08fe152586ed10d4ff3d538c2e0b5766e5f307cdea325e10be3f2c17cae6", size = 7096, upload-time = "2026-06-12T18:39:50.973Z" },
 ]
 
 [[package]]
@@ -3445,6 +3534,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9f/4c/2ef5483ef81e7b6e1b901eb2994fd280cb19860134a20ff99e72748f3ccb/types_jsonschema-4.26.0.20260408.tar.gz", hash = "sha256:82b75a976ed1507c473b8dee2d4841bd65926758c6d672bb93d08bf5e16f1b3f", size = 16553, upload-time = "2026-04-08T04:36:00.543Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/3c/724ad6ecaea06e8c6c8a8c9949a0979e6a2149b8aec4fe160135c64dd5ac/types_jsonschema-4.26.0.20260408-py3-none-any.whl", hash = "sha256:1ab0058c2612b0b81fc4e3c88ec3f9ad9b0af3fd31a176030d78b6d6cefb6e7b", size = 16081, upload-time = "2026-04-08T04:35:59.678Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds Cohere as a **first-class provider** across **LLM**, **Embedding**, and **Reranker**, closing the LLM/Embed/Rerank scope of #110. STT remains parked at #163.

Integrated via Cohere's **native v2 API** (`/v2/chat`, `/v2/embed`, `/v2/rerank`) rather than an OpenAI-compatible profile — per the refined P4 principle, native is justified because Cohere's differentiators (`documents`-based RAG, citations, `input_type` embeddings, native tool format) are not exposed on the compatibility endpoint. Pure HTTP via `httpx`, auth shared via `COHERE_API_KEY`.

## What's included

- **LLM** (`create_language("cohere", "command-a-03-2025")`): chat, streaming (SSE), tool calling. Esperanto's `top_p` maps to Cohere's `p`. Cohere-specific RAG fields (`documents`, `citation_options`, `connectors`) pass through via `config` without changing the universal `chat_complete` surface.
- **Embedding** (`create_embedding("cohere", "embed-v4.0")`): `input_type`-aware (default `search_document`, per-call override), auto-batched to Cohere's 96-texts/request limit.
- **Reranker** (`create_reranker("cohere", "rerank-v4.0-pro")`): maps `top_k` → Cohere `top_n`, normalized `RerankResponse`.
- **Model discovery**: `get_cohere_models()` lists chat/embed/rerank models live via `/v1/models`, tagged by Esperanto type.
- Factory + `__init__` registration, `docs/providers/cohere.md`, README/matrix updates.

## Design decisions

- **Citations out of scope for v1**: the request accepts `documents`/`citation_options`/`connectors`, but returned citations are **not** surfaced as a first-class `ChatCompletion` field (avoids inflating the universal interface; consistent with #110 "Out of Scope").
- **Model discovery is live** via `/v1/models` (not a static list).

## Testing

- 36 new mocked-API unit tests across the 3 capabilities + 3 discovery tests — all green.
- Full validation suite: **1255 passed, 1 skipped, 1 xfailed**.
- `ruff check .` and `mypy src/esperanto` clean.

## Release

- Bumps version to **2.23.0** and cuts the CHANGELOG in this PR (per maintainer request).

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

