### PR TITLE
chore: add one-shot 'make setup' dev bootstrap target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,18 @@ git clone https://github.com/lfnovo/esperanto.git
 cd esperanto
 ```
 
-2. Create a virtual environment and install dependencies:
+2. Bootstrap the environment in one step:
+```bash
+make setup
+```
+This creates the virtual environment and installs all dependencies (`uv venv && uv sync --all-extras`). Then activate it:
+```bash
+source .venv/bin/activate
+```
+
+<details>
+<summary>Or set it up manually</summary>
+
 ```bash
 uv venv
 source .venv/bin/activate
@@ -77,6 +88,7 @@ If you need the `transformers` extra (for local model support):
 ```bash
 uv sync --group dev --extra transformers
 ```
+</details>
 
 3. Activate the pre-commit hooks:
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-.PHONY: ruff lint test
+.PHONY: setup ruff lint test
+
+setup:
+	uv venv
+	uv sync --all-extras
 
 lint:
 	uv run python -m mypy .

--- a/README.md
+++ b/README.md
@@ -811,4 +811,4 @@ source .venv/bin/activate
 make test
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development guide.
+See [CONTRIBUTING.md](https://github.com/lfnovo/esperanto/blob/main/CONTRIBUTING.md) for the full development guide.

--- a/README.md
+++ b/README.md
@@ -800,11 +800,15 @@ git clone https://github.com/lfnovo/esperanto.git
 cd esperanto
 ```
 
-2. Install dependencies:
+2. Bootstrap the environment (creates a venv and installs all dependencies):
 ```bash
-pip install -r requirements.txt
+make setup
+source .venv/bin/activate
 ```
 
 3. Run tests:
 ```bash
-pytest
+make test
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development guide.


### PR DESCRIPTION
## Summary

Adds a single-command dev bootstrap so a fresh clone can reach a ready-to-develop state without remembering the `uv venv` → `uv sync` sequence (#212).

## Changes

- **Makefile** — new `setup` target: `uv venv && uv sync --all-extras` (matches the validator environment documented in CLAUDE.md).
- **CONTRIBUTING.md** — `make setup` is now the first setup step; the manual `uv venv`/`uv sync --group dev` path is preserved in a collapsible `<details>` block.
- **README.md** — the Development section now uses `make setup` + `make test`, replacing the stale `pip install -r requirements.txt` instruction (that file does not exist in the repo) and linking to CONTRIBUTING.md.

## Acceptance

- [x] A fresh clone can run `make setup` and land in a ready-to-develop state (verified locally)

Closes #212

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

