### PR TITLE
feat(audio): add OpenRouter TTS and STT providers

### DIFF
--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -285,8 +285,9 @@ OpenRouter exposes an OpenAI-compatible speech endpoint (`POST /api/v1/audio/spe
 that accepts `model`, `input`, `voice`, and `response_format`. Model names follow
 OpenRouter's `vendor/model` convention.
 
-**Available models** (from `?output_modalities=speech`, discoverable via
-`AIFactory.get_provider_models("openrouter")` for TTS):
+**Available models** — OpenRouter lists dedicated speech models under its
+`?output_modalities=speech` filter (they do **not** appear in the unfiltered
+`/models` list that `AIFactory.get_provider_models("openrouter")` returns):
 - `microsoft/mai-voice-2` (default)
 - `x-ai/grok-voice-tts-1.0`
 - `google/gemini-3.1-flash-tts-preview`

--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -11,8 +11,8 @@ OpenRouter provides unified access to multiple AI models from different provider
 | Language Models (LLM) | ✅ | Access to 100+ models from multiple providers |
 | Embeddings | ❌ | Not available |
 | Reranking | ❌ | Not available |
-| Speech-to-Text | ❌ | Not available |
-| Text-to-Speech | ❌ | Not available |
+| Speech-to-Text | ✅ | OpenAI-compatible transcription (`/audio/transcriptions`) |
+| Text-to-Speech | ✅ | OpenAI-compatible speech (`/audio/speech`) |
 
 **Official Documentation:** https://openrouter.ai/docs
 
@@ -278,6 +278,79 @@ focused_model = AIFactory.create_language(
     config={"temperature": 0.3, "max_tokens": 1024}
 )
 ```
+
+### Text-to-Speech (TTS)
+
+OpenRouter exposes an OpenAI-compatible speech endpoint (`POST /api/v1/audio/speech`)
+that accepts `model`, `input`, `voice`, and `response_format`. Model names follow
+OpenRouter's `vendor/model` convention.
+
+**Available models** (from `?output_modalities=speech`, discoverable via
+`AIFactory.get_provider_models("openrouter")` for TTS):
+- `microsoft/mai-voice-2` (default)
+- `x-ai/grok-voice-tts-1.0`
+- `google/gemini-3.1-flash-tts-preview`
+- `mistralai/voxtral-mini-tts-2603`
+- `hexgrad/kokoro-82m`, `sesame/csm-1b`, `canopylabs/orpheus-3b-0.1-ft`,
+  `zyphra/zonos-v0.1-transformer`, `zyphra/zonos-v0.1-hybrid`
+
+> **Voices are model-specific.** There is currently no OpenAI TTS model on
+> OpenRouter, so OpenAI's `alloy`/`nova` voice names do **not** apply. The default
+> `microsoft/mai-voice-2` uses Microsoft neural voice names (e.g.
+> `en-US-AvaNeural`, `en-US-AndrewNeural`). When picking a different model, pass a
+> voice listed on that model's page. `response_format` supports `mp3` (default)
+> and `pcm` only.
+
+```python
+from esperanto.factory import AIFactory
+
+# Zero-config: default model (microsoft/mai-voice-2) + default voice (en-US-AvaNeural)
+tts = AIFactory.create_text_to_speech("openrouter")
+response = tts.generate_speech("Hello from OpenRouter")
+with open("speech.mp3", "wb") as f:
+    f.write(response.audio_data)
+
+# Explicit model + a voice that model supports
+tts = AIFactory.create_text_to_speech("openrouter", "microsoft/mai-voice-2")
+response = tts.generate_speech("Hello", voice="en-US-AndrewNeural")
+
+# Async
+async def synth():
+    return (await tts.agenerate_speech("Hello", voice="en-US-EmmaNeural")).audio_data
+```
+
+### Speech-to-Text (STT)
+
+OpenRouter's transcription endpoint (`POST /api/v1/audio/transcriptions`) accepts a
+JSON body with base64-encoded audio (not OpenAI's multipart upload). Esperanto handles
+this encoding for you — pass a file path or a binary stream exactly like other providers.
+
+**Popular models:**
+- `openai/whisper-1` (default)
+- `openai/whisper-large-v3`
+
+```python
+from esperanto.factory import AIFactory
+
+stt = AIFactory.create_speech_to_text("openrouter", "openai/whisper-1")
+
+# From a file path
+result = stt.transcribe("audio.mp3", language="en")
+print(result.text)
+
+# From a binary stream
+with open("audio.mp3", "rb") as f:
+    result = stt.transcribe(f)
+
+# Usage stats (when reported by OpenRouter)
+if result.usage:
+    print(result.usage.input_seconds, result.usage.total_tokens)
+```
+
+The audio codec is inferred from the file extension (wav, mp3, flac, m4a, ogg, webm, aac).
+OpenRouter's transcription endpoint does not document a `prompt` parameter, so `prompt`
+is accepted for interface parity but not sent, and segment-level timestamps are not
+returned (`segments` stays `None`).
 
 ## Advanced Features
 

--- a/src/esperanto/__init__.py
+++ b/src/esperanto/__init__.py
@@ -132,6 +132,16 @@ except ImportError:
     DeepgramSpeechToTextModel = None  # type: ignore[assignment,misc]
 
 try:
+    from esperanto.providers.tts.openrouter import OpenRouterTextToSpeechModel
+except ImportError:
+    OpenRouterTextToSpeechModel = None  # type: ignore[assignment,misc]
+
+try:
+    from esperanto.providers.stt.openrouter import OpenRouterSpeechToTextModel
+except ImportError:
+    OpenRouterSpeechToTextModel = None  # type: ignore[assignment,misc]
+
+try:
     from esperanto.providers.llm.cohere import CohereLanguageModel
 except ImportError:
     CohereLanguageModel = None  # type: ignore[assignment,misc]
@@ -191,6 +201,8 @@ __all__ = [
     "MistralSpeechToTextModel",
     "DeepgramTextToSpeechModel",
     "DeepgramSpeechToTextModel",
+    "OpenRouterTextToSpeechModel",
+    "OpenRouterSpeechToTextModel",
     "CohereLanguageModel",
     "CohereEmbeddingModel",
     "CohereRerankerModel",

--- a/src/esperanto/factory.py
+++ b/src/esperanto/factory.py
@@ -56,6 +56,7 @@ class AIFactory:
             "google": "esperanto.providers.stt.google:GoogleSpeechToTextModel",
             "mistral": "esperanto.providers.stt.mistral:MistralSpeechToTextModel",
             "deepgram": "esperanto.providers.stt.deepgram:DeepgramSpeechToTextModel",
+            "openrouter": "esperanto.providers.stt.openrouter:OpenRouterSpeechToTextModel",
         },
         "text_to_speech": {
             "openai": "esperanto.providers.tts.openai:OpenAITextToSpeechModel",
@@ -67,6 +68,7 @@ class AIFactory:
             "xai": "esperanto.providers.tts.xai:XAITextToSpeechModel",
             "mistral": "esperanto.providers.tts.mistral:MistralTextToSpeechModel",
             "deepgram": "esperanto.providers.tts.deepgram:DeepgramTextToSpeechModel",
+            "openrouter": "esperanto.providers.tts.openrouter:OpenRouterTextToSpeechModel",
         },
         "reranker": {
             "jina": "esperanto.providers.reranker.jina:JinaRerankerModel",

--- a/src/esperanto/providers/stt/openrouter.py
+++ b/src/esperanto/providers/stt/openrouter.py
@@ -1,0 +1,208 @@
+"""OpenRouter Speech-to-Text provider implementation."""
+
+import base64
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, BinaryIO, Dict, List, Optional, Union
+
+import httpx
+
+from esperanto.common_types import (
+    Model,
+    TranscriptionResponse,
+    TranscriptionUsage,
+)
+from esperanto.providers.stt.base import SpeechToTextModel
+
+# OpenRouter's transcription endpoint takes a base64 payload with an explicit
+# codec token (NOT OpenAI's multipart file upload). Map common audio file
+# extensions onto the codecs OpenRouter documents as supported.
+_EXTENSION_TO_FORMAT = {
+    ".wav": "wav",
+    ".mp3": "mp3",
+    ".mpeg": "mp3",
+    ".mpga": "mp3",
+    ".flac": "flac",
+    ".m4a": "m4a",
+    ".mp4": "m4a",
+    ".ogg": "ogg",
+    ".oga": "ogg",
+    ".webm": "webm",
+    ".aac": "aac",
+}
+_DEFAULT_FORMAT = "mp3"
+
+
+@dataclass
+class OpenRouterSpeechToTextModel(SpeechToTextModel):
+    """OpenRouter speech-to-text provider.
+
+    Unlike OpenAI's multipart transcription API, OpenRouter's
+    ``POST /api/v1/audio/transcriptions`` endpoint accepts a JSON body with a
+    base64-encoded ``input_audio`` object and returns ``{"text", "usage"}``.
+    This provider builds that request shape while returning Esperanto's standard
+    :class:`TranscriptionResponse`.
+
+    Model names follow OpenRouter's ``vendor/model`` convention, e.g.
+    ``openai/whisper-1`` or ``openai/whisper-large-v3``.
+    """
+
+    DEFAULT_MODEL = "openai/whisper-1"
+    DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+
+    def __post_init__(self):
+        """Resolve credentials and initialize HTTP clients."""
+        super().__post_init__()
+
+        self.api_key = self.api_key or os.getenv("OPENROUTER_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "OpenRouter API key not found. Set the OPENROUTER_API_KEY environment variable."
+            )
+
+        self.base_url = (
+            self.base_url or os.getenv("OPENROUTER_BASE_URL") or self.DEFAULT_BASE_URL
+        ).rstrip("/")
+
+        self._create_http_clients()
+
+    def _get_headers(self) -> Dict[str, str]:
+        """Get headers for OpenRouter API requests."""
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": "https://github.com/lfnovo/esperanto",
+            "X-Title": "Esperanto",
+        }
+
+    def _handle_error(self, response: httpx.Response) -> None:
+        """Handle HTTP error responses."""
+        if response.status_code >= 400:
+            try:
+                error_data = response.json()
+                error_message = error_data.get("error", {}).get(
+                    "message", f"HTTP {response.status_code}"
+                )
+            except Exception:
+                error_message = f"HTTP {response.status_code}: {response.text}"
+            raise RuntimeError(f"OpenRouter API error: {error_message}")
+
+    def _get_default_model(self) -> str:
+        """Get the default model name."""
+        return self.DEFAULT_MODEL
+
+    @property
+    def provider(self) -> str:
+        """Get the provider name."""
+        return "openrouter"
+
+    def _get_models(self) -> List[Model]:
+        """List available models.
+
+        OpenRouter's ``/models`` endpoint does not expose a reliable
+        modality filter for transcription models, so model discovery is not
+        supported for this provider. Returns an empty list.
+        """
+        return []
+
+    def _detect_format(self, filename: Optional[str]) -> str:
+        """Map an audio filename to an OpenRouter codec token."""
+        if not filename:
+            return _DEFAULT_FORMAT
+        return _EXTENSION_TO_FORMAT.get(Path(filename).suffix.lower(), _DEFAULT_FORMAT)
+
+    def _read_audio(
+        self, audio_file: Union[str, BinaryIO]
+    ) -> tuple[bytes, str]:
+        """Read audio bytes and resolve a filename for format detection."""
+        if isinstance(audio_file, str):
+            with open(audio_file, "rb") as f:
+                return f.read(), audio_file
+        filename = getattr(audio_file, "name", None) or "audio.mp3"
+        return audio_file.read(), filename
+
+    def _build_payload(
+        self,
+        audio_file: Union[str, BinaryIO],
+        language: Optional[str],
+    ) -> Dict[str, Any]:
+        """Build the OpenRouter transcription request payload."""
+        audio_bytes, filename = self._read_audio(audio_file)
+        payload: Dict[str, Any] = {
+            "model": self.get_model_name(),
+            "input_audio": {
+                "data": base64.b64encode(audio_bytes).decode("ascii"),
+                "format": self._detect_format(filename),
+            },
+        }
+        if language:
+            payload["language"] = language
+        return payload
+
+    def _build_response(
+        self,
+        response_data: Dict[str, Any],
+        language: Optional[str],
+    ) -> TranscriptionResponse:
+        """Map OpenRouter's transcription JSON into a TranscriptionResponse."""
+        usage_data = response_data.get("usage") or {}
+        seconds = usage_data.get("seconds")
+        usage = (
+            TranscriptionUsage(
+                input_seconds=seconds,
+                input_tokens=usage_data.get("input_tokens"),
+                output_tokens=usage_data.get("output_tokens"),
+                total_tokens=usage_data.get("total_tokens"),
+            )
+            if usage_data
+            else None
+        )
+        return TranscriptionResponse(
+            text=response_data["text"],
+            language=response_data.get("language") or language,
+            duration=float(seconds) if seconds is not None else None,
+            usage=usage,
+            model=self.get_model_name(),
+            provider=self.provider,
+        )
+
+    def transcribe(
+        self,
+        audio_file: Union[str, BinaryIO],
+        language: Optional[str] = None,
+        prompt: Optional[str] = None,
+    ) -> TranscriptionResponse:
+        """Transcribe audio to text using OpenRouter's transcription API.
+
+        Note: OpenRouter's transcription endpoint does not document a ``prompt``
+        parameter, so ``prompt`` is accepted for interface parity but not sent.
+        """
+        payload = self._build_payload(audio_file, language)
+        response = self.client.post(
+            f"{self.base_url}/audio/transcriptions",
+            headers=self._get_headers(),
+            json=payload,
+        )
+        self._handle_error(response)
+        return self._build_response(response.json(), language)
+
+    async def atranscribe(
+        self,
+        audio_file: Union[str, BinaryIO],
+        language: Optional[str] = None,
+        prompt: Optional[str] = None,
+    ) -> TranscriptionResponse:
+        """Async transcribe audio to text using OpenRouter's transcription API.
+
+        Note: OpenRouter's transcription endpoint does not document a ``prompt``
+        parameter, so ``prompt`` is accepted for interface parity but not sent.
+        """
+        payload = self._build_payload(audio_file, language)
+        response = await self.async_client.post(
+            f"{self.base_url}/audio/transcriptions",
+            headers=self._get_headers(),
+            json=payload,
+        )
+        self._handle_error(response)
+        return self._build_response(response.json(), language)

--- a/src/esperanto/providers/tts/openrouter.py
+++ b/src/esperanto/providers/tts/openrouter.py
@@ -1,0 +1,173 @@
+"""OpenRouter Text-to-Speech provider implementation."""
+
+import os
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+from .base import AudioResponse, Model, Voice
+from .openai import OpenAITextToSpeechModel
+
+
+class OpenRouterTextToSpeechModel(OpenAITextToSpeechModel):
+    """OpenRouter Text-to-Speech provider.
+
+    OpenRouter exposes an OpenAI-compatible audio speech endpoint
+    (``POST /api/v1/audio/speech``) that accepts ``model``, ``input``, ``voice``
+    and ``response_format`` (``mp3`` or ``pcm`` only). This provider reuses the
+    OpenAI TTS request logic and overrides credential resolution, the required
+    OpenRouter HTTP headers, provider identity, and the model-specific defaults.
+
+    Model names follow OpenRouter's ``vendor/model`` convention. Note that
+    voices are model-specific — the default ``microsoft/mai-voice-2`` uses
+    Microsoft neural voice names (e.g. ``en-US-AvaNeural``), not OpenAI's
+    ``alloy``/``nova`` set. When selecting a different model, pass a voice that
+    the model supports (see its page on https://openrouter.ai/models).
+    """
+
+    DEFAULT_MODEL = "microsoft/mai-voice-2"
+    DEFAULT_VOICE = "en-US-AvaNeural"
+    DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+    PROVIDER = "openrouter"
+
+    # Verified working Microsoft neural voices for the default model.
+    _DEFAULT_MODEL_VOICES = {
+        "en-US-AvaNeural": ("FEMALE", "en-US"),
+        "en-US-EmmaNeural": ("FEMALE", "en-US"),
+        "en-US-AriaNeural": ("FEMALE", "en-US"),
+        "en-US-JennyNeural": ("FEMALE", "en-US"),
+        "en-US-AndrewNeural": ("MALE", "en-US"),
+        "en-US-BrianNeural": ("MALE", "en-US"),
+        "en-GB-SoniaNeural": ("FEMALE", "en-GB"),
+    }
+
+    def __init__(
+        self,
+        model_name: Optional[str] = None,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        **kwargs,
+    ):
+        """Initialize the OpenRouter TTS provider.
+
+        Args:
+            model_name: OpenRouter TTS model id (default: ``microsoft/mai-voice-2``).
+            api_key: OpenRouter API key. Falls back to ``OPENROUTER_API_KEY``.
+            base_url: API base URL. Falls back to ``OPENROUTER_BASE_URL`` then the
+                OpenRouter default (``https://openrouter.ai/api/v1``).
+            **kwargs: Additional configuration options.
+        """
+        api_key = api_key or os.getenv("OPENROUTER_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "OpenRouter API key not found. Set the OPENROUTER_API_KEY environment variable."
+            )
+
+        base_url = base_url or os.getenv("OPENROUTER_BASE_URL") or self.DEFAULT_BASE_URL
+
+        super().__init__(
+            model_name=model_name or self.DEFAULT_MODEL,
+            api_key=api_key,
+            base_url=base_url,
+            **kwargs,
+        )
+
+    def _get_headers(self) -> Dict[str, str]:
+        """Get request headers, adding OpenRouter's required attribution headers."""
+        headers = super()._get_headers()
+        headers.update(
+            {
+                "HTTP-Referer": "https://github.com/lfnovo/esperanto",
+                "X-Title": "Esperanto",
+            }
+        )
+        return headers
+
+    def _handle_error(self, response) -> None:
+        """Handle HTTP error responses with OpenRouter-specific messaging."""
+        if response.status_code >= 400:
+            try:
+                error_data = response.json()
+                error_message = error_data.get("error", {}).get(
+                    "message", f"HTTP {response.status_code}"
+                )
+            except Exception:
+                error_message = f"HTTP {response.status_code}: {response.text}"
+            raise RuntimeError(f"OpenRouter API error: {error_message}")
+
+    @property
+    def provider(self) -> str:
+        """Get the provider name."""
+        return self.PROVIDER
+
+    def _get_default_model(self) -> str:
+        """Get the default model name."""
+        return self.DEFAULT_MODEL
+
+    def _get_models(self) -> List[Model]:
+        """List OpenRouter models that output speech (dedicated TTS models).
+
+        Uses OpenRouter's ``output_modalities=speech`` filter, which surfaces the
+        dedicated text-to-speech models (these do not appear in the unfiltered
+        ``/models`` listing). Returns an empty list if the endpoint is
+        unreachable.
+        """
+        try:
+            response = self.client.get(
+                f"{self.base_url}/models",
+                headers=self._get_headers(),
+                params={"output_modalities": "speech"},
+            )
+            self._handle_error(response)
+            return [
+                Model(
+                    id=model["id"],
+                    owned_by=model["id"].split("/")[0] if "/" in model["id"] else "OpenRouter",
+                    context_window=None,  # Audio models don't have context windows
+                )
+                for model in response.json().get("data", [])
+            ]
+        except Exception:
+            return []
+
+    @property
+    def available_voices(self) -> Dict[str, Voice]:
+        """Return the voice catalog for the default model.
+
+        Voices on OpenRouter are model-specific; this catalog covers the
+        default ``microsoft/mai-voice-2`` model. For other models, supply a
+        voice listed on the model's page rather than relying on this catalog.
+        """
+        return {
+            voice_id: Voice(
+                name=voice_id,
+                id=voice_id,
+                gender=gender,
+                language_code=language_code,
+                description=f"Microsoft neural voice ({voice_id})",
+            )
+            for voice_id, (gender, language_code) in self._DEFAULT_MODEL_VOICES.items()
+        }
+
+    def generate_speech(
+        self,
+        text: str,
+        voice: Optional[str] = None,
+        output_file: Optional[Union[str, Path]] = None,
+        **kwargs,
+    ) -> AudioResponse:
+        """Generate speech, defaulting to a voice valid for the default model."""
+        return super().generate_speech(
+            text, voice or self.DEFAULT_VOICE, output_file, **kwargs
+        )
+
+    async def agenerate_speech(
+        self,
+        text: str,
+        voice: Optional[str] = None,
+        output_file: Optional[Union[str, Path]] = None,
+        **kwargs,
+    ) -> AudioResponse:
+        """Async generate speech, defaulting to a voice valid for the default model."""
+        return await super().agenerate_speech(
+            text, voice or self.DEFAULT_VOICE, output_file, **kwargs
+        )

--- a/src/esperanto/providers/tts/openrouter.py
+++ b/src/esperanto/providers/tts/openrouter.py
@@ -4,6 +4,8 @@ import os
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
+from esperanto.utils.logging import logger
+
 from .base import AudioResponse, Model, Voice
 from .openai import OpenAITextToSpeechModel
 
@@ -108,8 +110,9 @@ class OpenRouterTextToSpeechModel(OpenAITextToSpeechModel):
 
         Uses OpenRouter's ``output_modalities=speech`` filter, which surfaces the
         dedicated text-to-speech models (these do not appear in the unfiltered
-        ``/models`` listing). Returns an empty list if the endpoint is
-        unreachable.
+        ``/models`` listing). Logs and returns an empty list if discovery fails,
+        so a transient/auth/network error surfaces in logs rather than silently
+        masquerading as "no models available".
         """
         try:
             response = self.client.get(
@@ -126,7 +129,8 @@ class OpenRouterTextToSpeechModel(OpenAITextToSpeechModel):
                 )
                 for model in response.json().get("data", [])
             ]
-        except Exception:
+        except Exception as e:
+            logger.info(f"Failed to discover OpenRouter speech models: {e}")
             return []
 
     @property

--- a/tests/integration/test_stt_real.py
+++ b/tests/integration/test_stt_real.py
@@ -283,3 +283,43 @@ class TestOpenAICompatibleSTT:
 
         result = asyncio.run(_run())
         assert EXPECTED_TRANSCRIPT_FRAGMENT.lower() in result.text.lower()
+
+
+# =============================================================================
+# OpenRouter Tests
+# =============================================================================
+
+
+@pytest.mark.release
+@pytest.mark.skipif(
+    not os.getenv("OPENROUTER_API_KEY"),
+    reason="OPENROUTER_API_KEY not configured",
+)
+class TestOpenRouterSTT:
+    """Real integration tests for OpenRouter speech-to-text."""
+
+    MODEL = "openai/whisper-1"
+
+    def test_sync_transcribe(self):
+        """Test sync transcription with file-path input."""
+        model = AIFactory.create_speech_to_text("openrouter", self.MODEL)
+        result = model.transcribe(str(SAMPLE_AUDIO))
+        assert EXPECTED_TRANSCRIPT_FRAGMENT.lower() in result.text.lower()
+        assert result.provider == "openrouter"
+
+    def test_sync_transcribe_binary_io(self):
+        """Test sync transcription with BinaryIO input."""
+        model = AIFactory.create_speech_to_text("openrouter", self.MODEL)
+        with open(SAMPLE_AUDIO, "rb") as f:
+            result = model.transcribe(f)
+        assert EXPECTED_TRANSCRIPT_FRAGMENT.lower() in result.text.lower()
+
+    def test_async_atranscribe(self):
+        """Test async transcription with file-path input."""
+        model = AIFactory.create_speech_to_text("openrouter", self.MODEL)
+
+        async def _run() -> object:
+            return await model.atranscribe(str(SAMPLE_AUDIO))
+
+        result = asyncio.run(_run())
+        assert EXPECTED_TRANSCRIPT_FRAGMENT.lower() in result.text.lower()

--- a/tests/integration/test_tts_real.py
+++ b/tests/integration/test_tts_real.py
@@ -309,6 +309,43 @@ class TestDeepgramTTS:
 
 
 # =============================================================================
+# OpenRouter Tests
+# =============================================================================
+
+
+@pytest.mark.release
+@pytest.mark.skipif(
+    not os.getenv("OPENROUTER_API_KEY"),
+    reason="OPENROUTER_API_KEY not configured",
+)
+class TestOpenRouterTTS:
+    """Real integration tests for OpenRouter text-to-speech.
+
+    Uses the provider defaults (``microsoft/mai-voice-2`` + ``en-US-AvaNeural``),
+    which exercises the zero-config path end to end.
+    """
+
+    def test_sync_generate_speech(self):
+        """Test sync speech generation with default model and voice."""
+        model = AIFactory.create_text_to_speech("openrouter")
+        response = model.generate_speech(TEST_TEXT)
+        assert response.audio_data
+        assert response.content_type.startswith("audio/")
+        assert response.provider == "openrouter"
+
+    def test_async_agenerate_speech(self):
+        """Test async speech generation with default model and voice."""
+        model = AIFactory.create_text_to_speech("openrouter")
+
+        async def _run() -> object:
+            return await model.agenerate_speech(TEST_TEXT)
+
+        response = asyncio.run(_run())
+        assert response.audio_data
+        assert response.content_type.startswith("audio/")
+
+
+# =============================================================================
 # OpenAI-Compatible Tests
 # =============================================================================
 

--- a/tests/providers/stt/test_openrouter.py
+++ b/tests/providers/stt/test_openrouter.py
@@ -1,0 +1,225 @@
+"""Tests for the OpenRouter STT provider."""
+import base64
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from esperanto.providers.stt.openrouter import OpenRouterSpeechToTextModel
+
+SAMPLE_AUDIO = b"fake audio bytes for testing"
+TRANSCRIPTION_JSON = {
+    "text": "Hello from OpenRouter.",
+    "usage": {
+        "seconds": 9.2,
+        "total_tokens": 113,
+        "input_tokens": 83,
+        "output_tokens": 30,
+        "cost": 0.000508,
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+
+
+@pytest.fixture
+def mock_httpx_clients():
+    """Mock httpx clients for OpenRouter STT."""
+    client = Mock()
+    async_client = AsyncMock()
+
+    def make_response(status_code, json_data):
+        response = Mock()
+        response.status_code = status_code
+        response.json.return_value = json_data
+        return response
+
+    def make_async_response(status_code, json_data):
+        response = AsyncMock()
+        response.status_code = status_code
+        response.json = Mock(return_value=json_data)
+        return response
+
+    def mock_post(url, **kwargs):
+        if url.endswith("/audio/transcriptions"):
+            return make_response(200, TRANSCRIPTION_JSON)
+        return make_response(404, {"error": {"message": "Not found"}})
+
+    async def mock_async_post(url, **kwargs):
+        if url.endswith("/audio/transcriptions"):
+            return make_async_response(200, TRANSCRIPTION_JSON)
+        return make_async_response(404, {"error": {"message": "Not found"}})
+
+    client.post.side_effect = mock_post
+    async_client.post.side_effect = mock_async_post
+    return client, async_client
+
+
+@pytest.fixture
+def stt_model(mock_httpx_clients):
+    model = OpenRouterSpeechToTextModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+    return model
+
+
+@pytest.fixture
+def audio_path(tmp_path):
+    path = tmp_path / "sample.mp3"
+    path.write_bytes(SAMPLE_AUDIO)
+    return str(path)
+
+
+def test_init(stt_model):
+    assert stt_model.api_key == "test-key"
+    assert stt_model.provider == "openrouter"
+
+
+def test_init_missing_api_key():
+    with pytest.raises(ValueError, match="OpenRouter API key not found"):
+        OpenRouterSpeechToTextModel()
+
+
+def test_init_from_env_var(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "env-test-key")
+    model = OpenRouterSpeechToTextModel()
+    assert model.api_key == "env-test-key"
+
+
+def test_init_default_base_url(stt_model):
+    assert stt_model.base_url == "https://openrouter.ai/api/v1"
+
+
+def test_init_custom_base_url():
+    model = OpenRouterSpeechToTextModel(api_key="test-key", base_url="https://custom.api.com/v1")
+    assert model.base_url == "https://custom.api.com/v1"
+
+
+def test_init_base_url_from_env_var(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.setenv("OPENROUTER_BASE_URL", "https://env-base.api.com/v1")
+    model = OpenRouterSpeechToTextModel()
+    assert model.base_url == "https://env-base.api.com/v1"
+
+
+def test_init_base_url_strips_trailing_slash():
+    model = OpenRouterSpeechToTextModel(api_key="test-key", base_url="https://openrouter.ai/api/v1/")
+    assert model.base_url == "https://openrouter.ai/api/v1"
+
+
+def test_get_headers(stt_model):
+    headers = stt_model._get_headers()
+    assert headers["Authorization"] == "Bearer test-key"
+    assert headers["Content-Type"] == "application/json"
+    assert headers["HTTP-Referer"] == "https://github.com/lfnovo/esperanto"
+    assert headers["X-Title"] == "Esperanto"
+
+
+def test_handle_error_with_json(stt_model):
+    response = Mock()
+    response.status_code = 401
+    response.json.return_value = {"error": {"message": "Invalid API key"}}
+    with pytest.raises(RuntimeError, match="OpenRouter API error: Invalid API key"):
+        stt_model._handle_error(response)
+
+
+def test_handle_error_without_json(stt_model):
+    response = Mock()
+    response.status_code = 500
+    response.json.side_effect = Exception("Not JSON")
+    response.text = "Internal Server Error"
+    with pytest.raises(RuntimeError, match="OpenRouter API error: HTTP 500"):
+        stt_model._handle_error(response)
+
+
+def test_default_model(stt_model):
+    assert stt_model._get_default_model() == "openai/whisper-1"
+
+
+def test_transcribe_posts_base64_json(stt_model, audio_path):
+    """Transcription sends OpenRouter's JSON + base64 input_audio contract."""
+    result = stt_model.transcribe(audio_path)
+
+    stt_model.client.post.assert_called_once()
+    call_args = stt_model.client.post.call_args
+    assert call_args[0][0] == "https://openrouter.ai/api/v1/audio/transcriptions"
+
+    payload = call_args[1]["json"]
+    assert payload["model"] == "openai/whisper-1"
+    assert payload["input_audio"]["data"] == base64.b64encode(SAMPLE_AUDIO).decode("ascii")
+    assert payload["input_audio"]["format"] == "mp3"
+
+    assert result.text == "Hello from OpenRouter."
+    assert result.provider == "openrouter"
+    assert result.model == "openai/whisper-1"
+    # usage.seconds maps to both duration and input_seconds
+    assert result.duration == 9.2
+    assert result.usage.input_seconds == 9.2
+    assert result.usage.total_tokens == 113
+    assert result.usage.input_tokens == 83
+    assert result.usage.output_tokens == 30
+
+
+def test_transcribe_detects_wav_format(stt_model, tmp_path):
+    path = tmp_path / "clip.wav"
+    path.write_bytes(SAMPLE_AUDIO)
+    stt_model.transcribe(str(path))
+    payload = stt_model.client.post.call_args[1]["json"]
+    assert payload["input_audio"]["format"] == "wav"
+
+
+def test_transcribe_with_language(stt_model, audio_path):
+    stt_model.transcribe(audio_path, language="en")
+    payload = stt_model.client.post.call_args[1]["json"]
+    assert payload["language"] == "en"
+
+
+def test_transcribe_binary_io(stt_model, audio_path):
+    with open(audio_path, "rb") as f:
+        result = stt_model.transcribe(f)
+    payload = stt_model.client.post.call_args[1]["json"]
+    assert payload["input_audio"]["data"] == base64.b64encode(SAMPLE_AUDIO).decode("ascii")
+    assert result.text == "Hello from OpenRouter."
+
+
+def test_transcribe_api_error(stt_model, audio_path):
+    error_response = Mock()
+    error_response.status_code = 400
+    error_response.json.return_value = {"error": {"message": "Bad request"}}
+    stt_model.client.post.side_effect = lambda *a, **kw: error_response
+    with pytest.raises(RuntimeError, match="OpenRouter API error: Bad request"):
+        stt_model.transcribe(audio_path)
+
+
+def test_transcribe_no_usage_block(stt_model, audio_path):
+    """A response without usage still produces a valid TranscriptionResponse."""
+    resp = Mock()
+    resp.status_code = 200
+    resp.json.return_value = {"text": "no usage here"}
+    stt_model.client.post.side_effect = lambda *a, **kw: resp
+    result = stt_model.transcribe(audio_path)
+    assert result.text == "no usage here"
+    assert result.usage is None
+    assert result.duration is None
+
+
+@pytest.mark.asyncio
+async def test_atranscribe(stt_model, audio_path):
+    result = await stt_model.atranscribe(audio_path, language="en")
+
+    stt_model.async_client.post.assert_called_once()
+    call_args = stt_model.async_client.post.call_args
+    assert call_args[0][0] == "https://openrouter.ai/api/v1/audio/transcriptions"
+    payload = call_args[1]["json"]
+    assert payload["input_audio"]["data"] == base64.b64encode(SAMPLE_AUDIO).decode("ascii")
+    assert payload["language"] == "en"
+
+    assert result.text == "Hello from OpenRouter."
+    assert result.usage.total_tokens == 113
+
+
+def test_get_models_returns_list(stt_model):
+    """Model discovery is not filterable for STT; returns a list."""
+    assert isinstance(stt_model._get_models(), list)

--- a/tests/providers/tts/test_openrouter.py
+++ b/tests/providers/tts/test_openrouter.py
@@ -214,14 +214,15 @@ def test_generate_speech_uses_explicit_model():
     client.post.return_value = resp
     model.client = client
 
-    model.generate_speech(text="Hi", voice="alloy")
+    # This test only asserts model passthrough; voice defaults to the provider default.
+    model.generate_speech(text="Hi")
     assert client.post.call_args[1]["json"]["model"] == "mistralai/voxtral-mini-tts-2603"
 
 
 def test_generate_speech_saves_to_file(tts_model, tmp_path):
     """Test speech generation saves to file when output_file is specified."""
     output_file = tmp_path / "output.mp3"
-    tts_model.generate_speech(text="Hello", voice="alloy", output_file=output_file)
+    tts_model.generate_speech(text="Hello", voice="en-US-AvaNeural", output_file=output_file)
     assert output_file.exists()
     assert output_file.read_bytes() == b"mock audio data for testing"
 
@@ -234,20 +235,20 @@ def test_generate_speech_api_error(tts_model):
     tts_model.client.post.side_effect = lambda *a, **kw: error_response
 
     with pytest.raises(RuntimeError, match="Failed to generate speech"):
-        tts_model.generate_speech(text="Hello", voice="alloy")
+        tts_model.generate_speech(text="Hello", voice="en-US-AvaNeural")
 
 
 @pytest.mark.asyncio
 async def test_agenerate_speech(tts_model):
     """Test asynchronous speech generation."""
-    response = await tts_model.agenerate_speech(text="Hello world", voice="echo")
+    response = await tts_model.agenerate_speech(text="Hello world", voice="en-US-EmmaNeural")
 
     tts_model.async_client.post.assert_called_once()
     call_args = tts_model.async_client.post.call_args
     assert call_args[0][0] == "https://openrouter.ai/api/v1/audio/speech"
 
     json_payload = call_args[1]["json"]
-    assert json_payload["voice"] == "echo"
+    assert json_payload["voice"] == "en-US-EmmaNeural"
     assert json_payload["input"] == "Hello world"
 
     assert response.audio_data == b"mock audio data for testing"
@@ -258,6 +259,6 @@ async def test_agenerate_speech(tts_model):
 async def test_agenerate_speech_saves_to_file(tts_model, tmp_path):
     """Test async speech generation saves to file."""
     output_file = tmp_path / "async_output.mp3"
-    await tts_model.agenerate_speech(text="Hello", voice="alloy", output_file=output_file)
+    await tts_model.agenerate_speech(text="Hello", voice="en-US-AvaNeural", output_file=output_file)
     assert output_file.exists()
     assert output_file.read_bytes() == b"mock audio data for testing"

--- a/tests/providers/tts/test_openrouter.py
+++ b/tests/providers/tts/test_openrouter.py
@@ -1,0 +1,263 @@
+"""Tests for the OpenRouter TTS provider."""
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from esperanto.providers.tts.openrouter import OpenRouterTextToSpeechModel
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    """Ensure a clean environment for every test."""
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+
+
+@pytest.fixture
+def mock_tts_audio_response():
+    """Mock binary audio response data."""
+    return b"mock audio data for testing"
+
+
+@pytest.fixture
+def mock_httpx_clients(mock_tts_audio_response):
+    """Mock httpx clients for OpenRouter TTS."""
+    client = Mock()
+    async_client = AsyncMock()
+
+    def make_response(status_code, content=None, json_data=None):
+        response = Mock()
+        response.status_code = status_code
+        if content is not None:
+            response.content = content
+        if json_data is not None:
+            response.json.return_value = json_data
+        return response
+
+    def make_async_response(status_code, content=None, json_data=None):
+        response = AsyncMock()
+        response.status_code = status_code
+        if content is not None:
+            response.content = content
+        if json_data is not None:
+            response.json = Mock(return_value=json_data)
+        return response
+
+    def mock_post_side_effect(url, **kwargs):
+        if url.endswith("/audio/speech"):
+            return make_response(200, content=mock_tts_audio_response)
+        return make_response(404, json_data={"error": {"message": "Not found"}})
+
+    async def mock_async_post_side_effect(url, **kwargs):
+        if url.endswith("/audio/speech"):
+            return make_async_response(200, content=mock_tts_audio_response)
+        return make_async_response(404, json_data={"error": {"message": "Not found"}})
+
+    client.post.side_effect = mock_post_side_effect
+    async_client.post.side_effect = mock_async_post_side_effect
+
+    return client, async_client
+
+
+@pytest.fixture
+def tts_model(mock_httpx_clients):
+    """Create a TTS model instance with mocked HTTP clients."""
+    model = OpenRouterTextToSpeechModel(api_key="test-key")
+    model.client, model.async_client = mock_httpx_clients
+    return model
+
+
+def test_init(tts_model):
+    """Test model initialization."""
+    assert tts_model.api_key == "test-key"
+    assert tts_model.PROVIDER == "openrouter"
+
+
+def test_init_missing_api_key():
+    """Test that missing API key raises ValueError."""
+    with pytest.raises(ValueError, match="OpenRouter API key not found"):
+        OpenRouterTextToSpeechModel()
+
+
+def test_init_from_env_var(monkeypatch):
+    """Test initialization from environment variable."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "env-test-key")
+    model = OpenRouterTextToSpeechModel()
+    assert model.api_key == "env-test-key"
+
+
+def test_init_default_base_url(tts_model):
+    """Test that default base URL is the OpenRouter endpoint."""
+    assert tts_model.base_url == "https://openrouter.ai/api/v1"
+
+
+def test_init_custom_base_url():
+    """Test initialization with custom base URL."""
+    model = OpenRouterTextToSpeechModel(api_key="test-key", base_url="https://custom.api.com/v1")
+    assert model.base_url == "https://custom.api.com/v1"
+
+
+def test_init_base_url_from_env_var(monkeypatch):
+    """Test base URL from environment variable."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.setenv("OPENROUTER_BASE_URL", "https://env-base.api.com/v1")
+    model = OpenRouterTextToSpeechModel()
+    assert model.base_url == "https://env-base.api.com/v1"
+
+
+def test_init_base_url_strips_trailing_slash():
+    """Trailing slash is stripped to avoid double-slash URLs."""
+    model = OpenRouterTextToSpeechModel(api_key="test-key", base_url="https://openrouter.ai/api/v1/")
+    assert model.base_url == "https://openrouter.ai/api/v1"
+
+
+def test_get_headers(tts_model):
+    """Test request headers include auth and OpenRouter-required headers."""
+    headers = tts_model._get_headers()
+    assert headers["Authorization"] == "Bearer test-key"
+    assert headers["HTTP-Referer"] == "https://github.com/lfnovo/esperanto"
+    assert headers["X-Title"] == "Esperanto"
+
+
+def test_handle_error_with_json(tts_model):
+    """Test error handling with JSON error body."""
+    response = Mock()
+    response.status_code = 401
+    response.json.return_value = {"error": {"message": "Invalid API key"}}
+    with pytest.raises(RuntimeError, match="OpenRouter API error: Invalid API key"):
+        tts_model._handle_error(response)
+
+
+def test_handle_error_without_json(tts_model):
+    """Test error handling when response is not JSON."""
+    response = Mock()
+    response.status_code = 500
+    response.json.side_effect = Exception("Not JSON")
+    response.text = "Internal Server Error"
+    with pytest.raises(RuntimeError, match="OpenRouter API error: HTTP 500"):
+        tts_model._handle_error(response)
+
+
+def test_provider(tts_model):
+    """Test provider property."""
+    assert tts_model.provider == "openrouter"
+
+
+def test_get_default_model(tts_model):
+    """Test default model is a real OpenRouter speech model."""
+    assert tts_model._get_default_model() == "microsoft/mai-voice-2"
+
+
+def test_available_voices(tts_model):
+    """Voice catalog reflects the default model's Microsoft neural voices."""
+    voices = tts_model.available_voices
+    assert "en-US-AvaNeural" in voices
+    assert voices["en-US-AvaNeural"].id == "en-US-AvaNeural"
+    # OpenAI's alloy/nova set does not apply to the default model
+    assert "alloy" not in voices
+
+
+def test_default_voice_used_when_omitted(tts_model):
+    """When no voice is passed, a voice valid for the default model is sent."""
+    tts_model.generate_speech(text="Hello")
+    payload = tts_model.client.post.call_args[1]["json"]
+    assert payload["voice"] == "en-US-AvaNeural"
+
+
+def test_get_models_queries_speech_filter(tts_model):
+    """Model discovery hits /models with the output_modalities=speech filter."""
+    resp = Mock()
+    resp.status_code = 200
+    resp.json.return_value = {"data": [{"id": "microsoft/mai-voice-2"}, {"id": "hexgrad/kokoro-82m"}]}
+    client = Mock()
+    client.get.return_value = resp
+    tts_model.client = client
+
+    models = tts_model._get_models()
+    assert [m.id for m in models] == ["microsoft/mai-voice-2", "hexgrad/kokoro-82m"]
+    assert client.get.call_args[1]["params"] == {"output_modalities": "speech"}
+    assert models[0].owned_by == "microsoft"
+
+
+def test_generate_speech(tts_model):
+    """Test synchronous speech generation posts an OpenAI-compatible payload."""
+    response = tts_model.generate_speech(text="Hello world", voice="en-US-AndrewNeural")
+
+    tts_model.client.post.assert_called_once()
+    call_args = tts_model.client.post.call_args
+    assert call_args[0][0] == "https://openrouter.ai/api/v1/audio/speech"
+
+    json_payload = call_args[1]["json"]
+    assert json_payload["model"] == "microsoft/mai-voice-2"
+    assert json_payload["voice"] == "en-US-AndrewNeural"
+    assert json_payload["input"] == "Hello world"
+    assert json_payload["response_format"] == "mp3"
+
+    # OpenRouter-required headers travel with the request
+    headers = call_args[1]["headers"]
+    assert headers["HTTP-Referer"] == "https://github.com/lfnovo/esperanto"
+    assert headers["X-Title"] == "Esperanto"
+
+    assert response.audio_data == b"mock audio data for testing"
+    assert response.content_type == "audio/mp3"
+    assert response.voice == "en-US-AndrewNeural"
+    assert response.provider == "openrouter"
+
+
+def test_generate_speech_uses_explicit_model():
+    """Explicit model_name flows into the request payload."""
+    model = OpenRouterTextToSpeechModel(api_key="test-key", model_name="mistralai/voxtral-mini-tts-2603")
+    client = Mock()
+    resp = Mock()
+    resp.status_code = 200
+    resp.content = b"audio"
+    client.post.return_value = resp
+    model.client = client
+
+    model.generate_speech(text="Hi", voice="alloy")
+    assert client.post.call_args[1]["json"]["model"] == "mistralai/voxtral-mini-tts-2603"
+
+
+def test_generate_speech_saves_to_file(tts_model, tmp_path):
+    """Test speech generation saves to file when output_file is specified."""
+    output_file = tmp_path / "output.mp3"
+    tts_model.generate_speech(text="Hello", voice="alloy", output_file=output_file)
+    assert output_file.exists()
+    assert output_file.read_bytes() == b"mock audio data for testing"
+
+
+def test_generate_speech_api_error(tts_model):
+    """Test that API errors are raised as RuntimeError."""
+    error_response = Mock()
+    error_response.status_code = 400
+    error_response.json.return_value = {"error": {"message": "Bad request"}}
+    tts_model.client.post.side_effect = lambda *a, **kw: error_response
+
+    with pytest.raises(RuntimeError, match="Failed to generate speech"):
+        tts_model.generate_speech(text="Hello", voice="alloy")
+
+
+@pytest.mark.asyncio
+async def test_agenerate_speech(tts_model):
+    """Test asynchronous speech generation."""
+    response = await tts_model.agenerate_speech(text="Hello world", voice="echo")
+
+    tts_model.async_client.post.assert_called_once()
+    call_args = tts_model.async_client.post.call_args
+    assert call_args[0][0] == "https://openrouter.ai/api/v1/audio/speech"
+
+    json_payload = call_args[1]["json"]
+    assert json_payload["voice"] == "echo"
+    assert json_payload["input"] == "Hello world"
+
+    assert response.audio_data == b"mock audio data for testing"
+    assert response.provider == "openrouter"
+
+
+@pytest.mark.asyncio
+async def test_agenerate_speech_saves_to_file(tts_model, tmp_path):
+    """Test async speech generation saves to file."""
+    output_file = tmp_path / "async_output.mp3"
+    await tts_model.agenerate_speech(text="Hello", voice="alloy", output_file=output_file)
+    assert output_file.exists()
+    assert output_file.read_bytes() == b"mock audio data for testing"

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -307,3 +307,15 @@ class TestCreateSpeechToText:
             model_name="whisper-1",
             api_key="sk-test",
         )
+
+
+class TestOpenRouterAudioRegistration:
+    """Verify OpenRouter is registered for the audio modalities (issue #223)."""
+
+    def test_tts_registered(self):
+        cls = AIFactory._import_provider_class("text_to_speech", "openrouter")
+        assert cls.__name__ == "OpenRouterTextToSpeechModel"
+
+    def test_stt_registered(self):
+        cls = AIFactory._import_provider_class("speech_to_text", "openrouter")
+        assert cls.__name__ == "OpenRouterSpeechToTextModel"


### PR DESCRIPTION
Closes #223. Adds OpenRouter as a provider for the two remaining audio modalities (TTS + STT); LLM and embedding already exist.

## What's added
- **TTS** — `providers/tts/openrouter.py`, subclassing the OpenAI TTS provider against OpenRouter's OpenAI-compatible `POST /audio/speech`. Adds the required `HTTP-Referer`/`X-Title` headers, `OPENROUTER_API_KEY` / base-URL resolution, and real model discovery via `GET /models?output_modalities=speech`.
- **STT** — `providers/stt/openrouter.py`. See the note below — this endpoint is **not** OpenAI-multipart-compatible.
- Factory registration under `speech_to_text` and `text_to_speech`; both classes exported from the package root.
- Unit tests for both providers, factory-registration tests, real-API release tests (`-m release`), and provider docs.

## Two findings that differ from the issue's "mirror the OpenAI providers" pointer
Both verified against the live OpenRouter API:

1. **STT is not multipart-compatible.** OpenRouter's `POST /audio/transcriptions` takes a JSON body with base64 `input_audio` (`{data, format}`) and returns `{text, usage}`, unlike OpenAI's multipart file upload. The provider builds that request shape and maps `usage` into `TranscriptionUsage`. It still accepts a file path or a binary stream and returns the standard `TranscriptionResponse`. Segment-level timestamps aren't returned, so `segments` stays `None`; `prompt` isn't documented by OpenRouter, so it's accepted for interface parity but not sent.
2. **No OpenAI TTS model currently exists on OpenRouter** (`openai/*tts*` → "does not exist"), and dedicated TTS models are only listed under `?output_modalities=speech` (not the unfiltered `/models`). Voices are model-specific — the default `microsoft/mai-voice-2` uses Microsoft neural voice names (e.g. `en-US-AvaNeural`), not OpenAI's `alloy`/`nova`. `response_format` supports `mp3` (default) and `pcm` only.

The default model is `microsoft/mai-voice-2` for TTS and `openai/whisper-1` for STT.

## Verification
- `uv run pytest tests/providers tests/unit tests/common_types tests/test_deprecation_warnings.py` — full mocked scope passes; `ruff` and `mypy` clean.
- Real-API release tests (`-m release -k OpenRouter`) — **5 passed** (2 TTS + 3 STT) against the live API.

## Downstream
Open Notebook (lfnovo/open-notebook#987) then only needs `text_to_speech`/`speech_to_text` added to its OpenRouter modality mapping, once this ships in a release.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

