### PR TITLE
chore: release v2.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.25.0] - 2026-07-18
+
 ### Added
 
 - **oMLX built-in profile + `requires_api_key` flag** — [oMLX](https://github.com/madroidmaq/omlx),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esperanto"
-version = "2.24.0"
+version = "2.25.0"
 description = "A light-weight, production-ready, unified interface for various AI model providers"
 authors = [
     { name = "LUIS NOVO", email = "lfnovo@gmail.com" }

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "esperanto"
-version = "2.24.0"
+version = "2.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Cuts **v2.25.0**.

- Bumps `version` to 2.25.0 in `pyproject.toml` (+ `uv.lock`).
- Dates the CHANGELOG `[2.25.0] - 2026-07-18` section, opens a fresh `[Unreleased]`.

### Release contents (since v2.24.0)
- Schema-driven structured outputs across all LLM providers (#95)
- Multi-modality OpenAI-compatible profiles + `ProviderCapabilityError`/`EsperantoError` (#230)
- `requires_api_key` flag + oMLX built-in profile (#228)
- New providers: Novita (#120), OpenRouter TTS+STT (#224), PayPerQ / PPQ (#238)
- Deprecates `OpenACompatibleProfile(default_model=...)` in favor of `default_models` (back-compat kept)

### Validation
- Canonical validator green: 1468 passed, 1 skipped, 1 xfailed
- `ruff` + `mypy` clean
- Build + clean-room import gate green on the 2.25.0 wheel
- Real-API (`-m release`) verification skipped this cycle (no keys for the new PPQ/Novita providers)

Merging this, then the tag push triggers the PyPI publish.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

