### PR TITLE
chore: remove orphaned esperanto-release command

### DIFF
--- a/.claude/commands/esperanto-release.md
+++ b/.claude/commands/esperanto-release.md
@@ -1,8 +1,0 @@
-
-- Bump the version in @pyproject.toml
-- Run `uv sync --all-extras` locally
-- Commit and push, merge to main.
-- Don't forget to commit the uv.lock file too
-- Generate a new tag
-- Generate a new release via the Github cli. 
-(the github action workflow will publish it to pypi)


### PR DESCRIPTION
`.claude/` is gitignored (line 113 of `.gitignore`) — it's local tooling and not meant to be tracked. `.claude/commands/esperanto-release.md` was an anomaly: a tracked file inside that otherwise-ignored directory, committed before the ignore rule existed.

This removes it so `.claude/` is fully local, matching the `.gitignore` intent. No code or behavior change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

