### PR TITLE
test(azure): isolate endpoint normalization tests from host env

### DIFF
--- a/tests/providers/test_base_url_normalization.py
+++ b/tests/providers/test_base_url_normalization.py
@@ -352,6 +352,11 @@ def _azure_env(monkeypatch, modality_suffix: str) -> None:
         "https://test-endpoint.openai.azure.com/",
     )
     monkeypatch.setenv("AZURE_OPENAI_API_VERSION", f"2024-{modality_suffix}-01")
+    # Each Azure provider prefers its modality-specific endpoint override over
+    # AZURE_OPENAI_ENDPOINT. Clear them so a value present in the host env (or an
+    # auto-loaded .env) can't win over the endpoint this helper sets.
+    for suffix in ("LLM", "EMBEDDING", "STT", "TTS"):
+        monkeypatch.delenv(f"AZURE_OPENAI_ENDPOINT_{suffix}", raising=False)
 
 
 def test_azure_llm_endpoint_trailing_slash_stripped(monkeypatch):


### PR DESCRIPTION
## Problem

`test_azure_embedding_endpoint_trailing_slash_stripped` (and its LLM/STT/TTS siblings) fail whenever a modality-specific Azure endpoint override is present in the host environment — e.g. a dev machine with `AZURE_OPENAI_ENDPOINT_EMBEDDING` set, or a runner that auto-loads it from `.env`. Green on CI, red locally.

## Root cause

Each Azure provider prefers its modality-specific var (`AZURE_OPENAI_ENDPOINT_{LLM,EMBEDDING,STT,TTS}`) over the generic `AZURE_OPENAI_ENDPOINT` that the `_azure_env()` test helper monkeypatches. When the specific var is set in the host env, it wins over the monkeypatch and the assertion runs against the wrong endpoint.

## Fix

Test-only. `_azure_env()` now `delenv`s all four modality-specific overrides so the endpoint the helper sets is authoritative. This hardens all four Azure endpoint tests, not just embedding (the others were latently vulnerable to the same pollution).

Verified by running the tests with `AZURE_OPENAI_ENDPOINT_EMBEDDING` / `_STT` exported — fails on `main`, passes here.

Closes #219

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

