### PR TITLE
docs(security): add SECURITY.md with a vulnerability disclosure policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,11 @@ For non-trivial changes (new features, new providers, architectural changes), **
 
 ## How to Contribute
 
+### Reporting Security Vulnerabilities
+
+**Do not report security issues through public issues or PRs.** Please follow our
+[Security Policy](SECURITY.md) to report them privately.
+
 ### Reporting Bugs
 
 Before creating bug reports, check the issue list. When creating a bug report, include:

--- a/README.md
+++ b/README.md
@@ -788,6 +788,10 @@ Complete documentation is available in the [docs](https://github.com/lfnovo/espe
 
 We welcome contributions! Please see our [Contributing Guidelines](https://github.com/lfnovo/esperanto/blob/main/CONTRIBUTING.md) for details on how to get started.
 
+## Security 🔒
+
+Found a security vulnerability? Please report it privately — see our [Security Policy](https://github.com/lfnovo/esperanto/blob/main/SECURITY.md). Do not open a public issue for security reports.
+
 ## License 📄
 
 This project is licensed under the MIT License - see the [LICENSE](https://github.com/lfnovo/esperanto/blob/main/LICENSE) file for details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,58 @@
+# Security Policy
+
+Esperanto is a unified interface to many AI providers, and as such it handles
+provider API keys and brokers requests to external services. We take the
+security of the library and its users seriously.
+
+## Supported Versions
+
+Security fixes are released for the latest published minor version on PyPI.
+We recommend always running the most recent release.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 2.25.x  | :white_check_mark: |
+| < 2.25  | :x:                |
+
+When a new minor version ships, support for the previous line ends. If you are
+pinned to an older version, upgrade to receive security fixes.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+pull requests, or discussions.**
+
+Instead, use GitHub's private vulnerability reporting:
+
+1. Go to the [**Security** tab](https://github.com/lfnovo/esperanto/security) of
+   this repository.
+2. Click **Report a vulnerability**.
+3. Fill in the advisory form with as much detail as you can.
+
+This opens a private channel visible only to the maintainers.
+
+Please include, where applicable:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce, or a proof-of-concept.
+- The affected version(s) and, if known, the affected provider(s) or code path.
+- Any suggested remediation.
+
+## Response Timeline
+
+- **Acknowledgement:** we aim to acknowledge your report within **72 hours**.
+- **Assessment:** an initial assessment and severity triage within **7 days**.
+- **Resolution:** for confirmed vulnerabilities, we will work on a fix and keep
+  you informed of progress. Timelines depend on severity and complexity.
+
+Once a fix is available, we will coordinate a release and, with your consent,
+credit you in the release notes and the security advisory.
+
+## Scope
+
+This policy covers the Esperanto library itself. Vulnerabilities in the
+upstream provider APIs or third-party SDKs should be reported to their
+respective maintainers, though we welcome a heads-up if the issue affects how
+Esperanto should be used safely.
+
+Thank you for helping keep Esperanto and its users safe.


### PR DESCRIPTION
## Summary

Adds a `SECURITY.md` so there is a documented, private way to report vulnerabilities — the biggest gap flagged in the repo's security assessment (#210). For a library that brokers provider API keys, a disclosure path is table stakes.

## Changes

- **`SECURITY.md`** at repo root:
  - Private disclosure via **GitHub private vulnerability reporting** (Security tab → "Report a vulnerability") — no email exposed publicly.
  - **Supported versions** table (latest minor line).
  - **Response timeline**: 72h acknowledgement, 7d initial assessment.
  - Scope note (library vs upstream provider APIs).
- Linked from **README** (new Security section) and **CONTRIBUTING.md** (new "Reporting Security Vulnerabilities" section).

## Follow-up (repo owner action, not in this PR)

GitHub private vulnerability reporting must be **enabled** in **Settings → Code security and analysis → Private vulnerability reporting** for the "Report a vulnerability" button to appear. I could not toggle it via the API from here.

## Acceptance

- [x] `SECURITY.md` present and linked from README/CONTRIBUTING
- [x] A researcher has a clear, private channel to report issues

Closes #210

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

