### PR TITLE
fix(langchain): forward custom base_url in Anthropic & Cohere to_langchain()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`to_langchain()` now forwards a custom base URL for Anthropic and Cohere.**
+  Previously, converting an Anthropic- or Cohere-compatible model (configured with
+  a custom `base_url`) to LangChain silently reconnected to the official API.
+  Anthropic strips the `/v1` suffix that `ChatAnthropic` doesn't expect. The
+  default endpoint is still omitted so LangChain uses its own default. (#229)
+
 ### Changed
 
 - **ElevenLabs default models bumped to the latest.** Speech-to-text now defaults

--- a/src/esperanto/providers/llm/anthropic.py
+++ b/src/esperanto/providers/llm/anthropic.py
@@ -928,4 +928,13 @@ class AnthropicLanguageModel(LanguageModel):
         elif self.top_p is not None:
             kwargs["top_p"] = self.top_p
 
+        # Forward a custom (Anthropic-compatible) endpoint so the LangChain model
+        # doesn't silently reconnect to the official API. esperanto's base_url
+        # carries the /v1 suffix (it appends /messages); ChatAnthropic wants the
+        # API root, so strip it. Only pass when it differs from the default.
+        if self.base_url:
+            base_url = self.base_url.rstrip("/").removesuffix("/v1")
+            if base_url and base_url != "https://api.anthropic.com":
+                kwargs["base_url"] = base_url
+
         return ChatAnthropic(**kwargs)  # type: ignore[arg-type]

--- a/src/esperanto/providers/llm/cohere.py
+++ b/src/esperanto/providers/llm/cohere.py
@@ -711,4 +711,11 @@ class CohereLanguageModel(LanguageModel):
         if self.temperature is not None:
             kwargs["temperature"] = self.temperature
 
+        # Forward a custom base URL so the LangChain model doesn't silently
+        # reconnect to the official API. Only pass when it differs from the default.
+        if self.base_url:
+            base_url = self.base_url.rstrip("/")
+            if base_url and base_url != "https://api.cohere.com":
+                kwargs["base_url"] = base_url
+
         return ChatCohere(**kwargs)  # type: ignore[arg-type]

--- a/tests/providers/llm/test_anthropic_provider.py
+++ b/tests/providers/llm/test_anthropic_provider.py
@@ -1231,3 +1231,25 @@ class TestStreamingToolCalls:
 
         assert chunk is not None
         assert chunk.choices[0].finish_reason == "tool_calls"
+
+
+def test_anthropic_to_langchain_forwards_custom_base_url():
+    """A custom Anthropic-compatible endpoint is forwarded (with /v1 stripped)."""
+    model = AnthropicLanguageModel(
+        api_key="test-key",
+        model_name="claude-3-opus-20240229",
+        base_url="https://api.moonshot.ai/anthropic/v1",
+    )
+    with patch("langchain_anthropic.ChatAnthropic") as MockChat:
+        model.to_langchain()
+    assert MockChat.call_args.kwargs["base_url"] == "https://api.moonshot.ai/anthropic"
+
+
+def test_anthropic_to_langchain_omits_default_base_url():
+    """The default endpoint is not forwarded (ChatAnthropic uses its own default)."""
+    model = AnthropicLanguageModel(
+        api_key="test-key", model_name="claude-3-opus-20240229"
+    )
+    with patch("langchain_anthropic.ChatAnthropic") as MockChat:
+        model.to_langchain()
+    assert "base_url" not in MockChat.call_args.kwargs

--- a/tests/providers/llm/test_cohere.py
+++ b/tests/providers/llm/test_cohere.py
@@ -392,3 +392,25 @@ class TestCohereStructuredOutput:
             await model.achat_complete(
                 [{"role": "user", "content": "Capital?"}], tools=tools
             )
+
+
+def test_cohere_to_langchain_forwards_custom_base_url():
+    """A custom base URL is forwarded to ChatCohere."""
+    with patch.object(CohereLanguageModel, "_create_http_clients", lambda self: None):
+        model = CohereLanguageModel(
+            model_name="command-a-03-2025",
+            api_key="test-key",
+            base_url="https://gateway.internal/cohere",
+        )
+    with patch("langchain_cohere.ChatCohere") as MockChat:
+        model.to_langchain()
+    assert MockChat.call_args.kwargs["base_url"] == "https://gateway.internal/cohere"
+
+
+def test_cohere_to_langchain_omits_default_base_url():
+    """The default endpoint is not forwarded (ChatCohere uses its own default)."""
+    with patch.object(CohereLanguageModel, "_create_http_clients", lambda self: None):
+        model = CohereLanguageModel(model_name="command-a-03-2025", api_key="test-key")
+    with patch("langchain_cohere.ChatCohere") as MockChat:
+        model.to_langchain()
+    assert "base_url" not in MockChat.call_args.kwargs


### PR DESCRIPTION
`to_langchain()` dropped `self.base_url`, so a model configured for an Anthropic- or Cohere-compatible endpoint (e.g. Kimi, a gateway) silently reconnected to the official API.

### Fix
- **Anthropic** — forward `base_url`, stripping the `/v1` suffix that `ChatAnthropic` doesn't expect. Omit when it's the default.
- **Cohere** — forward `base_url` (no suffix strip). Omit when it's the default.

### Audit (all 12 LLM providers)
Checked every `to_langchain()`:
- **Already correct:** mistral, ollama, openai, openai-compatible, openrouter, perplexity (forward base_url); azure (azure_endpoint), vertex (project) use their own mechanism.
- **Not a gap:** groq — `base_url` is hardcoded (`api.groq.com`), nothing custom to forward.
- **Gaps:** anthropic + cohere (this PR); **google** is also affected but needs `client_options={"api_endpoint": ...}` rather than a plain `base_url` — filed as a follow-up.

### Tests
Mocked tests per provider: custom base_url is forwarded (Anthropic with `/v1` stripped), default is omitted. ruff + mypy clean; anthropic + cohere suites green (88).

Unblocks the workaround shim in lfnovo/open-notebook#1043.

Closes #229

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

