### PR TITLE
chore(release): 2.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.25.1] - 2026-07-19
+
 ### Fixed
 
 - **Vertex AI now authenticates from a service-account key file across all

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esperanto"
-version = "2.25.0"
+version = "2.25.1"
 description = "A light-weight, production-ready, unified interface for various AI model providers"
 authors = [
     { name = "LUIS NOVO", email = "lfnovo@gmail.com" }

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "esperanto"
-version = "2.25.0"
+version = "2.25.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Cuts the **2.25.1** patch release.

## Included since v2.25.0

- **fix(vertex):** authenticate from a service-account key across all modalities (#249)
- **fix(langchain):** forward custom base_url in Anthropic and Cohere `to_langchain()` (#229)
- **fix(elevenlabs):** default to latest STT/TTS models — scribe_v2, eleven_v3 (#245)

CI-only, not user-facing (no CHANGELOG entry): action bumps off Node 20 (#243), always-install to defuse poisoned venv cache (#251).

## Changes in this PR

- `pyproject.toml` version 2.25.0 → 2.25.1
- CHANGELOG `[Unreleased]` promoted to `## [2.25.1] - 2026-07-19`, fresh empty `[Unreleased]` opened
- `uv.lock` synced

## Test plan

- Bucket A green: 1480 passed, 1 skipped, 1 xfailed; ruff clean; mypy clean
- Build + clean-room import gate green

Tag push (→ PyPI publish) happens after merge.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

