### PR TITLE
feat: extend OpenAI-compatible profiles to embedding, STT, and TTS

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -88,6 +88,26 @@ When a provider's native endpoint genuinely doesn't return the data required to 
 
 **Origin:** Issue #185, 2026-05-12.
 
+### Opt-In Capability Declaration
+
+Declarative provider config (profiles) must explicitly declare which modalities it supports, and the default is the narrowest useful set — never "everything the mechanism could technically reach." Where a declared capability collides with an existing first-class class for the same name+modality, the explicit declaration wins, but registration emits a warning so the shadowing is visible.
+
+**Why:** A declarative mechanism that auto-applies to every modality starts lying: extending profiles to embeddings would have made DeepSeek and xAI advertise themselves as embedding providers overnight, breaking the honesty of the provider matrix and error messages. Opt-in also makes hybrid providers work by construction — xAI is a profile for `language` and a first-class class for `text_to_speech`, and declaring only `{"language"}` keeps the TTS class intact with no precedence special-case. The registration warning keeps the legitimate override (pointing a profile at a proxy) available without letting ambiguity happen silently.
+
+**Scope:** Profiles and any future declarative config that spans modalities or components. Pairs with **Demand-Driven Abstraction Extension** — declare a capability when a real endpoint needs it, not because the mechanism allows it.
+
+**Origin:** Issue #230, 2026-07-17.
+
+### No Default Beats a Wrong Default
+
+When a provider genuinely has no meaningful default (a bring-your-own-models local server like oMLX or Ollama, where the served models are whatever the user loaded), do not fall back to a generic placeholder — raise a clear error naming the provider and asking for an explicit model.
+
+**Why:** This is the boundary of **Hot-Swap-First Defaults**, not a contradiction of it. That principle says to pick a default that *makes typical workloads succeed*. A default like `whisper-1` or `text-embedding-3-small` on a server that never heard of those models doesn't make anything succeed — it converts a clear configuration error into an opaque 404 from someone else's endpoint. The honest default is no default.
+
+**Scope:** Provider/profile default model resolution (`_get_default_model()`), and any default that can only be correct for some endpoints behind the same interface. Refines **Hot-Swap-First Defaults**: prefer a working default; where none can work, prefer an error over a plausible-looking wrong one.
+
+**Origin:** Issue #230, 2026-07-17.
+
 ## Provider Tiers
 
 Not all providers require the same level of implementation effort. We classify them into tiers:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Multi-modality OpenAI-compatible profiles** — a registered
+  `OpenAICompatibleProfile` can now serve `embedding`, `speech_to_text`, and
+  `text_to_speech` in addition to `language`, via a new opt-in `capabilities`
+  field (default: `{"language"}`) and per-modality `default_models`. The four
+  factories (`create_language`/`create_embedding`/`create_speech_to_text`/
+  `create_text_to_speech`) resolve profiles through one shared precedence chain
+  (`ProfileAwareMixin`). Requesting a modality a profile doesn't declare raises
+  the new typed `ProviderCapabilityError` (unless a first-class class of the same
+  name covers it — e.g. xAI is a `language` profile and a first-class TTS class,
+  which keeps working). A profile that declares a modality but sets no default
+  model raises a clear error rather than falling back to a placeholder the
+  endpoint has never heard of. New base exception `EsperantoError`
+  (`ProviderCapabilityError` extends it), seeding the normalized exception
+  hierarchy. (#230)
 - **Schema-driven structured outputs across all LLM providers** — set
   `config={"structured": {"type": "json_schema", "schema": MyPydanticModel}}`
   (or a JSON Schema dict) and read the parsed, validated result from
@@ -22,6 +36,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`stream=True` raises `ValueError`); providers/models that can't honor a
   `json_schema` request fail fast with a clear error rather than silently degrading.
   (#95)
+
+### Deprecated
+
+- **`OpenAICompatibleProfile(default_model=...)`** — use
+  `default_models={"language": ...}` instead. The old field still works as a
+  back-compat alias for the language default and now emits a `DeprecationWarning`.
+  (#230)
 
 ## [2.24.0] - 2026-06-23
 

--- a/docs/providers/openai-compatible.md
+++ b/docs/providers/openai-compatible.md
@@ -86,7 +86,7 @@ AIFactory.register_openai_compatible_profile(
         name="my-company",
         base_url="https://llm.internal.company.com/v1",
         api_key_env="MY_COMPANY_LLM_KEY",
-        default_model="llama-3-70b",
+        default_models={"language": "llama-3-70b"},
     )
 )
 
@@ -96,6 +96,47 @@ response = model.chat_complete(messages)
 ```
 
 Several OpenAI-compatible providers are already registered as built-in profiles: **DeepSeek**, **xAI**, **DashScope** (Qwen), **MiniMax**, and **Novita**. Use `AIFactory.create_language("novita", "moonshotai/kimi-k2.5")` with `NOVITA_API_KEY` for the built-in Novita profile.
+
+### Multi-Modality Profiles
+
+A profile serves **language only** by default. If your endpoint also exposes
+OpenAI-compatible embedding, speech-to-text, or text-to-speech, declare those
+modalities via `capabilities` and give each a default model in `default_models`:
+
+```python
+AIFactory.register_openai_compatible_profile(
+    OpenAICompatibleProfile(
+        name="my-gateway",
+        base_url="https://gateway.internal.company.com/v1",
+        api_key_env="MY_GATEWAY_KEY",
+        capabilities={"language", "embedding"},
+        default_models={
+            "language": "llama-3-70b",
+            "embedding": "bge-large-en",
+        },
+    )
+)
+
+llm = AIFactory.create_language("my-gateway", "llama-3-70b")
+emb = AIFactory.create_embedding("my-gateway")   # uses the embedding default
+```
+
+Notes:
+
+- **Opt-in.** Requesting a modality a profile doesn't declare raises
+  `ProviderCapabilityError` (e.g. `create_embedding("deepseek", ...)` — DeepSeek
+  is language-only). This keeps the provider matrix honest.
+- **Hybrid providers.** If a first-class class already exists for a name+modality
+  (e.g. xAI has a first-class TTS class), a language-only profile of the same
+  name leaves that class untouched — `create_text_to_speech("xai", ...)` still
+  uses the first-class implementation.
+- **No default → error, not a placeholder.** A profile that declares a modality
+  but sets no default in `default_models` requires the caller to pass a
+  `model_name`; otherwise a clear error is raised rather than a generic
+  placeholder the endpoint may not serve.
+- **Deprecation.** `default_model="..."` is deprecated in favor of
+  `default_models={"language": "..."}`; it still works as a language alias and
+  emits a `DeprecationWarning`.
 
 ## Quick Start
 

--- a/src/esperanto/__init__.py
+++ b/src/esperanto/__init__.py
@@ -4,7 +4,9 @@ This module exports all public components of the library.
 """
 
 from esperanto.common_types import (
+    EsperantoError,
     FunctionCall,
+    ProviderCapabilityError,
     Tool,
     ToolCall,
     ToolCallValidationError,
@@ -176,6 +178,9 @@ __all__ = [
     "validate_tool_call",
     "validate_tool_calls",
     "find_tool_by_name",
+    # Errors
+    "EsperantoError",
+    "ProviderCapabilityError",
     # Profiles
     "OpenAICompatibleProfile",
     # Provider classes

--- a/src/esperanto/common_types/__init__.py
+++ b/src/esperanto/common_types/__init__.py
@@ -1,6 +1,11 @@
 """Types module for Esperanto."""
 
-from .exceptions import StructuredOutputValidationError, ToolCallValidationError
+from .exceptions import (
+    EsperantoError,
+    ProviderCapabilityError,
+    StructuredOutputValidationError,
+    ToolCallValidationError,
+)
 from .model import Model
 from .reranker import RerankResponse, RerankResult
 from .response import (
@@ -35,6 +40,9 @@ __all__ = [
     "ToolFunction",
     "ToolCall",
     "FunctionCall",
+    # Errors
+    "EsperantoError",
+    "ProviderCapabilityError",
     # Validation
     "ToolCallValidationError",
     "StructuredOutputValidationError",

--- a/src/esperanto/common_types/exceptions.py
+++ b/src/esperanto/common_types/exceptions.py
@@ -3,6 +3,24 @@
 from typing import List
 
 
+class EsperantoError(Exception):
+    """Base class for all Esperanto-raised errors.
+
+    This is the root of Esperanto's normalized exception hierarchy. Catching
+    ``EsperantoError`` catches any error the library raises deliberately (as
+    opposed to a raw provider/SDK exception). More specific error types are
+    built on top of this root — see issue #227 for the full hierarchy.
+    """
+
+
+class ProviderCapabilityError(EsperantoError):
+    """Raised when a provider is asked for a modality it does not support.
+
+    For example, requesting an embedding model from an OpenAI-compatible profile
+    that only declares ``language`` support.
+    """
+
+
 class ToolCallValidationError(Exception):
     """Raised when tool call arguments fail JSON schema validation.
 

--- a/src/esperanto/factory.py
+++ b/src/esperanto/factory.py
@@ -136,16 +136,16 @@ class AIFactory:
             Dict[str, List[str]]: A dictionary where keys are model types (language, embedding, speech_to_text, text_to_speech)
                 and values are lists of available provider names.
         """
-        from esperanto.providers.llm.profiles import get_all_profile_names
+        from esperanto.providers.llm.profiles import get_profile_capabilities
 
         result = {
             model_type: list(providers.keys())
             for model_type, providers in cls._provider_modules.items()
         }
-        # Merge OpenAI-compatible profile names into language providers
-        result["language"] = sorted(
-            set(result.get("language", [])) | get_all_profile_names()
-        )
+        # Merge each profile into every modality it declares (language-only by default)
+        for name, modalities in get_profile_capabilities().items():
+            for modality in modalities:
+                result[modality] = sorted(set(result.get(modality, [])) | {name})
         return result
 
     @classmethod
@@ -171,6 +171,19 @@ class AIFactory:
             >>> model = AIFactory.create_language("together", "meta-llama/Llama-3-70b-chat-hf")
         """
         from esperanto.providers.llm.profiles import register_profile
+
+        # Warn when a declared capability shadows an existing first-class provider
+        # of the same name+modality. The profile wins (create_* checks profiles
+        # first), so surface the shadowing rather than let it happen silently.
+        normalized = profile.name.lower().replace("_", "-")
+        for modality in profile.capabilities:
+            if normalized in cls._provider_modules.get(modality, {}):
+                warnings.warn(
+                    f"Profile '{normalized}' declares capability '{modality}', "
+                    f"which shadows the existing first-class {modality} provider "
+                    f"of the same name. The profile will take precedence.",
+                    stacklevel=2,
+                )
 
         register_profile(profile)
 
@@ -268,6 +281,34 @@ class AIFactory:
         return models
 
     @classmethod
+    def _profile_for_modality(cls, normalized: str, modality: str):
+        """Resolve the profile to use for (provider, modality), or None.
+
+        Returns the profile when it declares ``modality`` (profile wins). Returns
+        None to fall through to the first-class class registry — either because no
+        profile exists, or because a profile exists for a different modality but a
+        first-class class covers this one (hybrid providers, e.g. xAI is a
+        language profile and a first-class TTS class). Raises
+        ``ProviderCapabilityError`` when a profile exists, does not declare this
+        modality, and no first-class class can serve it either.
+        """
+        from esperanto.common_types import ProviderCapabilityError
+        from esperanto.providers.llm.profiles import get_profile
+
+        profile = get_profile(normalized)
+        if profile is None:
+            return None
+        if modality in profile.capabilities:
+            return profile
+        if normalized in cls._provider_modules.get(modality, {}):
+            return None  # hybrid provider: fall through to the first-class class
+        display = profile.display_name or profile.name
+        raise ProviderCapabilityError(
+            f"Provider '{normalized}' ({display}) does not support {modality}. "
+            f"Declared capabilities: {sorted(profile.capabilities)}."
+        )
+
+    @classmethod
     def _create_instance(
         cls,
         service_type: str,
@@ -293,11 +334,8 @@ class AIFactory:
         Returns:
             Language model instance
         """
-        from esperanto.providers.llm.profiles import get_profile
-
         normalized = provider.lower().replace("_", "-")
-        profile = get_profile(normalized)
-        if profile:
+        if cls._profile_for_modality(normalized, "language"):
             from esperanto.providers.llm.openai_compatible import (
                 OpenAICompatibleLanguageModel,
             )
@@ -325,6 +363,18 @@ class AIFactory:
         Returns:
             Embedding model instance
         """
+        normalized = provider.lower().replace("_", "-")
+        if cls._profile_for_modality(normalized, "embedding"):
+            from esperanto.providers.embedding.openai_compatible import (
+                OpenAICompatibleEmbeddingModel,
+            )
+
+            merged_config = dict(config or {})
+            merged_config["_profile_name"] = normalized
+            return OpenAICompatibleEmbeddingModel(
+                model_name=model_name, config=merged_config
+            )
+
         provider_class = cls._import_provider_class("embedding", provider)
         return provider_class(model_name=model_name, config=config or {})
 
@@ -363,6 +413,18 @@ class AIFactory:
             Speech-to-text model instance
         """
         config = config or {}
+        normalized = provider.lower().replace("_", "-")
+        if cls._profile_for_modality(normalized, "speech_to_text"):
+            from esperanto.providers.stt.openai_compatible import (
+                OpenAICompatibleSpeechToTextModel,
+            )
+
+            merged_config = dict(config)
+            merged_config["_profile_name"] = normalized
+            return OpenAICompatibleSpeechToTextModel(
+                model_name=model_name, config=merged_config
+            )
+
         return cls._create_instance(
             "speech_to_text", provider, model_name=model_name, **config
         )
@@ -413,6 +475,17 @@ class AIFactory:
                 stacklevel=2,
             )
             config["base_url"] = base_url
+
+        normalized = provider.lower().replace("_", "-")
+        if cls._profile_for_modality(normalized, "text_to_speech"):
+            from esperanto.providers.tts.openai_compatible import (
+                OpenAICompatibleTextToSpeechModel,
+            )
+
+            merged_config = {**config, **kwargs, "_profile_name": normalized}
+            return OpenAICompatibleTextToSpeechModel(
+                model_name=model_name, config=merged_config
+            )
 
         return cls._create_instance(
             "text_to_speech", provider, model_name=model_name, **config, **kwargs

--- a/src/esperanto/factory.py
+++ b/src/esperanto/factory.py
@@ -165,7 +165,7 @@ class AIFactory:
             ...         name="together",
             ...         base_url="https://api.together.xyz/v1",
             ...         api_key_env="TOGETHER_API_KEY",
-            ...         default_model="meta-llama/Llama-3-70b-chat-hf",
+            ...         default_models={"language": "meta-llama/Llama-3-70b-chat-hf"},
             ...     )
             ... )
             >>> model = AIFactory.create_language("together", "meta-llama/Llama-3-70b-chat-hf")

--- a/src/esperanto/providers/embedding/openai_compatible.py
+++ b/src/esperanto/providers/embedding/openai_compatible.py
@@ -57,7 +57,9 @@ class OpenAICompatibleEmbeddingModel(ProfileAwareMixin, EmbeddingModel):
 
         # Resolve provider profile (None when not profile-driven) and configuration
         # via the shared precedence chain (ProfileAwareMixin).
-        self._profile: Optional[OpenAICompatibleProfile] = self._resolve_profile(config)
+        self._profile: Optional[OpenAICompatibleProfile] = self._resolve_profile(
+            config, "embedding"
+        )
         self.base_url = self._resolve_base_url(
             "embedding", self._profile, base_url, config
         )
@@ -190,7 +192,9 @@ class OpenAICompatibleEmbeddingModel(ProfileAwareMixin, EmbeddingModel):
 
     @property
     def provider(self) -> str:
-        """Get the provider name."""
+        """Get the provider name (the profile name when profile-driven)."""
+        if self._profile is not None:
+            return self._profile.name
         return "openai-compatible"
 
     def embed(self, texts: List[str], **kwargs) -> List[List[float]]:

--- a/src/esperanto/providers/embedding/openai_compatible.py
+++ b/src/esperanto/providers/embedding/openai_compatible.py
@@ -1,18 +1,19 @@
 """OpenAI-compatible Embedding provider implementation."""
 
-import os
 from typing import Any, Dict, List, Optional
 
 import httpx
 
 from esperanto.common_types import Model
+from esperanto.providers.llm.profiles import OpenAICompatibleProfile
+from esperanto.providers.profile_mixin import ProfileAwareMixin
 from esperanto.utils import validate_and_decode_embedding
 from esperanto.utils.logging import logger
 
 from .base import EmbeddingModel
 
 
-class OpenAICompatibleEmbeddingModel(EmbeddingModel):
+class OpenAICompatibleEmbeddingModel(ProfileAwareMixin, EmbeddingModel):
     """OpenAI-compatible Embedding provider implementation for custom endpoints.
 
     This provider extends OpenAI's embedding implementation to work with any OpenAI-compatible
@@ -54,32 +55,40 @@ class OpenAICompatibleEmbeddingModel(EmbeddingModel):
         config = config or {}
         config.update(kwargs)
 
-        # Configuration precedence: Direct params > config > Environment variables
-        self.base_url = (
-            base_url
-            or config.get("base_url")
-            or os.getenv("OPENAI_COMPATIBLE_BASE_URL_EMBEDDING")
-            or os.getenv("OPENAI_COMPATIBLE_BASE_URL")
+        # Resolve provider profile (None when not profile-driven) and configuration
+        # via the shared precedence chain (ProfileAwareMixin).
+        self._profile: Optional[OpenAICompatibleProfile] = self._resolve_profile(config)
+        self.base_url = self._resolve_base_url(
+            "embedding", self._profile, base_url, config
+        )
+        self.api_key = self._resolve_api_key(
+            "embedding", self._profile, api_key, config
         )
 
-        self.api_key = (
-            api_key
-            or config.get("api_key")
-            or os.getenv("OPENAI_COMPATIBLE_API_KEY_EMBEDDING")
-            or os.getenv("OPENAI_COMPATIBLE_API_KEY")
-        )
-
-        # Validation
-        if not self.base_url:
-            raise ValueError(
-                "OpenAI-compatible base URL is required. "
-                "Set OPENAI_COMPATIBLE_BASE_URL_EMBEDDING or OPENAI_COMPATIBLE_BASE_URL "
-                "environment variable or provide base_url in config."
-            )
-
-        # Use a default API key if none is provided (some endpoints don't require authentication)
-        if not self.api_key:
-            self.api_key = "not-required"
+        if self._profile:
+            display = self._profile.display_name or self._profile.name.title()
+            if not self.base_url:
+                raise ValueError(
+                    f"{display} base URL is not configured. "
+                    f"Provide base_url in config or check the profile configuration."
+                )
+            if not self.api_key:
+                raise ValueError(
+                    f"{display} API key not found. "
+                    f"Set {self._profile.api_key_env} environment variable "
+                    f"or provide api_key in config."
+                )
+        else:
+            # Validation
+            if not self.base_url:
+                raise ValueError(
+                    "OpenAI-compatible base URL is required. "
+                    "Set OPENAI_COMPATIBLE_BASE_URL_EMBEDDING or OPENAI_COMPATIBLE_BASE_URL "
+                    "environment variable or provide base_url in config."
+                )
+            # Use a default API key if none is provided (some endpoints don't require authentication)
+            if not self.api_key:
+                self.api_key = "not-required"
 
         # Ensure base_url doesn't end with trailing slash for consistency
         if self.base_url.endswith("/"):
@@ -88,11 +97,11 @@ class OpenAICompatibleEmbeddingModel(EmbeddingModel):
         # Get timeout configuration (default to 120 seconds for embedding operations)
         self.timeout = config.get("timeout", 120.0)
 
-        # Remove base_url, api_key, and timeout from config to avoid duplication
+        # Remove base_url, api_key, timeout, and profile marker from config to avoid duplication
         clean_config = {
             k: v
             for k, v in config.items()
-            if k not in ["base_url", "api_key", "timeout"]
+            if k not in ["base_url", "api_key", "timeout", "_profile_name"]
         }
 
         # Initialize attributes for dataclass
@@ -172,10 +181,12 @@ class OpenAICompatibleEmbeddingModel(EmbeddingModel):
     def _get_default_model(self) -> str:
         """Get the default model name.
 
-        For OpenAI-compatible endpoints, we use a generic default
-        that users should override with their specific model.
+        Returns the profile's embedding default if a profile is active,
+        otherwise a generic default users should override.
         """
-        return "text-embedding-3-small"
+        return self._resolve_default_model(
+            "embedding", getattr(self, "_profile", None), "text-embedding-3-small"
+        )
 
     @property
     def provider(self) -> str:

--- a/src/esperanto/providers/llm/openai_compatible.py
+++ b/src/esperanto/providers/llm/openai_compatible.py
@@ -54,7 +54,7 @@ class OpenAICompatibleLanguageModel(ProfileAwareMixin, OpenAILanguageModel):
         # Resolve provider profile (None when not profile-driven) and configuration
         # via the shared precedence chain (ProfileAwareMixin).
         self._profile: Optional[OpenAICompatibleProfile] = self._resolve_profile(
-            self._config
+            self._config, "language"
         )
         self.base_url = self._resolve_base_url(
             "language", self._profile, self.base_url, self._config

--- a/src/esperanto/providers/llm/openai_compatible.py
+++ b/src/esperanto/providers/llm/openai_compatible.py
@@ -1,6 +1,5 @@
 """OpenAI-compatible language model implementation."""
 
-import os
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
@@ -18,13 +17,14 @@ from esperanto.common_types.validation import (
     validate_tool_calls as _validate_tool_calls,
 )
 from esperanto.providers.llm.openai import OpenAILanguageModel
-from esperanto.providers.llm.profiles import OpenAICompatibleProfile, get_profile
+from esperanto.providers.llm.profiles import OpenAICompatibleProfile
 from esperanto.providers.llm.structured_output import (
     ResolvedStructuredOutput,
     apply_structured_output,
     is_json_schema_unsupported_error,
     resolve_structured_output,
 )
+from esperanto.providers.profile_mixin import ProfileAwareMixin
 from esperanto.utils.logging import logger
 
 if TYPE_CHECKING:
@@ -35,7 +35,7 @@ _JSON_OBJECT_RESPONSE_FORMAT_ERROR = "'response_format.type' must be 'json_schem
 
 
 @dataclass
-class OpenAICompatibleLanguageModel(OpenAILanguageModel):
+class OpenAICompatibleLanguageModel(ProfileAwareMixin, OpenAILanguageModel):
     """OpenAI-compatible language model implementation for custom endpoints."""
 
     base_url: Optional[str] = None
@@ -51,28 +51,19 @@ class OpenAICompatibleLanguageModel(OpenAILanguageModel):
         if hasattr(self, "config") and self.config:
             self._config.update(self.config)
 
-        # Resolve provider profile if configured
-        profile_name = self._config.get("_profile_name")
-        self._profile: Optional[OpenAICompatibleProfile] = None
-        if profile_name:
-            self._profile = get_profile(profile_name)
-            if not self._profile:
-                raise ValueError(f"Unknown provider profile: '{profile_name}'")
+        # Resolve provider profile (None when not profile-driven) and configuration
+        # via the shared precedence chain (ProfileAwareMixin).
+        self._profile: Optional[OpenAICompatibleProfile] = self._resolve_profile(
+            self._config
+        )
+        self.base_url = self._resolve_base_url(
+            "language", self._profile, self.base_url, self._config
+        )
+        self.api_key = self._resolve_api_key(
+            "language", self._profile, self.api_key, self._config
+        )
 
         if self._profile:
-            # Profile-aware configuration precedence:
-            # explicit param > config dict > profile env var > profile default
-            self.base_url = (
-                self.base_url or
-                self._config.get("base_url") or
-                os.getenv(self._profile.base_url_env or "") or
-                self._profile.base_url
-            )
-            self.api_key = (
-                self.api_key or
-                self._config.get("api_key") or
-                os.getenv(self._profile.api_key_env)
-            )
             display = self._profile.display_name or self._profile.name.title()
             if not self.base_url:
                 raise ValueError(
@@ -86,20 +77,6 @@ class OpenAICompatibleLanguageModel(OpenAILanguageModel):
                     f"or provide api_key in config."
                 )
         else:
-            # Standard OpenAI-compatible configuration precedence
-            self.base_url = (
-                self.base_url or
-                self._config.get("base_url") or
-                os.getenv("OPENAI_COMPATIBLE_BASE_URL_LLM") or
-                os.getenv("OPENAI_COMPATIBLE_BASE_URL")
-            )
-            self.api_key = (
-                self.api_key or
-                self._config.get("api_key") or
-                os.getenv("OPENAI_COMPATIBLE_API_KEY_LLM") or
-                os.getenv("OPENAI_COMPATIBLE_API_KEY")
-            )
-
             # Validation
             if not self.base_url:
                 raise ValueError(
@@ -727,12 +704,10 @@ class OpenAICompatibleLanguageModel(OpenAILanguageModel):
     def _get_default_model(self) -> str:
         """Get the default model name.
 
-        Returns the profile's default_model if a profile is active,
+        Returns the profile's language default if a profile is active,
         otherwise a generic default.
         """
-        if self._profile:
-            return self._profile.default_model
-        return "gpt-3.5-turbo"
+        return self._resolve_default_model("language", self._profile, "gpt-3.5-turbo")
 
     @property
     def provider(self) -> str:

--- a/src/esperanto/providers/llm/profiles.py
+++ b/src/esperanto/providers/llm/profiles.py
@@ -2,10 +2,13 @@
 
 import warnings
 from dataclasses import dataclass, field
-from typing import Dict, Literal, Optional, Set
+from types import MappingProxyType
+from typing import Dict, Literal, Optional, Set, get_args
 
 Modality = Literal["language", "embedding", "speech_to_text", "text_to_speech"]
 """The modalities a profile can declare support for."""
+
+_VALID_MODALITIES: Set[str] = set(get_args(Modality))
 
 
 @dataclass(frozen=True)
@@ -45,6 +48,11 @@ class OpenAICompatibleProfile:
     api_key_env: str
     """Environment variable name for the API key (e.g., 'DEEPSEEK_API_KEY')."""
 
+    default_model: Optional[str] = None
+    """Deprecated. Back-compat alias for ``default_models['language']``. Kept in
+    its original positional slot so existing positional construction still binds
+    here. Passing this emits a DeprecationWarning; use ``default_models`` instead."""
+
     capabilities: Set[Modality] = field(default_factory=lambda: {"language"})
     """Modalities this profile serves. Defaults to language-only."""
 
@@ -52,10 +60,6 @@ class OpenAICompatibleProfile:
     """Default model per modality when the caller passes none. A modality with
     no entry has no default — the caller must pass a model name or a clear error
     is raised (never a generic placeholder)."""
-
-    default_model: Optional[str] = None
-    """Deprecated. Back-compat alias for ``default_models['language']``. Passing
-    this emits a DeprecationWarning; use ``default_models`` instead."""
 
     base_url_env: Optional[str] = None
     """Optional environment variable for base URL override."""
@@ -73,8 +77,17 @@ class OpenAICompatibleProfile:
     """Human-readable name for error messages (e.g., 'DeepSeek'). Defaults to name."""
 
     def __post_init__(self) -> None:
+        # Validate declared capabilities against the known modalities, so a typo
+        # can't leak an invalid category into get_available_providers().
+        invalid = sorted(c for c in self.capabilities if c not in _VALID_MODALITIES)
+        if invalid:
+            raise ValueError(
+                f"Unknown profile capabilities {invalid}; "
+                f"valid modalities are {sorted(_VALID_MODALITIES)}."
+            )
+
         # Fold the deprecated ``default_model`` into ``default_models['language']``.
-        # Frozen dataclass → mutate via object.__setattr__.
+        models = dict(self.default_models)
         if self.default_model is not None:
             warnings.warn(
                 "OpenAICompatibleProfile(default_model=...) is deprecated; "
@@ -82,10 +95,14 @@ class OpenAICompatibleProfile:
                 DeprecationWarning,
                 stacklevel=3,
             )
-            if "language" not in self.default_models:
-                merged = dict(self.default_models)
-                merged["language"] = self.default_model
-                object.__setattr__(self, "default_models", merged)
+            models.setdefault("language", self.default_model)
+
+        # Freeze the mutable collections. The dataclass is frozen (no rebinding),
+        # but a Set/Dict field is still mutable in place — and built-in profiles
+        # are shared global state, so a stray .add()/[...]= could drift behavior
+        # for every caller. Store immutable copies instead.
+        object.__setattr__(self, "capabilities", frozenset(self.capabilities))
+        object.__setattr__(self, "default_models", MappingProxyType(models))
 
     def default_model_for(self, modality: Modality) -> Optional[str]:
         """Return the default model for a modality, or None if none is set."""

--- a/src/esperanto/providers/llm/profiles.py
+++ b/src/esperanto/providers/llm/profiles.py
@@ -1,7 +1,11 @@
 """OpenAI-compatible provider profiles for config-driven virtual providers."""
 
-from dataclasses import dataclass
-from typing import Dict, Optional, Set
+import warnings
+from dataclasses import dataclass, field
+from typing import Dict, Literal, Optional, Set
+
+Modality = Literal["language", "embedding", "speech_to_text", "text_to_speech"]
+"""The modalities a profile can declare support for."""
 
 
 @dataclass(frozen=True)
@@ -9,8 +13,13 @@ class OpenAICompatibleProfile:
     """Declarative configuration for an OpenAI-compatible provider.
 
     Instead of creating a new Python class for each OpenAI-compatible endpoint,
-    define a profile and register it. The factory will create an
-    OpenAICompatibleLanguageModel configured by the profile.
+    define a profile and register it. The factory creates the appropriate
+    ``OpenAICompatible*Model`` for each modality the profile declares.
+
+    A profile only serves the modalities listed in ``capabilities`` (default:
+    ``{"language"}``). Requesting a modality the profile does not declare raises
+    ``ProviderCapabilityError``. This keeps the provider matrix honest — a
+    chat-only endpoint never advertises itself as an embedding provider.
 
     Example:
         >>> from esperanto import AIFactory
@@ -21,7 +30,7 @@ class OpenAICompatibleProfile:
         ...         name="together",
         ...         base_url="https://api.together.xyz/v1",
         ...         api_key_env="TOGETHER_API_KEY",
-        ...         default_model="meta-llama/Llama-3-70b-chat-hf",
+        ...         default_models={"language": "meta-llama/Llama-3-70b-chat-hf"},
         ...     )
         ... )
         >>> model = AIFactory.create_language("together", "meta-llama/Llama-3-70b-chat-hf")
@@ -36,8 +45,17 @@ class OpenAICompatibleProfile:
     api_key_env: str
     """Environment variable name for the API key (e.g., 'DEEPSEEK_API_KEY')."""
 
-    default_model: str
-    """Default model name when none is specified."""
+    capabilities: Set[Modality] = field(default_factory=lambda: {"language"})
+    """Modalities this profile serves. Defaults to language-only."""
+
+    default_models: Dict[Modality, str] = field(default_factory=dict)
+    """Default model per modality when the caller passes none. A modality with
+    no entry has no default — the caller must pass a model name or a clear error
+    is raised (never a generic placeholder)."""
+
+    default_model: Optional[str] = None
+    """Deprecated. Back-compat alias for ``default_models['language']``. Passing
+    this emits a DeprecationWarning; use ``default_models`` instead."""
 
     base_url_env: Optional[str] = None
     """Optional environment variable for base URL override."""
@@ -54,6 +72,25 @@ class OpenAICompatibleProfile:
     display_name: Optional[str] = None
     """Human-readable name for error messages (e.g., 'DeepSeek'). Defaults to name."""
 
+    def __post_init__(self) -> None:
+        # Fold the deprecated ``default_model`` into ``default_models['language']``.
+        # Frozen dataclass → mutate via object.__setattr__.
+        if self.default_model is not None:
+            warnings.warn(
+                "OpenAICompatibleProfile(default_model=...) is deprecated; "
+                'use default_models={"language": ...} instead.',
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            if "language" not in self.default_models:
+                merged = dict(self.default_models)
+                merged["language"] = self.default_model
+                object.__setattr__(self, "default_models", merged)
+
+    def default_model_for(self, modality: Modality) -> Optional[str]:
+        """Return the default model for a modality, or None if none is set."""
+        return self.default_models.get(modality)
+
 
 BUILTIN_PROFILES: Dict[str, OpenAICompatibleProfile] = {
     "deepseek": OpenAICompatibleProfile(
@@ -61,7 +98,7 @@ BUILTIN_PROFILES: Dict[str, OpenAICompatibleProfile] = {
         base_url="https://api.deepseek.com/v1",
         api_key_env="DEEPSEEK_API_KEY",
         base_url_env="DEEPSEEK_BASE_URL",
-        default_model="deepseek-chat",
+        default_models={"language": "deepseek-chat"},
         owned_by="DeepSeek",
         display_name="DeepSeek",
     ),
@@ -70,7 +107,7 @@ BUILTIN_PROFILES: Dict[str, OpenAICompatibleProfile] = {
         base_url="https://api.x.ai/v1",
         api_key_env="XAI_API_KEY",
         base_url_env="XAI_BASE_URL",
-        default_model="grok-2-latest",
+        default_models={"language": "grok-2-latest"},
         supports_response_format=False,
         model_prefix_filter="grok",
         owned_by="X.AI",
@@ -81,7 +118,7 @@ BUILTIN_PROFILES: Dict[str, OpenAICompatibleProfile] = {
         base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
         api_key_env="DASHSCOPE_API_KEY",
         base_url_env="DASHSCOPE_BASE_URL",
-        default_model="qwen-plus",
+        default_models={"language": "qwen-plus"},
         owned_by="Alibaba Cloud",
         display_name="DashScope",
     ),
@@ -90,7 +127,7 @@ BUILTIN_PROFILES: Dict[str, OpenAICompatibleProfile] = {
         base_url="https://api.minimax.io/v1",
         api_key_env="MINIMAX_API_KEY",
         base_url_env="MINIMAX_BASE_URL",
-        default_model="MiniMax-M2.5",
+        default_models={"language": "MiniMax-M2.5"},
         owned_by="MiniMax",
         display_name="MiniMax",
     ),
@@ -99,7 +136,7 @@ BUILTIN_PROFILES: Dict[str, OpenAICompatibleProfile] = {
         base_url="https://api.novita.ai/openai",
         api_key_env="NOVITA_API_KEY",
         base_url_env="NOVITA_BASE_URL",
-        default_model="moonshotai/kimi-k2.5",
+        default_models={"language": "moonshotai/kimi-k2.5"},
         owned_by="Novita",
         display_name="Novita",
     ),
@@ -126,3 +163,12 @@ def register_profile(profile: OpenAICompatibleProfile) -> None:
 def get_all_profile_names() -> Set[str]:
     """Return the combined set of builtin and user profile names."""
     return set(BUILTIN_PROFILES.keys()) | set(_USER_PROFILES.keys())
+
+
+def get_profile_capabilities() -> Dict[str, Set[Modality]]:
+    """Map every known profile name to its declared capabilities.
+
+    User profiles take precedence over builtins of the same name.
+    """
+    merged: Dict[str, OpenAICompatibleProfile] = {**BUILTIN_PROFILES, **_USER_PROFILES}
+    return {name: set(profile.capabilities) for name, profile in merged.items()}

--- a/src/esperanto/providers/profile_mixin.py
+++ b/src/esperanto/providers/profile_mixin.py
@@ -35,15 +35,29 @@ class ProfileAwareMixin:
     """
 
     def _resolve_profile(
-        self, config: Dict[str, Any]
+        self, config: Dict[str, Any], modality: Modality
     ) -> Optional[OpenAICompatibleProfile]:
-        """Look up the active profile from config, or None if not profile-driven."""
+        """Look up the active profile from config, or None if not profile-driven.
+
+        Enforces the modality capability at the construction boundary too, not
+        just in the factory — so directly constructing a modality adapter with a
+        profile that doesn't declare that modality fails fast rather than reaching
+        the wrong endpoint.
+        """
         profile_name = config.get("_profile_name")
         if not profile_name:
             return None
         profile = get_profile(profile_name)
         if not profile:
             raise ValueError(f"Unknown provider profile: '{profile_name}'")
+        if modality not in profile.capabilities:
+            from esperanto.common_types import ProviderCapabilityError
+
+            display = profile.display_name or profile.name
+            raise ProviderCapabilityError(
+                f"Provider '{profile.name}' ({display}) does not support {modality}. "
+                f"Declared capabilities: {sorted(profile.capabilities)}."
+            )
         return profile
 
     def _resolve_base_url(

--- a/src/esperanto/providers/profile_mixin.py
+++ b/src/esperanto/providers/profile_mixin.py
@@ -1,0 +1,110 @@
+"""Shared OpenAI-compatible profile resolution across all modalities.
+
+The four ``OpenAICompatible*Model`` classes (language, embedding, STT, TTS) each
+need to resolve ``base_url`` / ``api_key`` / default model from the same
+precedence chain, optionally driven by a registered provider profile. Keeping
+that chain in one place is the whole point of issue #230 — a copy per modality
+is exactly the kind of silent divergence this feature exists to remove.
+"""
+
+import os
+from typing import Any, Dict, Optional
+
+from esperanto.providers.llm.profiles import (
+    Modality,
+    OpenAICompatibleProfile,
+    get_profile,
+)
+
+# Modality -> suffix used in the generic OPENAI_COMPATIBLE_* env vars.
+_ENV_SUFFIX: Dict[str, str] = {
+    "language": "LLM",
+    "embedding": "EMBEDDING",
+    "speech_to_text": "STT",
+    "text_to_speech": "TTS",
+}
+
+
+class ProfileAwareMixin:
+    """Resolves configuration for OpenAI-compatible providers, profile-aware.
+
+    When a profile is active (``config['_profile_name']`` set), configuration
+    flows from the profile; otherwise it flows from the generic
+    ``OPENAI_COMPATIBLE_*`` env vars. Either way the precedence order is:
+    explicit param > config dict > env var > profile/hardcoded default.
+    """
+
+    def _resolve_profile(
+        self, config: Dict[str, Any]
+    ) -> Optional[OpenAICompatibleProfile]:
+        """Look up the active profile from config, or None if not profile-driven."""
+        profile_name = config.get("_profile_name")
+        if not profile_name:
+            return None
+        profile = get_profile(profile_name)
+        if not profile:
+            raise ValueError(f"Unknown provider profile: '{profile_name}'")
+        return profile
+
+    def _resolve_base_url(
+        self,
+        modality: Modality,
+        profile: Optional[OpenAICompatibleProfile],
+        explicit: Optional[str],
+        config: Dict[str, Any],
+    ) -> Optional[str]:
+        if profile:
+            return (
+                explicit
+                or config.get("base_url")
+                or os.getenv(profile.base_url_env or "")
+                or profile.base_url
+            )
+        suffix = _ENV_SUFFIX[modality]
+        return (
+            explicit
+            or config.get("base_url")
+            or os.getenv(f"OPENAI_COMPATIBLE_BASE_URL_{suffix}")
+            or os.getenv("OPENAI_COMPATIBLE_BASE_URL")
+        )
+
+    def _resolve_api_key(
+        self,
+        modality: Modality,
+        profile: Optional[OpenAICompatibleProfile],
+        explicit: Optional[str],
+        config: Dict[str, Any],
+    ) -> Optional[str]:
+        if profile:
+            return explicit or config.get("api_key") or os.getenv(profile.api_key_env)
+        suffix = _ENV_SUFFIX[modality]
+        return (
+            explicit
+            or config.get("api_key")
+            or os.getenv(f"OPENAI_COMPATIBLE_API_KEY_{suffix}")
+            or os.getenv("OPENAI_COMPATIBLE_API_KEY")
+        )
+
+    def _resolve_default_model(
+        self,
+        modality: Modality,
+        profile: Optional[OpenAICompatibleProfile],
+        generic_default: str,
+    ) -> str:
+        """Return the default model for this modality.
+
+        With no profile, fall back to the endpoint-generic default. With a
+        profile that declares this modality but sets no default (a
+        bring-your-own-models server), raise rather than return a placeholder
+        the endpoint has never heard of — no default beats a wrong default.
+        """
+        if profile is None:
+            return generic_default
+        model = profile.default_model_for(modality)
+        if model:
+            return model
+        display = profile.display_name or profile.name
+        raise ValueError(
+            f"{display} profile declares '{modality}' but sets no default model. "
+            f"Pass model_name explicitly."
+        )

--- a/src/esperanto/providers/stt/openai_compatible.py
+++ b/src/esperanto/providers/stt/openai_compatible.py
@@ -62,7 +62,9 @@ class OpenAICompatibleSpeechToTextModel(ProfileAwareMixin, SpeechToTextModel):
 
         # Resolve provider profile (None when not profile-driven) and configuration
         # via the shared precedence chain (ProfileAwareMixin).
-        self._profile: Optional[OpenAICompatibleProfile] = self._resolve_profile(config)
+        self._profile: Optional[OpenAICompatibleProfile] = self._resolve_profile(
+            config, "speech_to_text"
+        )
         self.base_url = self._resolve_base_url(
             "speech_to_text", self._profile, base_url, config
         )
@@ -187,7 +189,9 @@ class OpenAICompatibleSpeechToTextModel(ProfileAwareMixin, SpeechToTextModel):
 
     @property
     def provider(self) -> str:
-        """Get the provider name."""
+        """Get the provider name (the profile name when profile-driven)."""
+        if self._profile is not None:
+            return self._profile.name
         return "openai-compatible"
 
     def _get_api_kwargs(

--- a/src/esperanto/providers/stt/openai_compatible.py
+++ b/src/esperanto/providers/stt/openai_compatible.py
@@ -1,19 +1,20 @@
 """OpenAI-compatible Speech-to-Text provider implementation."""
 
 import mimetypes
-import os
 from pathlib import Path
 from typing import Any, BinaryIO, Dict, List, Optional, Union
 
 import httpx
 
 from esperanto.common_types import Model, TranscriptionResponse
+from esperanto.providers.llm.profiles import OpenAICompatibleProfile
+from esperanto.providers.profile_mixin import ProfileAwareMixin
 from esperanto.utils.logging import logger
 
 from .base import SpeechToTextModel
 
 
-class OpenAICompatibleSpeechToTextModel(SpeechToTextModel):
+class OpenAICompatibleSpeechToTextModel(ProfileAwareMixin, SpeechToTextModel):
     """OpenAI-compatible Speech-to-Text provider implementation for custom endpoints.
 
     This provider extends OpenAI's STT implementation to work with any OpenAI-compatible
@@ -59,32 +60,40 @@ class OpenAICompatibleSpeechToTextModel(SpeechToTextModel):
         config = config or {}
         config.update(kwargs)
 
-        # Configuration precedence: Direct params > config > Environment variables
-        self.base_url = (
-            base_url or
-            config.get("base_url") or
-            os.getenv("OPENAI_COMPATIBLE_BASE_URL_STT") or
-            os.getenv("OPENAI_COMPATIBLE_BASE_URL")
+        # Resolve provider profile (None when not profile-driven) and configuration
+        # via the shared precedence chain (ProfileAwareMixin).
+        self._profile: Optional[OpenAICompatibleProfile] = self._resolve_profile(config)
+        self.base_url = self._resolve_base_url(
+            "speech_to_text", self._profile, base_url, config
+        )
+        self.api_key = self._resolve_api_key(
+            "speech_to_text", self._profile, api_key, config
         )
 
-        self.api_key = (
-            api_key or
-            config.get("api_key") or
-            os.getenv("OPENAI_COMPATIBLE_API_KEY_STT") or
-            os.getenv("OPENAI_COMPATIBLE_API_KEY")
-        )
-
-        # Validation
-        if not self.base_url:
-            raise ValueError(
-                "OpenAI-compatible base URL is required. "
-                "Set OPENAI_COMPATIBLE_BASE_URL_STT or OPENAI_COMPATIBLE_BASE_URL "
-                "environment variable or provide base_url in config."
-            )
-
-        # Use a default API key if none is provided (some endpoints don't require authentication)
-        if not self.api_key:
-            self.api_key = "not-required"
+        if self._profile:
+            display = self._profile.display_name or self._profile.name.title()
+            if not self.base_url:
+                raise ValueError(
+                    f"{display} base URL is not configured. "
+                    f"Provide base_url in config or check the profile configuration."
+                )
+            if not self.api_key:
+                raise ValueError(
+                    f"{display} API key not found. "
+                    f"Set {self._profile.api_key_env} environment variable "
+                    f"or provide api_key in config."
+                )
+        else:
+            # Validation
+            if not self.base_url:
+                raise ValueError(
+                    "OpenAI-compatible base URL is required. "
+                    "Set OPENAI_COMPATIBLE_BASE_URL_STT or OPENAI_COMPATIBLE_BASE_URL "
+                    "environment variable or provide base_url in config."
+                )
+            # Use a default API key if none is provided (some endpoints don't require authentication)
+            if not self.api_key:
+                self.api_key = "not-required"
 
         # Ensure base_url doesn't end with trailing slash for consistency
         if self.base_url.endswith("/"):
@@ -93,8 +102,8 @@ class OpenAICompatibleSpeechToTextModel(SpeechToTextModel):
         # Get timeout configuration (default to 300 seconds for STT operations)
         self.timeout = config.get("timeout", 300.0)
 
-        # Remove base_url, api_key, and timeout from config to avoid duplication
-        clean_config = {k: v for k, v in config.items() if k not in ['base_url', 'api_key', 'timeout']}
+        # Remove base_url, api_key, timeout, and profile marker from config to avoid duplication
+        clean_config = {k: v for k, v in config.items() if k not in ['base_url', 'api_key', 'timeout', '_profile_name']}
 
         # Initialize attributes for dataclass
         self.model_name = model_name or self._get_default_model()
@@ -169,10 +178,12 @@ class OpenAICompatibleSpeechToTextModel(SpeechToTextModel):
     def _get_default_model(self) -> str:
         """Get the default model name.
 
-        For OpenAI-compatible endpoints, we use a generic default
-        that users should override with their specific model.
+        Returns the profile's STT default if a profile is active,
+        otherwise a generic default users should override.
         """
-        return "whisper-1"
+        return self._resolve_default_model(
+            "speech_to_text", getattr(self, "_profile", None), "whisper-1"
+        )
 
     @property
     def provider(self) -> str:

--- a/src/esperanto/providers/tts/openai_compatible.py
+++ b/src/esperanto/providers/tts/openai_compatible.py
@@ -1,17 +1,18 @@
 """OpenAI-compatible Text-to-Speech provider implementation."""
 
-import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from esperanto.common_types import Model
+from esperanto.providers.llm.profiles import OpenAICompatibleProfile
+from esperanto.providers.profile_mixin import ProfileAwareMixin
 from esperanto.utils.logging import logger
 
 from .base import AudioResponse, Voice
 from .openai import RESPONSE_FORMAT_TO_CONTENT_TYPE, OpenAITextToSpeechModel
 
 
-class OpenAICompatibleTextToSpeechModel(OpenAITextToSpeechModel):
+class OpenAICompatibleTextToSpeechModel(ProfileAwareMixin, OpenAITextToSpeechModel):
     """OpenAI-compatible Text-to-Speech provider implementation for custom endpoints.
 
     This provider extends OpenAI's TTS implementation to work with any OpenAI-compatible
@@ -53,39 +54,51 @@ class OpenAICompatibleTextToSpeechModel(OpenAITextToSpeechModel):
         config = config or {}
         config.update(kwargs)
 
-        # Configuration precedence: Direct params > config > Environment variables
-        self.base_url = (
-            base_url or
-            config.get("base_url") or
-            os.getenv("OPENAI_COMPATIBLE_BASE_URL_TTS") or
-            os.getenv("OPENAI_COMPATIBLE_BASE_URL")
+        # Resolve provider profile (None when not profile-driven) and configuration
+        # via the shared precedence chain (ProfileAwareMixin).
+        self._profile: Optional[OpenAICompatibleProfile] = self._resolve_profile(config)
+        self.base_url = self._resolve_base_url(
+            "text_to_speech", self._profile, base_url, config
+        )
+        self.api_key = self._resolve_api_key(
+            "text_to_speech", self._profile, api_key, config
         )
 
-        self.api_key = (
-            api_key or
-            config.get("api_key") or
-            os.getenv("OPENAI_COMPATIBLE_API_KEY_TTS") or
-            os.getenv("OPENAI_COMPATIBLE_API_KEY")
-        )
-
-        # Validation
-        if not self.base_url:
-            raise ValueError(
-                "OpenAI-compatible base URL is required. "
-                "Set OPENAI_COMPATIBLE_BASE_URL_TTS or OPENAI_COMPATIBLE_BASE_URL "
-                "environment variable or provide base_url in config."
-            )
-
-        # Use a default API key if none is provided (some endpoints don't require authentication)
-        if not self.api_key:
-            self.api_key = "not-required"
+        if self._profile:
+            display = self._profile.display_name or self._profile.name.title()
+            if not self.base_url:
+                raise ValueError(
+                    f"{display} base URL is not configured. "
+                    f"Provide base_url in config or check the profile configuration."
+                )
+            if not self.api_key:
+                raise ValueError(
+                    f"{display} API key not found. "
+                    f"Set {self._profile.api_key_env} environment variable "
+                    f"or provide api_key in config."
+                )
+        else:
+            # Validation
+            if not self.base_url:
+                raise ValueError(
+                    "OpenAI-compatible base URL is required. "
+                    "Set OPENAI_COMPATIBLE_BASE_URL_TTS or OPENAI_COMPATIBLE_BASE_URL "
+                    "environment variable or provide base_url in config."
+                )
+            # Use a default API key if none is provided (some endpoints don't require authentication)
+            if not self.api_key:
+                self.api_key = "not-required"
 
         # Ensure base_url doesn't end with trailing slash for consistency
         if self.base_url.endswith("/"):
             self.base_url = self.base_url.rstrip("/")
 
-        # Remove base_url and api_key from config to avoid duplication
-        clean_config = {k: v for k, v in config.items() if k not in ['base_url', 'api_key']}
+        # Remove base_url, api_key, and profile marker from config to avoid duplication
+        clean_config = {
+            k: v
+            for k, v in config.items()
+            if k not in ["base_url", "api_key", "_profile_name"]
+        }
 
         # Call parent's __init__ to set up HTTP clients and other initialization
         super().__init__(
@@ -193,10 +206,12 @@ class OpenAICompatibleTextToSpeechModel(OpenAITextToSpeechModel):
     def _get_default_model(self) -> str:
         """Get the default model name.
 
-        For OpenAI-compatible endpoints, we use a generic default
-        that users should override with their specific model.
+        Returns the profile's TTS default if a profile is active,
+        otherwise a generic default users should override.
         """
-        return "tts-1"
+        return self._resolve_default_model(
+            "text_to_speech", getattr(self, "_profile", None), "tts-1"
+        )
 
     @property
     def provider(self) -> str:

--- a/src/esperanto/providers/tts/openai_compatible.py
+++ b/src/esperanto/providers/tts/openai_compatible.py
@@ -56,7 +56,9 @@ class OpenAICompatibleTextToSpeechModel(ProfileAwareMixin, OpenAITextToSpeechMod
 
         # Resolve provider profile (None when not profile-driven) and configuration
         # via the shared precedence chain (ProfileAwareMixin).
-        self._profile: Optional[OpenAICompatibleProfile] = self._resolve_profile(config)
+        self._profile: Optional[OpenAICompatibleProfile] = self._resolve_profile(
+            config, "text_to_speech"
+        )
         self.base_url = self._resolve_base_url(
             "text_to_speech", self._profile, base_url, config
         )
@@ -215,7 +217,9 @@ class OpenAICompatibleTextToSpeechModel(ProfileAwareMixin, OpenAITextToSpeechMod
 
     @property
     def provider(self) -> str:
-        """Get the provider name."""
+        """Get the provider name (the profile name when profile-driven)."""
+        if self._profile is not None:
+            return self._profile.name
         return "openai-compatible"
 
     def generate_speech(

--- a/tests/providers/llm/test_profiles.py
+++ b/tests/providers/llm/test_profiles.py
@@ -66,7 +66,7 @@ class TestProfileRegistry:
         assert profile.name == "deepseek"
         assert profile.base_url == "https://api.deepseek.com/v1"
         assert profile.api_key_env == "DEEPSEEK_API_KEY"
-        assert profile.default_model == "deepseek-chat"
+        assert profile.default_model_for("language") == "deepseek-chat"
 
     def test_get_xai_profile(self):
         profile = get_profile("xai")
@@ -80,7 +80,7 @@ class TestProfileRegistry:
         assert profile.name == "dashscope"
         assert profile.base_url == "https://dashscope.aliyuncs.com/compatible-mode/v1"
         assert profile.api_key_env == "DASHSCOPE_API_KEY"
-        assert profile.default_model == "qwen-plus"
+        assert profile.default_model_for("language") == "qwen-plus"
 
     def test_get_novita_profile(self):
         profile = get_profile("novita")
@@ -88,7 +88,7 @@ class TestProfileRegistry:
         assert profile.name == "novita"
         assert profile.base_url == "https://api.novita.ai/openai"
         assert profile.api_key_env == "NOVITA_API_KEY"
-        assert profile.default_model == "moonshotai/kimi-k2.5"
+        assert profile.default_model_for("language") == "moonshotai/kimi-k2.5"
 
     def test_get_unknown_profile_returns_none(self):
         assert get_profile("unknown-provider") is None

--- a/tests/providers/test_profile_multimodality.py
+++ b/tests/providers/test_profile_multimodality.py
@@ -92,6 +92,36 @@ class TestProfileSchema:
             )
         assert p.default_model_for("language") == "explicit"
 
+    def test_positional_construction_binds_default_model(self):
+        # Back-compat: the 4th positional arg must still be default_model.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            p = OpenAICompatibleProfile("x", "http://x/v1", "X_KEY", "my-model")
+        assert p.default_model_for("language") == "my-model"
+
+    def test_invalid_capability_raises(self):
+        with pytest.raises(ValueError, match="Unknown profile capabilities"):
+            OpenAICompatibleProfile(
+                name="x",
+                base_url="http://x/v1",
+                api_key_env="X_KEY",
+                capabilities={"embeddng"},  # typo
+            )
+
+    def test_capabilities_and_default_models_are_immutable(self):
+        p = OpenAICompatibleProfile(
+            name="x",
+            base_url="http://x/v1",
+            api_key_env="X_KEY",
+            capabilities={"language", "embedding"},
+            default_models={"language": "a"},
+        )
+        assert isinstance(p.capabilities, frozenset)
+        with pytest.raises((AttributeError, TypeError)):
+            p.capabilities.add("speech_to_text")  # type: ignore[attr-defined]
+        with pytest.raises(TypeError):
+            p.default_models["language"] = "b"  # type: ignore[index]
+
     def test_builtins_do_not_warn_and_resolve_language_default(self, recwarn):
         # Re-importing built-ins must not emit deprecation noise; they use
         # default_models now, not default_model.
@@ -225,6 +255,39 @@ class TestFactoryResolution:
 # =============================================================================
 # Hybrid provider: xAI is a language profile AND a first-class TTS class
 # =============================================================================
+
+
+class TestDirectConstructionGate:
+    def test_direct_embedding_with_language_only_profile_raises(self, monkeypatch):
+        # Constructing the adapter directly (bypassing the factory) with a
+        # language-only profile must still be rejected at the boundary.
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "k")
+        from esperanto.providers.embedding.openai_compatible import (
+            OpenAICompatibleEmbeddingModel,
+        )
+
+        with pytest.raises(ProviderCapabilityError):
+            OpenAICompatibleEmbeddingModel(
+                model_name="m", config={"_profile_name": "deepseek"}
+            )
+
+
+class TestProviderIdentity:
+    def test_profile_backed_embedding_reports_profile_name(self, _env):
+        _register(
+            name="multi",
+            base_url="http://localhost:9/v1",
+            api_key_env="MULTI_KEY",
+            capabilities={"embedding"},
+            default_models={"embedding": "e"},
+        )
+        model = AIFactory.create_embedding("multi", None)
+        assert model.provider == "multi"
+
+    def test_plain_openai_compatible_embedding_reports_generic(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_COMPATIBLE_BASE_URL", "http://localhost:9/v1")
+        model = AIFactory.create_embedding("openai-compatible", "m")
+        assert model.provider == "openai-compatible"
 
 
 class TestHybridProvider:

--- a/tests/providers/test_profile_multimodality.py
+++ b/tests/providers/test_profile_multimodality.py
@@ -1,0 +1,275 @@
+"""Multi-modality OpenAI-compatible profile tests (issue #230).
+
+Profiles used to resolve only for ``create_language()``. These tests cover the
+extension to embedding / STT / TTS: opt-in capabilities, per-modality defaults,
+the profile-vs-class precedence (including the live xAI hybrid), the typed
+capability error, and the "no default beats a wrong default" rule.
+"""
+
+import warnings
+
+import pytest
+
+from esperanto.common_types import EsperantoError, ProviderCapabilityError
+from esperanto.factory import AIFactory
+from esperanto.providers.llm.profiles import (
+    _USER_PROFILES,
+    OpenAICompatibleProfile,
+    get_profile_capabilities,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_user_profiles():
+    _USER_PROFILES.clear()
+    yield
+    _USER_PROFILES.clear()
+
+
+@pytest.fixture
+def _env(monkeypatch):
+    """Provide API keys the profiles below resolve from, without touching host env."""
+    monkeypatch.setenv("MULTI_KEY", "k")
+    monkeypatch.setenv("NODEF_KEY", "k")
+    return monkeypatch
+
+
+def _register(**kwargs) -> OpenAICompatibleProfile:
+    profile = OpenAICompatibleProfile(**kwargs)
+    AIFactory.register_openai_compatible_profile(profile)
+    return profile
+
+
+# =============================================================================
+# Profile schema
+# =============================================================================
+
+
+class TestProfileSchema:
+    def test_capabilities_default_is_language_only(self):
+        p = OpenAICompatibleProfile(
+            name="x", base_url="http://x/v1", api_key_env="X_KEY"
+        )
+        assert p.capabilities == {"language"}
+
+    def test_default_models_default_empty(self):
+        p = OpenAICompatibleProfile(
+            name="x", base_url="http://x/v1", api_key_env="X_KEY"
+        )
+        assert p.default_models == {}
+        assert p.default_model_for("language") is None
+
+    def test_default_model_for_returns_declared(self):
+        p = OpenAICompatibleProfile(
+            name="x",
+            base_url="http://x/v1",
+            api_key_env="X_KEY",
+            capabilities={"language", "embedding"},
+            default_models={"language": "a", "embedding": "b"},
+        )
+        assert p.default_model_for("language") == "a"
+        assert p.default_model_for("embedding") == "b"
+        assert p.default_model_for("speech_to_text") is None
+
+    def test_deprecated_default_model_folds_into_language(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            p = OpenAICompatibleProfile(
+                name="x", base_url="http://x/v1", api_key_env="X_KEY", default_model="m"
+            )
+        assert p.default_model_for("language") == "m"
+        assert any(issubclass(x.category, DeprecationWarning) for x in w)
+
+    def test_explicit_default_models_wins_over_deprecated_alias(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            p = OpenAICompatibleProfile(
+                name="x",
+                base_url="http://x/v1",
+                api_key_env="X_KEY",
+                default_model="deprecated",
+                default_models={"language": "explicit"},
+            )
+        assert p.default_model_for("language") == "explicit"
+
+    def test_builtins_do_not_warn_and_resolve_language_default(self, recwarn):
+        # Re-importing built-ins must not emit deprecation noise; they use
+        # default_models now, not default_model.
+        from esperanto.providers.llm.profiles import get_profile
+
+        p = get_profile("deepseek")
+        assert p.default_model_for("language") == "deepseek-chat"
+        assert p.default_model is None
+        assert not [x for x in recwarn.list if issubclass(x.category, DeprecationWarning)]
+
+
+# =============================================================================
+# Exception hierarchy (seeds #227)
+# =============================================================================
+
+
+class TestExceptionHierarchy:
+    def test_capability_error_is_esperanto_error(self):
+        assert issubclass(ProviderCapabilityError, EsperantoError)
+        assert issubclass(EsperantoError, Exception)
+
+
+# =============================================================================
+# get_profile_capabilities + get_available_providers
+# =============================================================================
+
+
+class TestCapabilityDiscovery:
+    def test_builtins_are_language_only(self):
+        caps = get_profile_capabilities()
+        for name in ("deepseek", "xai", "dashscope", "minimax", "novita"):
+            assert caps[name] == {"language"}
+
+    def test_available_providers_merges_by_capability(self, _env):
+        _register(
+            name="multi",
+            base_url="http://localhost:9/v1",
+            api_key_env="MULTI_KEY",
+            capabilities={"language", "embedding"},
+            default_models={"language": "l", "embedding": "e"},
+        )
+        providers = AIFactory.get_available_providers()
+        assert "multi" in providers["language"]
+        assert "multi" in providers["embedding"]
+        assert "multi" not in providers["speech_to_text"]
+        assert "multi" not in providers["text_to_speech"]
+
+    def test_chat_only_profile_absent_from_embedding_matrix(self):
+        providers = AIFactory.get_available_providers()
+        assert "deepseek" in providers["language"]
+        assert "deepseek" not in providers["embedding"]
+
+
+# =============================================================================
+# Factory resolution across modalities
+# =============================================================================
+
+
+class TestFactoryResolution:
+    @pytest.mark.parametrize(
+        "modality, create, default_key, default_val",
+        [
+            ("embedding", AIFactory.create_embedding, "embedding", "m-emb"),
+            (
+                "speech_to_text",
+                AIFactory.create_speech_to_text,
+                "speech_to_text",
+                "m-stt",
+            ),
+            (
+                "text_to_speech",
+                AIFactory.create_text_to_speech,
+                "text_to_speech",
+                "m-tts",
+            ),
+        ],
+    )
+    def test_profile_resolves_for_declared_modality(
+        self, _env, modality, create, default_key, default_val
+    ):
+        _register(
+            name="multi",
+            base_url="http://localhost:9/v1",
+            api_key_env="MULTI_KEY",
+            capabilities={modality},
+            default_models={default_key: default_val},
+        )
+        model = create("multi", None)
+        assert type(model).__name__.startswith("OpenAICompatible")
+        assert model.base_url == "http://localhost:9/v1"
+        assert model.model_name == default_val
+
+    def test_undeclared_modality_without_class_raises_capability_error(self, _env):
+        _register(
+            name="chatonly",
+            base_url="http://localhost:9/v1",
+            api_key_env="MULTI_KEY",
+            capabilities={"language"},
+            default_models={"language": "l"},
+        )
+        with pytest.raises(ProviderCapabilityError):
+            AIFactory.create_embedding("chatonly", "whatever")
+
+    def test_deepseek_embedding_raises_capability_error(self):
+        with pytest.raises(ProviderCapabilityError):
+            AIFactory.create_embedding("deepseek", "x")
+
+    def test_no_default_beats_wrong_default(self, _env):
+        _register(
+            name="nodef",
+            base_url="http://localhost:9/v1",
+            api_key_env="NODEF_KEY",
+            capabilities={"embedding"},
+            default_models={},  # declares embedding but no default
+        )
+        with pytest.raises(ValueError, match="no default model"):
+            AIFactory.create_embedding("nodef", None)
+
+    def test_no_default_but_explicit_model_ok(self, _env):
+        _register(
+            name="nodef",
+            base_url="http://localhost:9/v1",
+            api_key_env="NODEF_KEY",
+            capabilities={"embedding"},
+            default_models={},
+        )
+        model = AIFactory.create_embedding("nodef", "user-model")
+        assert model.model_name == "user-model"
+
+
+# =============================================================================
+# Hybrid provider: xAI is a language profile AND a first-class TTS class
+# =============================================================================
+
+
+class TestHybridProvider:
+    def test_xai_tts_falls_through_to_first_class(self, monkeypatch):
+        monkeypatch.setenv("XAI_API_KEY", "test-key")
+        model = AIFactory.create_text_to_speech("xai", "grok-tts")
+        assert type(model).__name__ == "XAITextToSpeechModel"
+
+    def test_xai_language_uses_profile(self, monkeypatch):
+        monkeypatch.setenv("XAI_API_KEY", "test-key")
+        model = AIFactory.create_language("xai", "grok-2-latest")
+        assert type(model).__name__ == "OpenAICompatibleLanguageModel"
+
+
+# =============================================================================
+# Collision warning
+# =============================================================================
+
+
+class TestCollisionWarning:
+    def test_declaring_capability_that_shadows_class_warns(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            AIFactory.register_openai_compatible_profile(
+                OpenAICompatibleProfile(
+                    name="xai",
+                    base_url="http://x/v1",
+                    api_key_env="XAI_API_KEY",
+                    capabilities={"language", "text_to_speech"},
+                    default_models={"language": "grok"},
+                )
+            )
+        assert any("shadows" in str(x.message) for x in w)
+
+    def test_language_only_profile_does_not_warn_for_tts_class(self):
+        # xAI default (language-only) must NOT warn even though a TTS class exists.
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            AIFactory.register_openai_compatible_profile(
+                OpenAICompatibleProfile(
+                    name="xai2",
+                    base_url="http://x/v1",
+                    api_key_env="XAI_API_KEY",
+                    capabilities={"language"},
+                    default_models={"language": "grok"},
+                )
+            )
+        assert not [x for x in w if "shadows" in str(x.message)]


### PR DESCRIPTION
## Summary

Extends OpenAI-compatible **provider profiles** from language-only to also serve
**embedding, speech-to-text, and text-to-speech**. The `openai_compatible.py`
adapters for those modalities already existed — this wires profiles into their
factories and adds a capability model so the extension stays honest.

Closes #230.

## What changed

- **Opt-in `capabilities`** on `OpenAICompatibleProfile` (default `{"language"}`).
  A profile is only reachable for the modalities it declares; requesting an
  undeclared modality raises the new typed `ProviderCapabilityError`.
- **Per-modality `default_models`**. `default_model` is deprecated (kept as a
  back-compat alias for `default_models["language"]`, emits `DeprecationWarning`).
  The five built-in profiles were migrated to `default_models`.
- **`ProfileAwareMixin`** (new) centralizes the base_url / api_key / default-model
  precedence chain for all four modality adapters — one source of truth instead of
  a copy per modality. The production LLM adapter was refactored onto it.
- **Hybrid providers work by construction.** xAI is a `language` profile *and* a
  first-class TTS class; `create_text_to_speech("xai", ...)` still resolves to the
  first-class class because the profile declares only `language`.
- **No default beats a wrong default.** A profile declaring a modality with no
  default model raises a clear error instead of falling back to a placeholder
  (`whisper-1`, `text-embedding-3-small`, `tts-1`) the endpoint may not serve.
- **New exceptions** `EsperantoError` (root) + `ProviderCapabilityError`, seeding
  the normalized exception hierarchy (#227).
- **Reranker is out of scope** — no OpenAI-compatible reranking endpoint exists.

## Design

Two reusable principles were captured in ARCHITECTURE.md during the design phase
(*Opt-In Capability Declaration*, *No Default Beats a Wrong Default*).

## Test plan

- New `tests/providers/test_profile_multimodality.py` (21 tests): capability
  schema, deprecation fold, per-modality factory resolution, `ProviderCapabilityError`,
  the xAI hybrid fall-through, no-default error, collision warning, and the
  per-capability `get_available_providers` merge.
- Updated `tests/providers/llm/test_profiles.py` for the built-in `default_models`
  migration.
- Canonical validator green locally: **1447 passed, 1 skipped, 1 xfailed**
  (`uv run pytest tests/providers tests/unit tests/common_types tests/test_deprecation_warnings.py -q --no-cov`).
- `ruff check .` and `mypy src/esperanto` both clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

