### PR TITLE
fix(langchain): forward custom base_url in Google to_langchain()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`to_langchain()` now forwards a custom base URL for Google.** Converting a
+  Google (Gemini) model configured with a custom endpoint (`GEMINI_API_BASE_URL`)
+  to LangChain previously reconnected to the official
+  `generativelanguage.googleapis.com`. `ChatGoogleGenerativeAI` accepts a plain
+  `base_url`, so the custom host is now forwarded (with the `/v1beta` suffix
+  stripped). The default endpoint is still omitted so LangChain uses its own
+  default. Completes the `to_langchain()` base URL audit started in #229. (#248)
+
 ## [2.25.1] - 2026-07-19
 
 ### Fixed

--- a/src/esperanto/providers/llm/google.py
+++ b/src/esperanto/providers/llm/google.py
@@ -172,6 +172,11 @@ class GoogleLanguageModel(LanguageModel):
                     if isinstance(schema_payload, dict):
                         kwargs["response_schema"] = schema_payload
 
+            _DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+            if self.base_url != _DEFAULT_BASE_URL:
+                custom_host = self.base_url[:-len("/v1beta")] if self.base_url.endswith("/v1beta") else self.base_url
+                kwargs["base_url"] = custom_host
+
             self._langchain_model = ChatGoogleGenerativeAI(**kwargs)
         return self._langchain_model
 

--- a/tests/providers/llm/test_google_provider.py
+++ b/tests/providers/llm/test_google_provider.py
@@ -877,6 +877,7 @@ def test_google_langchain_conversion():
 
 def test_google_to_langchain_forwards_custom_base_url():
     """A custom Gemini-compatible endpoint is forwarded (without /v1beta suffix)."""
+    pytest.importorskip("langchain_google_genai")
     with patch.dict(os.environ, {"GEMINI_API_BASE_URL": "https://custom.gemini.internal"}):
         model = GoogleLanguageModel(api_key="test-key", model_name="gemini-2.0-flash")
     with patch("langchain_google_genai.ChatGoogleGenerativeAI") as MockChat:
@@ -886,6 +887,7 @@ def test_google_to_langchain_forwards_custom_base_url():
 
 def test_google_to_langchain_omits_default_base_url():
     """The default endpoint is not forwarded (ChatGoogleGenerativeAI uses its own default)."""
+    pytest.importorskip("langchain_google_genai")
     model = GoogleLanguageModel(api_key="test-key", model_name="gemini-2.0-flash")
     with patch("langchain_google_genai.ChatGoogleGenerativeAI") as MockChat:
         model.to_langchain()

--- a/tests/providers/llm/test_google_provider.py
+++ b/tests/providers/llm/test_google_provider.py
@@ -873,3 +873,20 @@ def test_google_langchain_conversion():
     assert langchain_model.temperature == 0.7
     assert langchain_model.max_output_tokens == 100
     assert langchain_model.top_p == 0.9
+
+
+def test_google_to_langchain_forwards_custom_base_url():
+    """A custom Gemini-compatible endpoint is forwarded (without /v1beta suffix)."""
+    with patch.dict(os.environ, {"GEMINI_API_BASE_URL": "https://custom.gemini.internal"}):
+        model = GoogleLanguageModel(api_key="test-key", model_name="gemini-2.0-flash")
+    with patch("langchain_google_genai.ChatGoogleGenerativeAI") as MockChat:
+        model.to_langchain()
+    assert MockChat.call_args.kwargs["base_url"] == "https://custom.gemini.internal"
+
+
+def test_google_to_langchain_omits_default_base_url():
+    """The default endpoint is not forwarded (ChatGoogleGenerativeAI uses its own default)."""
+    model = GoogleLanguageModel(api_key="test-key", model_name="gemini-2.0-flash")
+    with patch("langchain_google_genai.ChatGoogleGenerativeAI") as MockChat:
+        model.to_langchain()
+    assert "base_url" not in MockChat.call_args.kwargs


### PR DESCRIPTION
## Summary

Completes the `to_langchain()` base URL audit started in #229. `GoogleLanguageModel.to_langchain()` previously dropped a custom Gemini endpoint: a model configured via `GEMINI_API_BASE_URL` silently reconnected to `https://generativelanguage.googleapis.com`.

## Fix

Unlike the assumption in the issue, `ChatGoogleGenerativeAI` (verified against the installed `langchain-google-genai 4.2.0`) **does** accept a plain `base_url` kwarg — `client_options`/`transport` are not exposed. So the fix forwards `base_url` directly, only when it differs from the default, stripping the `/v1beta` suffix that Esperanto appends (the SDK re-appends the API version itself).

## Acceptance criteria

- [x] A `GoogleLanguageModel` with a custom `GEMINI_API_BASE_URL` produces a `ChatGoogleGenerativeAI` pointed at that host
- [x] The default endpoint is not forwarded (LangChain uses its own default)
- [x] Mocked tests mirroring the #229 tests (custom forwarded / default omitted)
- [x] ruff + mypy clean, full validator suite passes (1481 passed)

Closes #248

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

