### PR TITLE
ci: always install deps so a poisoned venv cache can't persist

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,14 +21,15 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Load cached venv
-      id: cached-dependencies
       uses: actions/cache@v4
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
 
+    # Always run the sync — a cache hit only warms .venv; skipping the install on
+    # a hit lets a partial/poisoned cache (e.g. missing numpy/torch) persist
+    # forever. `uv sync` is fast and idempotent against a warm cache.
     - name: Create venv and install dependencies
-      if: steps.cached-dependencies.outputs.cache-hit != 'true'
       run: |
         uv sync --all-extras && uv pip install mxbai-rerank
 


### PR DESCRIPTION
The test workflow only installed dependencies on a cache **miss**:

```yaml
- name: Create venv and install dependencies
  if: steps.cached-dependencies.outputs.cache-hit != 'true'
  run: uv sync --all-extras && uv pip install mxbai-rerank
```

The cache key is `venv-${os}-${py}-${hashFiles('pyproject.toml')}`. Once a `.venv` got cached without the heavy extras (numpy/torch) — which happened around the recent `actions/cache@v3→v4` bump — every subsequent PR with an unchanged `pyproject.toml` hit that poisoned cache, **skipped the install**, and failed collecting `test_transformers*` / `test_advanced_features` with `ModuleNotFoundError: numpy/torch`. It affected all PRs regardless of their diff.

**Fix:** always run `uv sync --all-extras` (dropped the `if: cache-hit` guard). The cache still warms `.venv`, `uv` is fast and idempotent, and the post-run cache save now stores a complete venv — so the poison heals on the first run.

No code change; workflow only.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

