### PR TITLE
fix(typing): make __all__ static so mypy --strict downstream sees explicit re-exports

### DIFF
--- a/src/esperanto/__init__.py
+++ b/src/esperanto/__init__.py
@@ -141,37 +141,6 @@ try:
 except ImportError:
     CohereRerankerModel = None  # type: ignore[assignment,misc]
 
-# Store all provider classes
-__provider_classes = {
-    'AnthropicLanguageModel': AnthropicLanguageModel,
-    'GoogleLanguageModel': GoogleLanguageModel,
-    'OpenAILanguageModel': OpenAILanguageModel,
-    'OpenAICompatibleLanguageModel': OpenAICompatibleLanguageModel,
-    'OpenRouterLanguageModel': OpenRouterLanguageModel,
-    'XAILanguageModel': XAILanguageModel,
-    'OpenAIEmbeddingModel': OpenAIEmbeddingModel,
-    'GoogleEmbeddingModel': GoogleEmbeddingModel,
-    "AzureEmbeddingModel": AzureEmbeddingModel,
-    "OllamaEmbeddingModel": OllamaEmbeddingModel,
-    "OllamaLanguageModel": OllamaLanguageModel,
-    "AzureLanguageModel": AzureLanguageModel,
-    "MistralLanguageModel": MistralLanguageModel,
-    "DeepSeekLanguageModel": DeepSeekLanguageModel,
-    "GroqLanguageModel": GroqLanguageModel,
-    "VertexLanguageModel": VertexLanguageModel,
-    "VertexEmbeddingModel": VertexEmbeddingModel,
-    "VertexTextToSpeechModel": VertexTextToSpeechModel,
-    "MistralTextToSpeechModel": MistralTextToSpeechModel,
-    "MistralSpeechToTextModel": MistralSpeechToTextModel,
-    "DeepgramTextToSpeechModel": DeepgramTextToSpeechModel,
-    "CohereLanguageModel": CohereLanguageModel,
-    "CohereEmbeddingModel": CohereEmbeddingModel,
-    "CohereRerankerModel": CohereRerankerModel,
-}
-
-# Get list of available provider classes (excluding None values)
-provider_classes = [name for name, cls in __provider_classes.items() if cls is not None]
-
 # Import factory after defining providers
 from esperanto.factory import AIFactory  # noqa: E402
 
@@ -194,7 +163,29 @@ __all__ = [
     "find_tool_by_name",
     # Profiles
     "OpenAICompatibleProfile",
-] + provider_classes
-
-# Make provider classes available at module level
-globals().update({k: v for k, v in __provider_classes.items() if v is not None})
+    # Provider classes
+    "AnthropicLanguageModel",
+    "GoogleLanguageModel",
+    "OllamaLanguageModel",
+    "OpenAILanguageModel",
+    "OpenAICompatibleLanguageModel",
+    "OpenRouterLanguageModel",
+    "XAILanguageModel",
+    "OpenAIEmbeddingModel",
+    "GoogleEmbeddingModel",
+    "OllamaEmbeddingModel",
+    "AzureEmbeddingModel",
+    "AzureLanguageModel",
+    "MistralLanguageModel",
+    "DeepSeekLanguageModel",
+    "GroqLanguageModel",
+    "VertexLanguageModel",
+    "VertexEmbeddingModel",
+    "VertexTextToSpeechModel",
+    "MistralTextToSpeechModel",
+    "MistralSpeechToTextModel",
+    "DeepgramTextToSpeechModel",
+    "CohereLanguageModel",
+    "CohereEmbeddingModel",
+    "CohereRerankerModel",
+]

--- a/tests/unit/probe_reexport.py
+++ b/tests/unit/probe_reexport.py
@@ -1,0 +1,19 @@
+# ruff: noqa: F401, I001
+from esperanto import (
+    AIFactory,
+    LanguageModel,
+    EmbeddingModel,
+    SpeechToTextModel,
+    TextToSpeechModel,
+    Tool,
+    ToolFunction,
+    ToolCall,
+    FunctionCall,
+    ToolCallValidationError,
+    validate_tool_call,
+    validate_tool_calls,
+    find_tool_by_name,
+    OpenAICompatibleProfile,
+    AnthropicLanguageModel,
+    OpenAILanguageModel,
+)

--- a/tests/unit/test_mypy_reexport.py
+++ b/tests/unit/test_mypy_reexport.py
@@ -1,0 +1,31 @@
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def probe_path() -> Path:
+    return Path(__file__).parent / "probe_reexport.py"
+
+
+def test_no_reexport_errors(probe_path: Path) -> None:
+    if shutil.which("mypy") is None:
+        pytest.skip("mypy not on PATH")
+
+    result = subprocess.run(
+        [sys.executable, "-m", "mypy", "--strict", str(probe_path)],
+        capture_output=True,
+        text=True,
+    )
+
+    reexport_errors = [
+        line
+        for line in result.stdout.splitlines()
+        if "does not explicitly export attribute" in line
+    ]
+    assert reexport_errors == [], (
+        "mypy --strict found re-export errors:\n" + "\n".join(reexport_errors)
+    )


### PR DESCRIPTION
## Summary

Closes #190.

Downstream packages compiling with `mypy --strict` (which implies `no_implicit_reexport`) could not do `from esperanto import AIFactory` — mypy raised `Module "esperanto" does not explicitly export attribute "..."`. The cause was a runtime-built `__all__` (`[...] + provider_classes`), invisible to static analyzers.

## Changes

- Replace the dynamic `__all__` with a single static `list[str]` literal enumerating every public name (factory, base classes, tool types, profile, and all provider classes).
- Remove the now-redundant `__provider_classes` dict and `globals().update(...)` — provider names are already bound at module level by the existing `try/except` import blocks.
- Conditional/optional-dependency import behavior is unchanged.

## Tests

- New `tests/unit/probe_reexport.py` + `tests/unit/test_mypy_reexport.py`: run `mypy --strict` against a probe importing the public names and assert zero "does not explicitly export attribute" errors.
- Full validator green; `ruff` and `mypy src/esperanto` clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

