### PR TITLE
fix(elevenlabs): default to latest STT/TTS models (scribe_v2, eleven_v3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **ElevenLabs default models bumped to the latest.** Speech-to-text now defaults
+  to `scribe_v2` (was `scribe_v1`) and lists it in model discovery; text-to-speech
+  now defaults to `eleven_v3` (was `eleven_multilingual_v2`). Both older models
+  remain usable by passing an explicit `model_name`. Verified against the live
+  ElevenLabs API. (#245)
+
 ## [2.25.0] - 2026-07-18
 
 ### Added

--- a/src/esperanto/providers/stt/elevenlabs.py
+++ b/src/esperanto/providers/stt/elevenlabs.py
@@ -52,7 +52,7 @@ class ElevenLabsSpeechToTextModel(SpeechToTextModel):
 
     def _get_default_model(self) -> str:
         """Get the default model name."""
-        return "scribe_v1"
+        return "scribe_v2"
 
     @property
     def provider(self) -> str:
@@ -62,6 +62,11 @@ class ElevenLabsSpeechToTextModel(SpeechToTextModel):
     def _get_models(self) -> List[Model]:
         """List all available models for this provider."""
         return [
+            Model(
+                id="scribe_v2",
+                owned_by="ElevenLabs",
+                context_window=None,  # Audio models don't have context windows
+            ),
             Model(
                 id="scribe_v1",
                 owned_by="ElevenLabs",

--- a/src/esperanto/providers/tts/elevenlabs.py
+++ b/src/esperanto/providers/tts/elevenlabs.py
@@ -12,12 +12,13 @@ class ElevenLabsTextToSpeechModel(TextToSpeechModel):
     """ElevenLabs Text-to-Speech provider implementation.
     
     Supports multiple models including:
+    - eleven_v3: Latest, most expressive model (default)
     - eleven_multilingual_v2: Multilingual model
+    - eleven_flash_v2_5 / eleven_turbo_v2_5: Faster, low-latency models
     - eleven_monolingual_v1: English-only model
-    - eleven_turbo_v2: Faster, lower-quality model
     """
-    
-    DEFAULT_MODEL = "eleven_multilingual_v2"
+
+    DEFAULT_MODEL = "eleven_v3"
     DEFAULT_VOICE = "Aria"  # One of their default voices
     PROVIDER = "elevenlabs"
     

--- a/tests/integration/test_stt_real.py
+++ b/tests/integration/test_stt_real.py
@@ -227,16 +227,27 @@ class TestMistralSTT:
     reason="ELEVENLABS_API_KEY not configured",
 )
 class TestElevenLabsSTT:
-    """Real integration tests for ElevenLabs speech-to-text."""
+    """Real integration tests for ElevenLabs speech-to-text (Scribe)."""
+
+    def test_default_model_is_scribe_v2(self):
+        """The default model resolves to the latest Scribe (scribe_v2)."""
+        model = AIFactory.create_speech_to_text("elevenlabs")
+        assert model.get_model_name() == "scribe_v2"
 
     def test_sync_transcribe(self):
-        """Test sync transcription."""
+        """Test sync transcription (default model = scribe_v2)."""
         model = AIFactory.create_speech_to_text("elevenlabs")
         result = model.transcribe(str(SAMPLE_AUDIO))
         assert EXPECTED_TRANSCRIPT_FRAGMENT.lower() in result.text.lower()
 
+    def test_sync_transcribe_scribe_v2_explicit(self):
+        """Explicit scribe_v2 model_id transcribes the sample."""
+        model = AIFactory.create_speech_to_text("elevenlabs", "scribe_v2")
+        result = model.transcribe(str(SAMPLE_AUDIO))
+        assert EXPECTED_TRANSCRIPT_FRAGMENT.lower() in result.text.lower()
+
     def test_async_atranscribe(self):
-        """Test async transcription."""
+        """Test async transcription (default model = scribe_v2)."""
         model = AIFactory.create_speech_to_text("elevenlabs")
 
         async def _run() -> object:

--- a/tests/providers/stt/test_elevenlabs.py
+++ b/tests/providers/stt/test_elevenlabs.py
@@ -107,7 +107,7 @@ def test_elevenlabs_transcribe(audio_file, mock_httpx_clients):
     assert call_args[0][0] == "https://api.elevenlabs.io/v1/speech-to-text"
     assert "files" in call_args[1]
     assert "data" in call_args[1]
-    assert call_args[1]["data"]["model_id"] == "scribe_v1"
+    assert call_args[1]["data"]["model_id"] == "scribe_v2"
 
     assert isinstance(response, TranscriptionResponse)
     assert response.text == "This is a test transcription"
@@ -214,7 +214,7 @@ def test_elevenlabs_provider_name():
 
 def test_elevenlabs_default_model():
     model = ElevenLabsSpeechToTextModel(api_key="test-key")
-    assert model._get_default_model() == "scribe_v1"
+    assert model._get_default_model() == "scribe_v2"
 
 
 def test_elevenlabs_missing_api_key():


### PR DESCRIPTION
ElevenLabs' current latest models are **scribe_v2** (STT) and **eleven_v3** (TTS); our defaults were a generation behind (`scribe_v1` / `eleven_multilingual_v2`).

### Changes
- **STT**: default `scribe_v1` → `scribe_v2`; add `scribe_v2` to `_get_models` discovery (kept `scribe_v1`/`scribe_v1_experimental`, still valid).
- **TTS**: default `eleven_multilingual_v2` → `eleven_v3`; reconciles with the `eleven_v3` fallback already used in the voice-fetch payloads.
- Older models remain usable by passing an explicit `model_name` (pure passthrough).

### Verification
- Queried the live ElevenLabs API — authoritative model list is `scribe_v1`, `scribe_v1_experimental`, `scribe_v2` (note: `scribe_v2_realtime` is a separate realtime endpoint, tracked separately).
- Ran real `-m release` STT tests: default resolves to `scribe_v2`, and sync + async transcription of the sample fixture passes end-to-end.
- Updated the two mocked unit tests that asserted the old default; `ruff`/`mypy` clean, stt/tts suites green (325).

`scribe_v2_realtime` (websocket streaming) is intentionally out of scope here — filed as a follow-up.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

