### PR TITLE
chore(release): bump to 2.24.0 and cut CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.24.0] - 2026-06-23
+
+### Added
+
+- **Deepgram speech-to-text provider** — Deepgram is now selectable for STT via
+  `AIFactory.create_speech_to_text("deepgram", "nova-3")`, complementing the
+  existing Deepgram TTS provider. Posts to `/v1/listen` with `utterances=true`,
+  authenticates with the shared `DEEPGRAM_API_KEY`, and normalizes the response
+  to a `TranscriptionResponse`: `text` always, plus `segments` (built from
+  `results.utterances`, with Deepgram-specific extras — confidence, channel, id,
+  speaker — under each segment's `metadata`). When Deepgram returns no utterance
+  timing, `segments` stays `None` rather than being fabricated. Ships with
+  mocked-API unit tests. (#202)
+
+### Fixed
+
+- **OpenAI STT `gpt-4o-transcribe` compatibility** — the OpenAI STT provider no
+  longer hardcodes `response_format="verbose_json"`, which only `whisper-1`
+  accepts. It now sends `verbose_json` for the Whisper family (preserving
+  segments and duration) and `json` for the `gpt-4o-transcribe` /
+  `gpt-4o-mini-transcribe` family, which previously failed with a compatibility
+  error. When those models omit segments/duration, the corresponding
+  `TranscriptionResponse` fields stay `None`. (#204)
+- **`mypy --strict` re-exports** — the package-level `__all__` is now a static
+  literal instead of a runtime-built list, so downstream packages compiling with
+  `mypy --strict` (which implies `no_implicit_reexport`) can
+  `from esperanto import AIFactory` without "does not explicitly export
+  attribute" errors. Runtime import behavior, including graceful degradation for
+  missing optional dependencies, is unchanged. (#190)
+
 ## [2.23.0] - 2026-06-16
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esperanto"
-version = "2.23.0"
+version = "2.24.0"
 description = "A light-weight, production-ready, unified interface for various AI model providers"
 authors = [
     { name = "LUIS NOVO", email = "lfnovo@gmail.com" }

--- a/uv.lock
+++ b/uv.lock
@@ -516,7 +516,7 @@ wheels = [
 
 [[package]]
 name = "esperanto"
-version = "2.23.0"
+version = "2.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Release **2.24.0**.

Cuts the CHANGELOG and bumps the version for the three changes merged since v2.23.0:

- **Added** — Deepgram speech-to-text provider (#202)
- **Fixed** — OpenAI STT `gpt-4o-transcribe` `response_format` compatibility (#204)
- **Fixed** — static `__all__` so `mypy --strict` downstream sees explicit re-exports (#190)

Includes the bumped `pyproject.toml`, the new CHANGELOG section, and the updated `uv.lock`. Tag `v2.24.0` + GitHub release follow once this merges (the release workflow publishes to PyPI).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

