### PR TITLE
feat: add oMLX built-in profile + requires_api_key flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **oMLX built-in profile + `requires_api_key` flag** — [oMLX](https://github.com/madroidmaq/omlx),
+  a local OpenAI-compatible MLX server for Apple Silicon, is now a built-in
+  profile (`omlx`, `capabilities={"language", "embedding"}`, base URL
+  `http://localhost:11435/v1`, override via `OMLX_API_BASE`). A new
+  `requires_api_key` flag on `OpenAICompatibleProfile` (default `True`) lets
+  local/no-auth endpoints tolerate a missing API key — it falls back to
+  `"not-required"` instead of raising. oMLX sets no default models (bring your
+  own), so pass a `model_name`. (#228)
+
 - **Multi-modality OpenAI-compatible profiles** — a registered
   `OpenAICompatibleProfile` can now serve `embedding`, `speech_to_text`, and
   `text_to_speech` in addition to `language`, via a new opt-in `capabilities`

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -21,6 +21,7 @@ Welcome to the Esperanto provider guide. This page helps you choose the right AI
 | [DashScope (Qwen)](./dashscope.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | [MiniMax](./minimax.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | [Novita](./openai-compatible.md)* | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| [oMLX](./openai-compatible.md)* | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | [OpenRouter](./openrouter.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | [PayPerQ (PPQ)](./ppq.md) | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ |
 | [Transformers](./transformers.md) | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
@@ -32,6 +33,8 @@ Welcome to the Esperanto provider guide. This page helps you choose the right AI
 *⚠️ OpenAI-Compatible: JSON mode support depends on the specific endpoint implementation
 
 *Novita is available as a built-in OpenAI-compatible LLM profile. Use `AIFactory.create_language("novita", "moonshotai/kimi-k2.5")` with `NOVITA_API_KEY`. See [OpenAI-Compatible](./openai-compatible.md) for the shared setup path.
+
+*oMLX is a built-in OpenAI-compatible profile for the local [oMLX](https://github.com/madroidmaq/omlx) MLX server (language + embedding, no API key). Use `AIFactory.create_language("omlx", "<your-model>")`; base URL defaults to `http://localhost:11435/v1` (override via `OMLX_API_BASE`). See [OpenAI-Compatible](./openai-compatible.md).
 
 ## Quick Selection Guide
 
@@ -56,6 +59,7 @@ Welcome to the Esperanto provider guide. This page helps you choose the right AI
 **Fully Local:**
 - **[Ollama](./ollama.md)**: LLM + Embedding (simple setup, no API costs)
 - **[Transformers](./transformers.md)**: Embedding + Reranking (100+ models, offline)
+- **[oMLX](./openai-compatible.md)**: LLM + Embedding on Apple Silicon (MLX, no API key)
 - **[OpenAI-Compatible](./openai-compatible.md)**: Connect to local LM Studio, vLLM, or Ollama
 
 **Self-Hosted Options:**
@@ -342,6 +346,7 @@ Enterprise features, private deployment:
 No API costs, privacy-focused:
 - [Ollama](./ollama.md)
 - [Transformers](./transformers.md)
+- [oMLX](./openai-compatible.md) (Apple Silicon MLX, OpenAI-compatible profile)
 - [OpenAI-Compatible](./openai-compatible.md)
 
 ## Next Steps

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -21,7 +21,7 @@ Welcome to the Esperanto provider guide. This page helps you choose the right AI
 | [DashScope (Qwen)](./dashscope.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | [MiniMax](./minimax.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | [Novita](./openai-compatible.md)* | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| [oMLX](./openai-compatible.md)* | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| [oMLX](./openai-compatible.md)* | ✅ | ✅ | ❌ | ❌ | ❌ | ⚠️* |
 | [OpenRouter](./openrouter.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | [PayPerQ (PPQ)](./ppq.md) | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ |
 | [Transformers](./transformers.md) | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |

--- a/docs/providers/openai-compatible.md
+++ b/docs/providers/openai-compatible.md
@@ -95,7 +95,7 @@ model = AIFactory.create_language("my-company", "llama-3-70b")
 response = model.chat_complete(messages)
 ```
 
-Several OpenAI-compatible providers are already registered as built-in profiles: **DeepSeek**, **xAI**, **DashScope** (Qwen), **MiniMax**, and **Novita**. Use `AIFactory.create_language("novita", "moonshotai/kimi-k2.5")` with `NOVITA_API_KEY` for the built-in Novita profile.
+Several OpenAI-compatible providers are already registered as built-in profiles: **DeepSeek**, **xAI**, **DashScope** (Qwen), **MiniMax**, **Novita**, **PayPerQ (PPQ)**, and **oMLX**. Use `AIFactory.create_language("novita", "moonshotai/kimi-k2.5")` with `NOVITA_API_KEY` for the built-in Novita profile.
 
 ### Multi-Modality Profiles
 
@@ -137,6 +137,13 @@ Notes:
 - **Deprecation.** `default_model="..."` is deprecated in favor of
   `default_models={"language": "..."}`; it still works as a language alias and
   emits a `DeprecationWarning`.
+- **No-auth / local endpoints.** For a local server that needs no API key (e.g.
+  [oMLX](https://github.com/madroidmaq/omlx)), set `requires_api_key=False`; a
+  missing key then falls back to `"not-required"` instead of raising. The
+  built-in **oMLX** profile (`omlx`, `capabilities={"language", "embedding"}`,
+  base URL `http://localhost:11435/v1`, override via `OMLX_API_BASE`) uses this.
+  It sets no default models, so pass a `model_name` for whatever MLX model you
+  have loaded.
 
 ## Quick Start
 

--- a/src/esperanto/providers/embedding/openai_compatible.py
+++ b/src/esperanto/providers/embedding/openai_compatible.py
@@ -68,18 +68,9 @@ class OpenAICompatibleEmbeddingModel(ProfileAwareMixin, EmbeddingModel):
         )
 
         if self._profile:
-            display = self._profile.display_name or self._profile.name.title()
-            if not self.base_url:
-                raise ValueError(
-                    f"{display} base URL is not configured. "
-                    f"Provide base_url in config or check the profile configuration."
-                )
-            if not self.api_key:
-                raise ValueError(
-                    f"{display} API key not found. "
-                    f"Set {self._profile.api_key_env} environment variable "
-                    f"or provide api_key in config."
-                )
+            self.api_key = self._finalize_profile_credentials(
+                self._profile, self.base_url, self.api_key
+            )
         else:
             # Validation
             if not self.base_url:
@@ -93,7 +84,7 @@ class OpenAICompatibleEmbeddingModel(ProfileAwareMixin, EmbeddingModel):
                 self.api_key = "not-required"
 
         # Ensure base_url doesn't end with trailing slash for consistency
-        if self.base_url.endswith("/"):
+        if self.base_url and self.base_url.endswith("/"):
             self.base_url = self.base_url.rstrip("/")
 
         # Get timeout configuration (default to 120 seconds for embedding operations)

--- a/src/esperanto/providers/llm/openai_compatible.py
+++ b/src/esperanto/providers/llm/openai_compatible.py
@@ -64,18 +64,9 @@ class OpenAICompatibleLanguageModel(ProfileAwareMixin, OpenAILanguageModel):
         )
 
         if self._profile:
-            display = self._profile.display_name or self._profile.name.title()
-            if not self.base_url:
-                raise ValueError(
-                    f"{display} base URL is not configured. "
-                    f"Provide base_url in config or check the profile configuration."
-                )
-            if not self.api_key:
-                raise ValueError(
-                    f"{display} API key not found. "
-                    f"Set {self._profile.api_key_env} environment variable "
-                    f"or provide api_key in config."
-                )
+            self.api_key = self._finalize_profile_credentials(
+                self._profile, self.base_url, self.api_key
+            )
         else:
             # Validation
             if not self.base_url:

--- a/src/esperanto/providers/llm/profiles.py
+++ b/src/esperanto/providers/llm/profiles.py
@@ -64,11 +64,6 @@ class OpenAICompatibleProfile:
     base_url_env: Optional[str] = None
     """Optional environment variable for base URL override."""
 
-    requires_api_key: bool = True
-    """Whether the endpoint requires an API key. Set False for local/no-auth
-    endpoints (e.g. oMLX): a missing key then falls back to 'not-required'
-    instead of raising, mirroring the generic openai-compatible path."""
-
     supports_response_format: bool = True
     """Whether the endpoint supports the response_format parameter."""
 
@@ -80,6 +75,12 @@ class OpenAICompatibleProfile:
 
     display_name: Optional[str] = None
     """Human-readable name for error messages (e.g., 'DeepSeek'). Defaults to name."""
+
+    requires_api_key: bool = True
+    """Whether the endpoint requires an API key. Set False for local/no-auth
+    endpoints (e.g. oMLX): a missing key then falls back to 'not-required'
+    instead of raising, mirroring the generic openai-compatible path.
+    (Kept last so new fields don't shift existing positional slots.)"""
 
     def __post_init__(self) -> None:
         # Validate declared capabilities against the known modalities, so a typo

--- a/src/esperanto/providers/llm/profiles.py
+++ b/src/esperanto/providers/llm/profiles.py
@@ -64,6 +64,11 @@ class OpenAICompatibleProfile:
     base_url_env: Optional[str] = None
     """Optional environment variable for base URL override."""
 
+    requires_api_key: bool = True
+    """Whether the endpoint requires an API key. Set False for local/no-auth
+    endpoints (e.g. oMLX): a missing key then falls back to 'not-required'
+    instead of raising, mirroring the generic openai-compatible path."""
+
     supports_response_format: bool = True
     """Whether the endpoint supports the response_format parameter."""
 
@@ -171,6 +176,17 @@ BUILTIN_PROFILES: Dict[str, OpenAICompatibleProfile] = {
         },
         owned_by="PayPerQ",
         display_name="PayPerQ",
+    ),
+    "omlx": OpenAICompatibleProfile(
+        name="omlx",
+        base_url="http://localhost:11435/v1",
+        api_key_env="OMLX_API_KEY",
+        base_url_env="OMLX_API_BASE",
+        capabilities={"language", "embedding"},
+        default_models={},  # bring-your-own-models: no fixed default
+        requires_api_key=False,
+        owned_by="oMLX",
+        display_name="oMLX",
     ),
 }
 

--- a/src/esperanto/providers/profile_mixin.py
+++ b/src/esperanto/providers/profile_mixin.py
@@ -99,6 +99,35 @@ class ProfileAwareMixin:
             or os.getenv("OPENAI_COMPATIBLE_API_KEY")
         )
 
+    def _finalize_profile_credentials(
+        self,
+        profile: OpenAICompatibleProfile,
+        base_url: Optional[str],
+        api_key: Optional[str],
+    ) -> str:
+        """Validate a profile-active adapter's resolved base_url + api_key.
+
+        Raises on a missing base URL, and on a missing API key unless the profile
+        opts out via ``requires_api_key=False`` — in which case the key defaults
+        to ``"not-required"`` (local/no-auth endpoints), mirroring the generic
+        openai-compatible path. Returns the final API key to store.
+        """
+        display = profile.display_name or profile.name.title()
+        if not base_url:
+            raise ValueError(
+                f"{display} base URL is not configured. "
+                f"Provide base_url in config or check the profile configuration."
+            )
+        if not api_key:
+            if profile.requires_api_key:
+                raise ValueError(
+                    f"{display} API key not found. "
+                    f"Set {profile.api_key_env} environment variable "
+                    f"or provide api_key in config."
+                )
+            return "not-required"
+        return api_key
+
     def _resolve_default_model(
         self,
         modality: Modality,

--- a/src/esperanto/providers/stt/openai_compatible.py
+++ b/src/esperanto/providers/stt/openai_compatible.py
@@ -73,18 +73,9 @@ class OpenAICompatibleSpeechToTextModel(ProfileAwareMixin, SpeechToTextModel):
         )
 
         if self._profile:
-            display = self._profile.display_name or self._profile.name.title()
-            if not self.base_url:
-                raise ValueError(
-                    f"{display} base URL is not configured. "
-                    f"Provide base_url in config or check the profile configuration."
-                )
-            if not self.api_key:
-                raise ValueError(
-                    f"{display} API key not found. "
-                    f"Set {self._profile.api_key_env} environment variable "
-                    f"or provide api_key in config."
-                )
+            self.api_key = self._finalize_profile_credentials(
+                self._profile, self.base_url, self.api_key
+            )
         else:
             # Validation
             if not self.base_url:
@@ -98,7 +89,7 @@ class OpenAICompatibleSpeechToTextModel(ProfileAwareMixin, SpeechToTextModel):
                 self.api_key = "not-required"
 
         # Ensure base_url doesn't end with trailing slash for consistency
-        if self.base_url.endswith("/"):
+        if self.base_url and self.base_url.endswith("/"):
             self.base_url = self.base_url.rstrip("/")
 
         # Get timeout configuration (default to 300 seconds for STT operations)

--- a/src/esperanto/providers/tts/openai_compatible.py
+++ b/src/esperanto/providers/tts/openai_compatible.py
@@ -67,18 +67,9 @@ class OpenAICompatibleTextToSpeechModel(ProfileAwareMixin, OpenAITextToSpeechMod
         )
 
         if self._profile:
-            display = self._profile.display_name or self._profile.name.title()
-            if not self.base_url:
-                raise ValueError(
-                    f"{display} base URL is not configured. "
-                    f"Provide base_url in config or check the profile configuration."
-                )
-            if not self.api_key:
-                raise ValueError(
-                    f"{display} API key not found. "
-                    f"Set {self._profile.api_key_env} environment variable "
-                    f"or provide api_key in config."
-                )
+            self.api_key = self._finalize_profile_credentials(
+                self._profile, self.base_url, self.api_key
+            )
         else:
             # Validation
             if not self.base_url:
@@ -92,7 +83,7 @@ class OpenAICompatibleTextToSpeechModel(ProfileAwareMixin, OpenAITextToSpeechMod
                 self.api_key = "not-required"
 
         # Ensure base_url doesn't end with trailing slash for consistency
-        if self.base_url.endswith("/"):
+        if self.base_url and self.base_url.endswith("/"):
             self.base_url = self.base_url.rstrip("/")
 
         # Remove base_url, api_key, and profile marker from config to avoid duplication

--- a/tests/providers/test_profile_multimodality.py
+++ b/tests/providers/test_profile_multimodality.py
@@ -290,6 +290,65 @@ class TestProviderIdentity:
         assert model.provider == "openai-compatible"
 
 
+class TestRequiresApiKey:
+    def test_no_auth_profile_defaults_key(self, monkeypatch):
+        # A requires_api_key=False profile with no key set constructs fine.
+        monkeypatch.delenv("NOAUTH_KEY", raising=False)
+        _register(
+            name="noauth",
+            base_url="http://localhost:9/v1",
+            api_key_env="NOAUTH_KEY",
+            capabilities={"language"},
+            default_models={"language": "m"},
+            requires_api_key=False,
+        )
+        model = AIFactory.create_language("noauth", "m")
+        assert model.api_key == "not-required"
+
+    def test_requires_key_profile_still_raises(self, monkeypatch):
+        monkeypatch.delenv("NEEDKEY_KEY", raising=False)
+        _register(
+            name="needkey",
+            base_url="http://localhost:9/v1",
+            api_key_env="NEEDKEY_KEY",
+            capabilities={"language"},
+            default_models={"language": "m"},
+            # requires_api_key defaults True
+        )
+        with pytest.raises(ValueError, match="API key not found"):
+            AIFactory.create_language("needkey", "m")
+
+
+class TestOmlxProfile:
+    def test_omlx_no_auth_language_and_embedding(self, monkeypatch):
+        for var in ("OMLX_API_KEY", "OMLX_API_BASE"):
+            monkeypatch.delenv(var, raising=False)
+        llm = AIFactory.create_language("omlx", "some-model")
+        emb = AIFactory.create_embedding("omlx", "some-embed")
+        assert llm.api_key == "not-required"
+        assert emb.api_key == "not-required"
+        assert emb.base_url == "http://localhost:11435/v1"
+        assert emb.provider == "omlx"
+
+    def test_omlx_audio_modalities_unsupported(self, monkeypatch):
+        monkeypatch.delenv("OMLX_API_KEY", raising=False)
+        with pytest.raises(ProviderCapabilityError):
+            AIFactory.create_speech_to_text("omlx", "x")
+        with pytest.raises(ProviderCapabilityError):
+            AIFactory.create_text_to_speech("omlx", "x")
+
+    def test_omlx_no_default_requires_model(self, monkeypatch):
+        monkeypatch.delenv("OMLX_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="no default model"):
+            AIFactory.create_embedding("omlx", None)
+
+    def test_omlx_base_url_override(self, monkeypatch):
+        monkeypatch.delenv("OMLX_API_KEY", raising=False)
+        monkeypatch.setenv("OMLX_API_BASE", "http://localhost:9999/v1")
+        model = AIFactory.create_language("omlx", "m")
+        assert model.base_url == "http://localhost:9999/v1"
+
+
 class TestHybridProvider:
     def test_xai_tts_falls_through_to_first_class(self, monkeypatch):
         monkeypatch.setenv("XAI_API_KEY", "test-key")


### PR DESCRIPTION
## Summary

Adds a built-in **oMLX** profile and the `requires_api_key` flag that no-auth
local endpoints need.

[oMLX](https://github.com/madroidmaq/omlx) is a local OpenAI-compatible MLX
inference server for Apple Silicon. With multi-modality profiles landed (#230),
it's a profile config entry — no dedicated classes.

Closes #228.

## What changed

- **`requires_api_key` flag** on `OpenAICompatibleProfile` (default `True`, so
  DeepSeek/xAI/PPQ/etc. are unaffected). When `False`, a missing API key falls
  back to `"not-required"` instead of raising — the profile path previously
  *required* a key, which broke local no-auth servers.
- **`omlx` built-in profile**: `capabilities={"language", "embedding"}`, base URL
  `http://localhost:11435/v1` (override via `OMLX_API_BASE`), `requires_api_key=False`,
  and **no default models** (bring-your-own — per #230's "no default beats a
  wrong default", a missing `model_name` raises a clear error).
- **Centralization**: the profile-active credential validation (base_url + api_key)
  moved into `ProfileAwareMixin._finalize_profile_credentials`, removing the
  four-way duplication #230 left across the modality adapters.

## Notes

- oMLX declares only `language` + `embedding` (it doesn't do audio), so
  `create_speech_to_text("omlx", ...)` / `create_text_to_speech("omlx", ...)`
  raise `ProviderCapabilityError`.
- Default port `11435` rather than oMLX's own `8000` (8000 collides with SurrealDB
  in the Open Notebook stack); override via `OMLX_API_BASE`.

## Test plan

- New oMLX + `requires_api_key` tests in `tests/providers/test_profile_multimodality.py`:
  no-auth construction, `requires_api_key=True` still raises, audio modalities
  raise `ProviderCapabilityError`, no-default requires a model, `OMLX_API_BASE`
  override.
- Canonical validator green locally: **1468 passed, 1 skipped, 1 xfailed**.
- `ruff check .` and `mypy src/esperanto` clean.

Closes #228


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

