### PR TITLE
fix(vertex): authenticate from a service-account key across all modalities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Vertex AI now authenticates from a service-account key file across all
+  modalities.** `VertexTextToSpeechModel` and `VertexEmbeddingModel` previously
+  ignored a configured key and shelled out to the `gcloud` CLI (unusable in
+  containers where `gcloud` isn't installed). All three Vertex providers now
+  share one auth path (`VertexAuthMixin`): explicit key file (`credentials_file`
+  or `credentials_path` config, or `GOOGLE_APPLICATION_CREDENTIALS`) →
+  Application Default Credentials → `gcloud` CLI as a last resort. A missing
+  `gcloud` binary now raises a clear error instead of an opaque crash. (#249)
 - **`to_langchain()` now forwards a custom base URL for Anthropic and Cohere.**
   Previously, converting an Anthropic- or Cohere-compatible model (configured with
   a custom `base_url`) to LangChain silently reconnected to the official API.

--- a/src/esperanto/providers/embedding/vertex.py
+++ b/src/esperanto/providers/embedding/vertex.py
@@ -1,15 +1,14 @@
 """Google Vertex AI embedding model provider."""
 import os
-import subprocess
-import time
 from typing import Any, Dict, List, Optional
 
 import httpx
 
 from esperanto.providers.embedding.base import EmbeddingModel, Model
+from esperanto.providers.vertex_auth import VertexAuthMixin
 
 
-class VertexEmbeddingModel(EmbeddingModel):
+class VertexEmbeddingModel(VertexAuthMixin, EmbeddingModel):
     """Google Vertex AI embedding model implementation."""
 
     def __init__(self, vertex_project: Optional[str] = None, vertex_location: Optional[str] = None, **kwargs):
@@ -30,38 +29,16 @@ class VertexEmbeddingModel(EmbeddingModel):
         # Initialize HTTP clients with configurable timeout
         self._create_http_clients()
         
-        # Cache for access token
+        # Cache for access token (gcloud fallback)
         self._access_token: Optional[str] = None
         self._token_expiry: float = 0
-        
+
         # Update config with model_name if provided
         if "model_name" in kwargs:
             self._config["model_name"] = kwargs["model_name"]
 
-    def _get_access_token(self) -> str:
-        """Get OAuth 2.0 access token for Google Cloud APIs."""
-        current_time = time.time()
-        
-        # Check if token is still valid (with 5-minute buffer)
-        if self._access_token and current_time < (self._token_expiry - 300):
-            return self._access_token
-            
-        try:
-            # Use gcloud to get access token
-            result = subprocess.run(
-                ["gcloud", "auth", "application-default", "print-access-token"],
-                capture_output=True,
-                text=True,
-                check=True
-            )
-            self._access_token = result.stdout.strip()
-            # Tokens typically expire in 1 hour
-            self._token_expiry = current_time + 3600
-            return self._access_token
-        except subprocess.CalledProcessError as e:
-            raise RuntimeError(
-                f"Failed to get access token. Make sure you're authenticated with 'gcloud auth application-default login': {e}"
-            )
+        # Resolve service-account / ADC credentials (VertexAuthMixin)
+        self._load_credentials()
 
     def _get_headers(self) -> Dict[str, str]:
         """Get headers for Vertex AI API requests."""

--- a/src/esperanto/providers/llm/vertex.py
+++ b/src/esperanto/providers/llm/vertex.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-import subprocess
 import time
 import uuid
 from dataclasses import dataclass
@@ -40,10 +39,11 @@ from esperanto.providers.llm.structured_output import (
     apply_structured_output,
     resolve_structured_output,
 )
+from esperanto.providers.vertex_auth import VertexAuthMixin
 
 
 @dataclass
-class VertexLanguageModel(LanguageModel):
+class VertexLanguageModel(VertexAuthMixin, LanguageModel):
     """Google Vertex AI language model implementation."""
 
     vertex_project: Optional[str] = None
@@ -78,86 +78,6 @@ class VertexLanguageModel(LanguageModel):
 
         # Cache for LangChain model
         self._langchain_model = None
-
-    def _load_credentials(self):
-        """Load Google Cloud credentials.
-
-        Priority:
-        1. Explicit credentials_file parameter
-        2. GOOGLE_APPLICATION_CREDENTIALS environment variable
-        3. Application Default Credentials (google.auth.default)
-        4. None (falls back to gcloud CLI in _get_access_token)
-        """
-        self._credentials = None
-        creds_path = self.credentials_file or os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
-
-        if creds_path:
-            # Explicit credentials file — errors must propagate so the user
-            # doesn't silently fall back to a different identity.
-            try:
-                from google.oauth2 import service_account
-            except ImportError:
-                raise ImportError(
-                    "credentials_file requires the google-auth package. "
-                    "Install with: uv add google-auth or pip install google-auth"
-                )
-
-            scopes = ["https://www.googleapis.com/auth/cloud-platform"]
-            self._credentials = service_account.Credentials.from_service_account_file(
-                creds_path, scopes=scopes
-            )
-        else:
-            # ADC — best-effort; fall back to gcloud CLI if unavailable.
-            try:
-                import google.auth
-
-                self._credentials, _ = google.auth.default(
-                    scopes=["https://www.googleapis.com/auth/cloud-platform"]
-                )
-            except ImportError:
-                self._credentials = None
-            except Exception:
-                self._credentials = None
-
-    def _get_access_token(self) -> str:
-        """Get OAuth 2.0 access token for Google Cloud APIs."""
-        # Use google-auth credentials if available
-        if self._credentials is not None:
-            try:
-                from google.auth.transport.requests import Request
-
-                if not self._credentials.valid:
-                    self._credentials.refresh(Request())
-                return self._credentials.token
-            except Exception as e:
-                raise RuntimeError(
-                    f"Failed to refresh credentials: {e}"
-                )
-
-        current_time = time.time()
-
-        # Check if cached token is still valid (with 5-minute buffer)
-        if self._access_token and current_time < (self._token_expiry - 300):
-            return self._access_token
-
-        try:
-            # Fall back to gcloud CLI
-            result = subprocess.run(
-                ["gcloud", "auth", "application-default", "print-access-token"],
-                capture_output=True,
-                text=True,
-                check=True
-            )
-            self._access_token = result.stdout.strip()
-            # Tokens typically expire in 1 hour
-            self._token_expiry = current_time + 3600
-            return self._access_token
-        except subprocess.CalledProcessError as e:
-            raise RuntimeError(
-                "Failed to get access token. Either set credentials_file / "
-                "GOOGLE_APPLICATION_CREDENTIALS, install google-auth for ADC, "
-                f"or authenticate with 'gcloud auth application-default login': {e}"
-            )
 
     def _get_headers(self) -> Dict[str, str]:
         """Get headers for Vertex AI API requests."""

--- a/src/esperanto/providers/tts/vertex.py
+++ b/src/esperanto/providers/tts/vertex.py
@@ -1,17 +1,17 @@
 """Google Vertex AI Text-to-Speech provider implementation."""
 import base64
 import os
-import subprocess
-import time
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
 import httpx
 
+from esperanto.providers.vertex_auth import VertexAuthMixin
+
 from .base import AudioResponse, Model, TextToSpeechModel, Voice
 
 
-class VertexTextToSpeechModel(TextToSpeechModel):
+class VertexTextToSpeechModel(VertexAuthMixin, TextToSpeechModel):
     """Google Cloud Text-to-Speech provider implementation via Vertex AI.
     
     Uses the Cloud Text-to-Speech API for text-to-speech generation.
@@ -52,34 +52,12 @@ class VertexTextToSpeechModel(TextToSpeechModel):
         # Initialize HTTP clients with configurable timeout
         self._create_http_clients()
 
-        # Cache for access token
+        # Cache for access token (gcloud fallback)
         self._access_token = None
         self._token_expiry = 0
 
-    def _get_access_token(self) -> str:
-        """Get OAuth 2.0 access token for Google Cloud APIs."""
-        current_time = time.time()
-        
-        # Check if token is still valid (with 5-minute buffer)
-        if self._access_token and current_time < (self._token_expiry - 300):
-            return self._access_token
-            
-        try:
-            # Use gcloud to get access token
-            result = subprocess.run(
-                ["gcloud", "auth", "application-default", "print-access-token"],
-                capture_output=True,
-                text=True,
-                check=True
-            )
-            self._access_token = result.stdout.strip()
-            # Tokens typically expire in 1 hour
-            self._token_expiry = current_time + 3600
-            return self._access_token
-        except subprocess.CalledProcessError as e:
-            raise RuntimeError(
-                f"Failed to get access token. Make sure you're authenticated with 'gcloud auth application-default login': {e}"
-            )
+        # Resolve service-account / ADC credentials (VertexAuthMixin)
+        self._load_credentials()
 
     def _get_headers(self) -> Dict[str, str]:
         """Get headers for Cloud Text-to-Speech API requests."""

--- a/src/esperanto/providers/vertex_auth.py
+++ b/src/esperanto/providers/vertex_auth.py
@@ -1,0 +1,109 @@
+"""Shared Google Cloud (Vertex AI) authentication for the Vertex providers.
+
+All three Vertex modalities (language, embedding, text-to-speech) authenticate
+the same way against Google Cloud. This mixin is the single implementation:
+resolve credentials once (`_load_credentials`), then mint an OAuth token per
+request (`_get_access_token`).
+
+Credential resolution priority:
+1. An explicit service-account key file — from a ``credentials_file`` attribute,
+   or a ``credentials_file`` / ``credentials_path`` config entry.
+2. ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable.
+3. Application Default Credentials (``google.auth.default``).
+4. The ``gcloud`` CLI (last-resort fallback in ``_get_access_token``).
+"""
+
+import os
+import subprocess
+import time
+from typing import Any, Optional
+
+_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
+
+
+class VertexAuthMixin:
+    """Google Cloud auth shared across the Vertex provider modalities."""
+
+    # Attributes the mixin reads/writes; providers may also initialize these.
+    _credentials: Optional[Any] = None
+    _access_token: Optional[str] = None
+    _token_expiry: float = 0.0
+
+    def _load_credentials(self) -> None:
+        """Resolve service-account / ADC credentials into ``self._credentials``.
+
+        Sets ``self._credentials`` to a google-auth Credentials object, or
+        ``None`` to signal the ``gcloud`` CLI fallback in ``_get_access_token``.
+        """
+        self._credentials = None
+        config = getattr(self, "_config", None) or {}
+        creds_path = (
+            getattr(self, "credentials_file", None)
+            or config.get("credentials_file")
+            or config.get("credentials_path")
+            or os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+        )
+
+        if creds_path:
+            # Explicit credentials file — errors must propagate so the user
+            # doesn't silently fall back to a different identity.
+            try:
+                from google.oauth2 import service_account
+            except ImportError:
+                raise ImportError(
+                    "A Vertex credentials file requires the google-auth package. "
+                    "Install with: uv add google-auth or pip install google-auth"
+                )
+            self._credentials = service_account.Credentials.from_service_account_file(
+                creds_path, scopes=_SCOPES
+            )
+        else:
+            # ADC — best-effort; fall back to the gcloud CLI if unavailable.
+            try:
+                import google.auth
+
+                self._credentials, _ = google.auth.default(scopes=_SCOPES)
+            except ImportError:
+                self._credentials = None
+            except Exception:
+                self._credentials = None
+
+    def _get_access_token(self) -> str:
+        """Get an OAuth 2.0 access token for Google Cloud APIs."""
+        # Prefer resolved google-auth credentials (service account or ADC).
+        creds = getattr(self, "_credentials", None)
+        if creds is not None:
+            try:
+                from google.auth.transport.requests import Request
+
+                if not creds.valid:
+                    creds.refresh(Request())
+                return creds.token
+            except Exception as e:
+                raise RuntimeError(f"Failed to refresh Vertex credentials: {e}")
+
+        current_time = time.time()
+
+        # Cached gcloud token still valid (5-minute buffer)?
+        cached = self._access_token
+        if cached and current_time < (self._token_expiry - 300):
+            return cached
+
+        try:
+            # Last-resort fallback: the gcloud CLI.
+            result = subprocess.run(
+                ["gcloud", "auth", "application-default", "print-access-token"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            self._access_token = result.stdout.strip()
+            self._token_expiry = current_time + 3600  # tokens last ~1 hour
+            return self._access_token
+        except (subprocess.CalledProcessError, FileNotFoundError) as e:
+            raise RuntimeError(
+                "Failed to get a Vertex AI access token. Provide a service account "
+                "key via credentials_file / credentials_path or "
+                "GOOGLE_APPLICATION_CREDENTIALS, install google-auth for ADC, or "
+                f"authenticate with 'gcloud auth application-default login': {e}"
+            )

--- a/src/esperanto/providers/vertex_auth.py
+++ b/src/esperanto/providers/vertex_auth.py
@@ -7,13 +7,15 @@ request (`_get_access_token`).
 
 Credential resolution priority:
 1. An explicit service-account key file — from a ``credentials_file`` attribute,
-   or a ``credentials_file`` / ``credentials_path`` config entry.
-2. ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable.
-3. Application Default Credentials (``google.auth.default``).
-4. The ``gcloud`` CLI (last-resort fallback in ``_get_access_token``).
+   or a ``credentials_file`` / ``credentials_path`` config entry (loaded as a
+   service-account key).
+2. Application Default Credentials (``google.auth.default``), which itself reads
+   ``GOOGLE_APPLICATION_CREDENTIALS`` and supports every credential type
+   (service-account keys, workload/workforce identity federation, the metadata
+   server, ...).
+3. The ``gcloud`` CLI (last-resort fallback in ``_get_access_token``).
 """
 
-import os
 import subprocess
 import time
 from typing import Any, Optional
@@ -37,14 +39,17 @@ class VertexAuthMixin:
         """
         self._credentials = None
         config = getattr(self, "_config", None) or {}
-        creds_path = (
+        # A key file the caller explicitly declared — treat it as a
+        # service-account key. GOOGLE_APPLICATION_CREDENTIALS is deliberately NOT
+        # read here: it can point at a federated/external-account config that is
+        # not a service-account key, so it's left for ADC below to interpret.
+        explicit_key = (
             getattr(self, "credentials_file", None)
             or config.get("credentials_file")
             or config.get("credentials_path")
-            or os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
         )
 
-        if creds_path:
+        if explicit_key:
             # Explicit credentials file — errors must propagate so the user
             # doesn't silently fall back to a different identity.
             try:
@@ -55,10 +60,13 @@ class VertexAuthMixin:
                     "Install with: uv add google-auth or pip install google-auth"
                 )
             self._credentials = service_account.Credentials.from_service_account_file(
-                creds_path, scopes=_SCOPES
+                explicit_key, scopes=_SCOPES
             )
         else:
-            # ADC — best-effort; fall back to the gcloud CLI if unavailable.
+            # Application Default Credentials — reads GOOGLE_APPLICATION_CREDENTIALS
+            # itself and handles every credential type (service-account keys,
+            # workload/workforce identity federation, metadata server, ...).
+            # Best-effort; fall back to the gcloud CLI if unavailable.
             try:
                 import google.auth
 

--- a/tests/providers/llm/test_vertex_provider.py
+++ b/tests/providers/llm/test_vertex_provider.py
@@ -889,27 +889,23 @@ class TestCredentials:
                 )
                 assert model._credentials is mock_creds
 
-    def test_google_application_credentials_env_var(self):
-        """Test loading credentials from GOOGLE_APPLICATION_CREDENTIALS env var."""
-        mock_creds = MagicMock()
-        mock_creds.valid = True
-        mock_creds.token = "env-sa-token"
-
+    def test_google_application_credentials_routes_through_adc(self, mock_google_auth):
+        """GOOGLE_APPLICATION_CREDENTIALS is interpreted by ADC
+        (google.auth.default), not forced through from_service_account_file — so
+        workload/workforce identity federation configs authenticate correctly."""
+        mock_default, mock_creds = mock_google_auth
         env = {
             "VERTEX_PROJECT": "test-project",
-            "GOOGLE_APPLICATION_CREDENTIALS": "/env/path/sa.json",
+            "GOOGLE_APPLICATION_CREDENTIALS": "/env/path/config.json",
         }
         with patch.dict(os.environ, env, clear=False):
             with patch(
                 "google.oauth2.service_account.Credentials.from_service_account_file",
-                return_value=mock_creds,
             ) as mock_from_file:
                 model = VertexLanguageModel(model_name="gemini-2.0-flash")
-                mock_from_file.assert_called_once_with(
-                    "/env/path/sa.json",
-                    scopes=["https://www.googleapis.com/auth/cloud-platform"],
-                )
-                assert model._credentials is mock_creds
+        mock_from_file.assert_not_called()
+        mock_default.assert_called_once()
+        assert model._credentials is mock_creds
 
     def test_credentials_file_takes_priority_over_env_var(self):
         """Test that explicit credentials_file takes priority over env var."""
@@ -1034,21 +1030,6 @@ class TestCredentials:
                         model_name="gemini-2.0-flash",
                         credentials_file="/path/sa.json",
                     )
-
-    def test_env_var_credentials_raises_on_invalid_file(self):
-        """Test that GOOGLE_APPLICATION_CREDENTIALS raises on invalid file instead of falling back."""
-        env = {
-            "VERTEX_PROJECT": "test-project",
-            "GOOGLE_APPLICATION_CREDENTIALS": "/bad/path/sa.json",
-        }
-        with patch.dict(os.environ, env, clear=False):
-            with patch(
-                "google.oauth2.service_account.Credentials.from_service_account_file",
-                side_effect=ValueError("Invalid service account info"),
-            ):
-                with pytest.raises(ValueError, match="Invalid service account"):
-                    VertexLanguageModel(model_name="gemini-2.0-flash")
-
 
 class TestLangChainIntegration:
     """Tests for LangChain integration using ChatGoogleGenerativeAI."""

--- a/tests/providers/llm/test_vertex_provider.py
+++ b/tests/providers/llm/test_vertex_provider.py
@@ -903,9 +903,9 @@ class TestCredentials:
                 "google.oauth2.service_account.Credentials.from_service_account_file",
             ) as mock_from_file:
                 model = VertexLanguageModel(model_name="gemini-2.0-flash")
-        mock_from_file.assert_not_called()
-        mock_default.assert_called_once()
-        assert model._credentials is mock_creds
+                mock_from_file.assert_not_called()
+                mock_default.assert_called_once()
+                assert model._credentials is mock_creds
 
     def test_credentials_file_takes_priority_over_env_var(self):
         """Test that explicit credentials_file takes priority over env var."""

--- a/tests/providers/test_vertex_auth.py
+++ b/tests/providers/test_vertex_auth.py
@@ -1,0 +1,135 @@
+"""Shared Vertex AI authentication tests (issue #249).
+
+The three Vertex providers (language, embedding, TTS) share one auth path via
+VertexAuthMixin. These verify that a configured service-account key file is
+actually used — the bug was that TTS/embedding ignored it and shelled out to the
+gcloud CLI. Everything is mocked; no real credentials or network.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from esperanto.providers.vertex_auth import VertexAuthMixin
+
+
+class _Dummy(VertexAuthMixin):
+    def __init__(self, config=None, credentials_file=None):
+        self._config = config or {}
+        if credentials_file is not None:
+            self.credentials_file = credentials_file
+
+
+@pytest.fixture
+def fake_creds():
+    creds = MagicMock()
+    creds.valid = True
+    creds.token = "sa-token"
+    return creds
+
+
+# --- credential resolution ------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"config": {"credentials_path": "/fake/key.json"}},  # downstream alias
+        {"config": {"credentials_file": "/fake/key.json"}},  # config key
+        {"credentials_file": "/fake/key.json"},              # attribute (llm field)
+    ],
+    ids=["credentials_path", "credentials_file_config", "credentials_file_attr"],
+)
+def test_service_account_file_is_used(kwargs, fake_creds):
+    with patch(
+        "google.oauth2.service_account.Credentials.from_service_account_file",
+        return_value=fake_creds,
+    ) as mock_load:
+        d = _Dummy(**kwargs)
+        d._load_credentials()
+    mock_load.assert_called_once()
+    assert mock_load.call_args[0][0] == "/fake/key.json"
+    assert d._credentials is fake_creds
+
+
+def test_env_var_credentials(monkeypatch, fake_creds):
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "/env/key.json")
+    with patch(
+        "google.oauth2.service_account.Credentials.from_service_account_file",
+        return_value=fake_creds,
+    ) as mock_load:
+        d = _Dummy()
+        d._load_credentials()
+    assert mock_load.call_args[0][0] == "/env/key.json"
+
+
+# --- token acquisition ----------------------------------------------------- #
+
+
+def test_token_uses_credentials_not_gcloud(fake_creds):
+    d = _Dummy()
+    d._credentials = fake_creds
+    with patch("esperanto.providers.vertex_auth.subprocess.run") as mock_run:
+        token = d._get_access_token()
+    assert token == "sa-token"
+    mock_run.assert_not_called()  # the whole point: no gcloud when a key is set
+
+
+def test_token_falls_back_to_gcloud_without_credentials():
+    d = _Dummy()
+    d._credentials = None
+    d._access_token = None
+    d._token_expiry = 0
+    result = MagicMock()
+    result.stdout = "gcloud-token\n"
+    with patch(
+        "esperanto.providers.vertex_auth.subprocess.run", return_value=result
+    ) as mock_run:
+        token = d._get_access_token()
+    assert token == "gcloud-token"
+    mock_run.assert_called_once()
+
+
+def test_gcloud_missing_raises_clear_error():
+    """gcloud not installed (container) → clear error naming the key options."""
+    d = _Dummy()
+    d._credentials = None
+    d._access_token = None
+    d._token_expiry = 0
+    with patch(
+        "esperanto.providers.vertex_auth.subprocess.run",
+        side_effect=FileNotFoundError("gcloud"),
+    ):
+        with pytest.raises(RuntimeError, match="credentials_file / credentials_path"):
+            d._get_access_token()
+
+
+# --- end-to-end at construction (the actual bug) --------------------------- #
+
+
+def test_tts_construction_consumes_credentials_path(monkeypatch, fake_creds):
+    monkeypatch.setenv("VERTEX_PROJECT", "test-project")
+    from esperanto.providers.tts.vertex import VertexTextToSpeechModel
+
+    with patch(
+        "google.oauth2.service_account.Credentials.from_service_account_file",
+        return_value=fake_creds,
+    ) as mock_load:
+        model = VertexTextToSpeechModel(
+            model_name="standard", config={"credentials_path": "/fake/key.json"}
+        )
+    mock_load.assert_called_once()
+    assert model._credentials is fake_creds
+
+
+def test_embedding_construction_consumes_credentials_path(monkeypatch, fake_creds):
+    monkeypatch.setenv("VERTEX_PROJECT", "test-project")
+    from esperanto.providers.embedding.vertex import VertexEmbeddingModel
+
+    with patch(
+        "google.oauth2.service_account.Credentials.from_service_account_file",
+        return_value=fake_creds,
+    ) as mock_load:
+        model = VertexEmbeddingModel(config={"credentials_path": "/fake/key.json"})
+    mock_load.assert_called_once()
+    assert model._credentials is fake_creds

--- a/tests/providers/test_vertex_auth.py
+++ b/tests/providers/test_vertex_auth.py
@@ -52,15 +52,21 @@ def test_service_account_file_is_used(kwargs, fake_creds):
     assert d._credentials is fake_creds
 
 
-def test_env_var_credentials(monkeypatch, fake_creds):
-    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "/env/key.json")
+def test_env_var_routes_through_adc_not_service_account(monkeypatch, fake_creds):
+    """GOOGLE_APPLICATION_CREDENTIALS is left for ADC (google.auth.default) to
+    interpret — never forced through from_service_account_file, which would break
+    workload/workforce identity federation configs."""
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "/env/federated.json")
     with patch(
-        "google.oauth2.service_account.Credentials.from_service_account_file",
-        return_value=fake_creds,
-    ) as mock_load:
+        "google.oauth2.service_account.Credentials.from_service_account_file"
+    ) as mock_sa, patch(
+        "google.auth.default", return_value=(fake_creds, "proj")
+    ) as mock_adc:
         d = _Dummy()
         d._load_credentials()
-    assert mock_load.call_args[0][0] == "/env/key.json"
+    mock_sa.assert_not_called()
+    mock_adc.assert_called_once()
+    assert d._credentials is fake_creds
 
 
 # --- token acquisition ----------------------------------------------------- #


### PR DESCRIPTION
`VertexTextToSpeechModel` and `VertexEmbeddingModel` ignored a configured credentials file and shelled out to the `gcloud` CLI — so Vertex TTS/embedding were **unusable via a service-account key** and broke in containers where `gcloud` isn't installed. The correct auth already lived in the LLM provider, but it was triplicated and had drifted (only the LLM copy was fixed).

### Change (full scope, per the audit)
- New **`VertexAuthMixin`** (`providers/vertex_auth.py`) — one auth implementation for all three Vertex modalities. Resolution: explicit key file (`credentials_file` attr, `credentials_file`/`credentials_path` config, or `GOOGLE_APPLICATION_CREDENTIALS`) → Application Default Credentials → `gcloud` CLI (last resort).
- **llm/vertex, tts/vertex, embedding/vertex** all use it; the duplicated `_load_credentials`/`_get_access_token` bodies are gone.
- Accepts both `credentials_file` (LLM's existing field) and `credentials_path` (what the downstream open-notebook stores) for parity.
- A missing `gcloud` binary now raises a clear `RuntimeError` instead of an uncaught `FileNotFoundError`.

### Scope note
The issue reported TTS, but **embedding/vertex had the identical bug** — both are fixed here.

### Tests
New `tests/providers/test_vertex_auth.py` (9): credentials_path/credentials_file/attr/env resolution, token-uses-credentials-not-gcloud, gcloud fallback, missing-gcloud clear error, and end-to-end construction of TTS + embedding consuming `credentials_path`. Canonical validator green (1481); existing Vertex suites unaffected (the structured-output parity test that patches `_load_credentials` still works — method name preserved). ruff + mypy clean.

Fixes the unconsumed `credentials_path` behind lfnovo/open-notebook#1151.

Closes #249

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

