### PR TITLE
docs: provider notability bar + Novita doc consistency

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -169,6 +169,17 @@ Before implementing a new provider, ask yourself:
 
 When in doubt, open an issue. We'd rather discuss the design upfront than review a PR that doesn't align with these principles.
 
+### Provider Notability Bar
+
+Esperanto attracts provider-addition PRs, some primarily for the contributor's own visibility. We accept providers that are **real, operating services with a public API and demonstrable adoption** — not vanity listings, pre-launch products, or endpoints without a genuine user base. The bar scales with maintenance cost:
+
+- **Profile-based (OpenAI-compatible) providers** — a low bar. Cost is a few lines of config in `profiles.py` and no dedicated code path, so a working public OpenAI-compatible endpoint from a real company/service is enough. (This is how DeepSeek, xAI, DashScope, MiniMax, and Novita were added.)
+- **First-class provider classes** — a higher bar. These carry ongoing maintenance (custom request/response handling, provider-specific bugs, test surface), so they need meaningful adoption or a genuinely distinct API that many users need — not just novelty.
+
+When a provider's legitimacy isn't obvious, open an issue and link evidence (official docs, funding/company info, community usage) before implementing. This keeps the decision consistent and the provider list trustworthy rather than a directory of every endpoint that wanted a backlink.
+
+**Origin:** Recurring vanity-PR pattern surfaced during PR review, 2026-07-14.
+
 ## Architecture Overview
 
 ### Provider Pattern

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -109,6 +109,7 @@ Welcome to the Esperanto provider guide. This page helps you choose the right AI
 
 **Multiple Models Access:**
 - **[OpenRouter](./openrouter.md)**: 100+ models from various providers
+- **[Novita](./openai-compatible.md)**: 200+ open-source models (OpenAI-compatible profile)
 
 **Local Deployment:**
 - **[Ollama](./ollama.md)**: Llama, Mistral, Qwen, etc.
@@ -208,6 +209,7 @@ Welcome to the Esperanto provider guide. This page helps you choose the right AI
 | [xAI](./xai.md) | ✅ | ❌ | ✅ | 128K |
 | [DashScope](./dashscope.md) | ✅ | ✅ | ✅ | 1M (qwen-max-longcontext) |
 | [MiniMax](./minimax.md) | ✅ | ✅ | ✅ | 204K |
+| [Novita](./openai-compatible.md) | ✅ | ✅ | ✅ | Model-dependent |
 | [OpenRouter](./openrouter.md) | ✅ | ✅ | ✅ | Varies |
 | [Ollama](./ollama.md) | ✅ | ❌ | ✅ | Model-dependent |
 | [OpenAI-Compatible](./openai-compatible.md) | ✅ | ⚠️ | ⚠️ | Endpoint-dependent |


### PR DESCRIPTION
## Summary

Two small doc changes prompted by reviewing the recent wave of provider-addition PRs:

1. **Provider Notability Bar** (`ARCHITECTURE.md`) — codify when we accept a new provider, so the decision is consistent instead of case-by-case. We take real, operating services with a public API and demonstrable adoption; the bar scales with maintenance cost (low for OpenAI-compatible **profiles**, higher for **first-class** classes). This closes a recurring decision loop: several PRs add providers mainly for the contributor's own visibility, and we had no written criterion to point to.

2. **Novita doc consistency** (`docs/providers/README.md`) — Novita (merged in #120) was in the support matrix but missing from the LLM "Multiple Models Access" list and the "LLM Features" table. Added to both (the cubic P2 nit on #120).

Docs-only; no code paths touched, no CHANGELOG entry needed.

## Test plan

- [x] No code changes — docs and ARCHITECTURE only.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

