### PR TITLE
fix(langchain): preserve Gemini custom endpoint

### DIFF
--- a/src/esperanto/providers/llm/google.py
+++ b/src/esperanto/providers/llm/google.py
@@ -157,6 +157,9 @@ class GoogleLanguageModel(LanguageModel):
                 "top_p": self.top_p,
                 "google_api_key": self.api_key,
             }
+            base_host = (self.base_url or "").removesuffix("/v1beta")
+            if base_host and base_host != "https://generativelanguage.googleapis.com":
+                kwargs["client_options"] = {"api_endpoint": base_host}
             resolved_structured = resolve_structured_output(
                 self.structured,
                 allow_string_json_alias=True,

--- a/tests/providers/llm/test_gemini_provider.py
+++ b/tests/providers/llm/test_gemini_provider.py
@@ -286,6 +286,19 @@ def test_to_langchain():
     # Skip API key check since it's masked
 
 
+def test_to_langchain_forwards_custom_base_url():
+    """Test LangChain conversion preserves a custom Gemini endpoint."""
+    with patch.dict(
+        os.environ, {"GEMINI_API_BASE_URL": "https://gemini.example.com/"}
+    ):
+        with patch("langchain_google_genai.ChatGoogleGenerativeAI") as mock_chat_class:
+            GoogleLanguageModel(api_key="test-key").to_langchain()
+
+    assert mock_chat_class.call_args.kwargs["client_options"] == {
+        "api_endpoint": "https://gemini.example.com"
+    }
+
+
 def test_to_langchain_json_mode_sets_response_mime_type():
     """Test LangChain conversion passes JSON mode settings."""
     mock_chat_google = MagicMock()


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #248.

#### What does this implement/fix? Explain your changes.

`GoogleLanguageModel.to_langchain()` now forwards a custom `GEMINI_API_BASE_URL` through `client_options` while leaving LangChain's default endpoint untouched. A regression test covers the custom endpoint mapping.

#### Any other comments?

Validated with the 12 Google LangChain provider tests, Ruff, and Mypy.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

