### PR TITLE
feat(embedding): auto-batch requests to respect per-provider limits (part 1)

### DIFF
--- a/src/esperanto/providers/embedding/azure.py
+++ b/src/esperanto/providers/embedding/azure.py
@@ -1,7 +1,7 @@
 """Azure OpenAI embedding model provider."""
 
 import os
-from typing import Dict, List
+from typing import ClassVar, Dict, List
 
 import httpx
 
@@ -11,6 +11,9 @@ from esperanto.utils import validate_and_decode_embedding
 
 class AzureEmbeddingModel(EmbeddingModel):
     """Azure OpenAI embedding model implementation using direct HTTP."""
+
+    # Azure OpenAI accepts up to 2048 inputs per embeddings request.
+    MAX_BATCH_SIZE: ClassVar[int] = 2048
 
     def __init__(self, **kwargs):
         """Initialize Azure embedding provider.
@@ -110,32 +113,33 @@ class AzureEmbeddingModel(EmbeddingModel):
         # Clean texts using enhanced text cleaning
         texts = [self._clean_text(text) for text in texts]
 
-        # Prepare request payload
-        payload = {
-            "input": texts,
-            "model": self.deployment_name,
-            **self._get_api_kwargs(),
-        }
+        results: List[List[float]] = []
+        for batch in self._iter_embed_batches(texts):
+            # Prepare request payload
+            payload = {
+                "input": batch,
+                "model": self.deployment_name,
+                **self._get_api_kwargs(),
+            }
 
-        # Add any runtime kwargs like dimensions
-        if "dimensions" in kwargs:
-            payload["dimensions"] = kwargs["dimensions"]
+            # Add any runtime kwargs like dimensions
+            if "dimensions" in kwargs:
+                payload["dimensions"] = kwargs["dimensions"]
 
-        # Make HTTP request
-        url = self._build_url()
-        response = self.client.post(
-            url,
-            headers=self._get_headers(),
-            json=payload
-        )
-        self._handle_error(response)
+            # Make HTTP request
+            url = self._build_url()
+            response = self.client.post(
+                url,
+                headers=self._get_headers(),
+                json=payload
+            )
+            self._handle_error(response)
 
-        # Parse response
-        response_data = response.json()
-        results = []
-        for idx, data in enumerate(response_data["data"]):
-            raw = data.get("embedding")
-            results.append(validate_and_decode_embedding(idx, raw))
+            # Parse response
+            response_data = response.json()
+            for idx, data in enumerate(response_data["data"]):
+                raw = data.get("embedding")
+                results.append(validate_and_decode_embedding(idx, raw))
         return results
 
     async def aembed(self, texts: List[str], **kwargs) -> List[List[float]]:
@@ -151,32 +155,33 @@ class AzureEmbeddingModel(EmbeddingModel):
         # Clean texts using enhanced text cleaning
         texts = [self._clean_text(text) for text in texts]
 
-        # Prepare request payload
-        payload = {
-            "input": texts,
-            "model": self.deployment_name,
-            **self._get_api_kwargs(),
-        }
+        results: List[List[float]] = []
+        for batch in self._iter_embed_batches(texts):
+            # Prepare request payload
+            payload = {
+                "input": batch,
+                "model": self.deployment_name,
+                **self._get_api_kwargs(),
+            }
 
-        # Add any runtime kwargs like dimensions
-        if "dimensions" in kwargs:
-            payload["dimensions"] = kwargs["dimensions"]
+            # Add any runtime kwargs like dimensions
+            if "dimensions" in kwargs:
+                payload["dimensions"] = kwargs["dimensions"]
 
-        # Make HTTP request
-        url = self._build_url()
-        response = await self.async_client.post(
-            url,
-            headers=self._get_headers(),
-            json=payload
-        )
-        self._handle_error(response)
+            # Make HTTP request
+            url = self._build_url()
+            response = await self.async_client.post(
+                url,
+                headers=self._get_headers(),
+                json=payload
+            )
+            self._handle_error(response)
 
-        # Parse response
-        response_data = response.json()
-        results = []
-        for idx, data in enumerate(response_data["data"]):
-            raw = data.get("embedding")
-            results.append(validate_and_decode_embedding(idx, raw))
+            # Parse response
+            response_data = response.json()
+            for idx, data in enumerate(response_data["data"]):
+                raw = data.get("embedding")
+                results.append(validate_and_decode_embedding(idx, raw))
         return results
 
     def _get_default_model(self) -> str:

--- a/src/esperanto/providers/embedding/azure.py
+++ b/src/esperanto/providers/embedding/azure.py
@@ -137,7 +137,7 @@ class AzureEmbeddingModel(EmbeddingModel):
 
             # Parse response
             response_data = response.json()
-            for idx, data in enumerate(response_data["data"]):
+            for idx, data in enumerate(response_data["data"], start=len(results)):
                 raw = data.get("embedding")
                 results.append(validate_and_decode_embedding(idx, raw))
         return results
@@ -179,7 +179,7 @@ class AzureEmbeddingModel(EmbeddingModel):
 
             # Parse response
             response_data = response.json()
-            for idx, data in enumerate(response_data["data"]):
+            for idx, data in enumerate(response_data["data"], start=len(results)):
                 raw = data.get("embedding")
                 results.append(validate_and_decode_embedding(idx, raw))
         return results

--- a/src/esperanto/providers/embedding/base.py
+++ b/src/esperanto/providers/embedding/base.py
@@ -1,10 +1,11 @@
 """Base embedding model interface."""
 
+import logging
 import re
 import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, ClassVar, Dict, Iterator, List, Optional
 
 from esperanto.common_types import Model
 from esperanto.common_types.task_type import EmbeddingTaskType
@@ -14,6 +15,13 @@ from esperanto.utils.connect import HttpConnectionMixin
 @dataclass
 class EmbeddingModel(HttpConnectionMixin, ABC):
     """Base class for all embedding models."""
+
+    # Per-provider hard ceiling on how many texts a single embedding request may
+    # contain. 0 means the provider imposes no cap (send the whole list in one
+    # request). Providers override this with their API's documented limit; the
+    # base class uses it to auto-batch large inputs so switching providers never
+    # breaks otherwise-correct user code (ARCHITECTURE.md "Hot-Swap-First Defaults").
+    MAX_BATCH_SIZE: ClassVar[int] = 0
 
     api_key: Optional[str] = None
     base_url: Optional[str] = None
@@ -283,6 +291,53 @@ class EmbeddingModel(HttpConnectionMixin, ABC):
         kwargs = self._serialize_config_for_api(kwargs)
 
         return kwargs
+
+    def _get_embed_batch_size(self) -> Optional[int]:
+        """Resolve the effective number of texts to send per embedding request.
+
+        Returns the batch size, or ``None`` when no chunking should be applied
+        (the whole input goes in a single request). The provider ceiling comes
+        from ``MAX_BATCH_SIZE`` (0 = no cap); users may lower it via
+        ``config={"embed_batch_size": N}``.
+
+        Resolution rules:
+        - unset → ``MAX_BATCH_SIZE`` (or ``None`` when that is 0);
+        - ``N > MAX_BATCH_SIZE`` → silently clamped to ``MAX_BATCH_SIZE`` with a
+          ``logging.debug`` message (a request-shape sanitize, not a feature drop);
+        - ``N <= 0`` → ``ValueError``.
+        """
+        override = self._config.get("embed_batch_size")
+        if override is not None:
+            if not isinstance(override, int) or isinstance(override, bool) or override <= 0:
+                raise ValueError(
+                    f"embed_batch_size must be a positive integer, got {override!r}"
+                )
+            if 0 < self.MAX_BATCH_SIZE < override:
+                logging.debug(
+                    "embed_batch_size=%s exceeds %s MAX_BATCH_SIZE=%s; clamping to %s",
+                    override,
+                    type(self).__name__,
+                    self.MAX_BATCH_SIZE,
+                    self.MAX_BATCH_SIZE,
+                )
+                return self.MAX_BATCH_SIZE
+            return override
+        return self.MAX_BATCH_SIZE if self.MAX_BATCH_SIZE > 0 else None
+
+    def _iter_embed_batches(self, texts: List[str]) -> Iterator[List[str]]:
+        """Yield successive slices of ``texts`` respecting the resolved batch size.
+
+        Empty input yields nothing, so callers make zero API calls. When batching
+        is disabled or the input already fits, the whole list is yielded once.
+        """
+        if not texts:
+            return
+        size = self._get_embed_batch_size()
+        if not size or size >= len(texts):
+            yield list(texts)
+            return
+        for start in range(0, len(texts), size):
+            yield texts[start : start + size]
 
     @property
     @abstractmethod

--- a/src/esperanto/providers/embedding/base.py
+++ b/src/esperanto/providers/embedding/base.py
@@ -283,6 +283,9 @@ class EmbeddingModel(HttpConnectionMixin, ABC):
         kwargs.pop("api_key", None)
         kwargs.pop("base_url", None)
         kwargs.pop("organization", None)
+        # Client-side batching control — never send it in the request body, or
+        # providers that reject unknown fields would fail on a valid override.
+        kwargs.pop("embed_batch_size", None)
 
         # Filter out unsupported advanced features
         kwargs = self._filter_unsupported_params(kwargs)

--- a/src/esperanto/providers/embedding/cohere.py
+++ b/src/esperanto/providers/embedding/cohere.py
@@ -91,8 +91,7 @@ class CohereEmbeddingModel(EmbeddingModel):
         texts = [self._clean_text(text) for text in texts]
 
         results: List[List[float]] = []
-        for start in range(0, len(texts), self.MAX_BATCH_SIZE):
-            batch = texts[start : start + self.MAX_BATCH_SIZE]
+        for batch in self._iter_embed_batches(texts):
             payload = self._build_payload(batch, **kwargs)
 
             response = self.client.post(
@@ -110,8 +109,7 @@ class CohereEmbeddingModel(EmbeddingModel):
         texts = [self._clean_text(text) for text in texts]
 
         results: List[List[float]] = []
-        for start in range(0, len(texts), self.MAX_BATCH_SIZE):
-            batch = texts[start : start + self.MAX_BATCH_SIZE]
+        for batch in self._iter_embed_batches(texts):
             payload = self._build_payload(batch, **kwargs)
 
             response = await self.async_client.post(

--- a/src/esperanto/providers/embedding/jina.py
+++ b/src/esperanto/providers/embedding/jina.py
@@ -1,7 +1,7 @@
 """Jina AI embedding model implementation."""
 
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 
 import httpx
 
@@ -14,6 +14,9 @@ from .base import EmbeddingModel
 
 class JinaEmbeddingModel(EmbeddingModel):
     """Jina AI embeddings with native support for all advanced features."""
+
+    # Jina's embeddings API accepts up to 2048 inputs per request.
+    MAX_BATCH_SIZE: ClassVar[int] = 2048
 
     # Jina supports all advanced features natively
     SUPPORTED_FEATURES = ["task_type", "late_chunking", "output_dimensions", "truncate_at_max_length"]
@@ -148,34 +151,35 @@ class JinaEmbeddingModel(EmbeddingModel):
         if not texts:
             return []
 
-        payload = self._build_request_payload(texts)
+        results: List[List[float]] = []
+        for batch in self._iter_embed_batches(texts):
+            payload = self._build_request_payload(batch)
 
-        try:
-            response = self.client.post(
-                self.base_url or "",
-                json=payload,
-                headers=self._get_headers()
-            )
+            try:
+                response = self.client.post(
+                    self.base_url or "",
+                    json=payload,
+                    headers=self._get_headers()
+                )
 
-            if response.status_code != 200:
-                self._handle_error(response)
+                if response.status_code != 200:
+                    self._handle_error(response)
 
-            response_data = response.json()
+                response_data = response.json()
 
-            # Extract embeddings from response
-            embeddings = []
-            for idx, item in enumerate(response_data.get("data", [])):
-                embedding = item.get("embedding")
-                embeddings.append(validate_and_decode_embedding(idx, embedding))
+                # Extract embeddings from response
+                for idx, item in enumerate(response_data.get("data", [])):
+                    embedding = item.get("embedding")
+                    results.append(validate_and_decode_embedding(idx, embedding))
 
-            return embeddings
+            except httpx.TimeoutException:
+                raise RuntimeError("Request to Jina API timed out")
+            except httpx.RequestError as e:
+                raise RuntimeError(f"Network error calling Jina API: {str(e)}")
+            finally:
+                pass  # Client is reused, don't close
 
-        except httpx.TimeoutException:
-            raise RuntimeError("Request to Jina API timed out")
-        except httpx.RequestError as e:
-            raise RuntimeError(f"Network error calling Jina API: {str(e)}")
-        finally:
-            pass  # Client is reused, don't close
+        return results
 
     async def aembed(self, texts: List[str], **kwargs) -> List[List[float]]:
         """Create embeddings for the given texts asynchronously.
@@ -190,32 +194,33 @@ class JinaEmbeddingModel(EmbeddingModel):
         if not texts:
             return []
 
-        payload = self._build_request_payload(texts)
+        results: List[List[float]] = []
+        for batch in self._iter_embed_batches(texts):
+            payload = self._build_request_payload(batch)
 
-        try:
-            response = await self.async_client.post(
-                self.base_url or "",
-                json=payload,
-                headers=self._get_headers()
-            )
+            try:
+                response = await self.async_client.post(
+                    self.base_url or "",
+                    json=payload,
+                    headers=self._get_headers()
+                )
 
-            if response.status_code != 200:
-                self._handle_error(response)
+                if response.status_code != 200:
+                    self._handle_error(response)
 
-            response_data = response.json()
+                response_data = response.json()
 
-            # Extract embeddings from response
-            embeddings = []
-            for idx, item in enumerate(response_data.get("data", [])):
-                embedding = item.get("embedding")
-                embeddings.append(validate_and_decode_embedding(idx, embedding))
+                # Extract embeddings from response
+                for idx, item in enumerate(response_data.get("data", [])):
+                    embedding = item.get("embedding")
+                    results.append(validate_and_decode_embedding(idx, embedding))
 
-            return embeddings
+            except httpx.TimeoutException:
+                raise RuntimeError("Request to Jina API timed out")
+            except httpx.RequestError as e:
+                raise RuntimeError(f"Network error calling Jina API: {str(e)}")
 
-        except httpx.TimeoutException:
-            raise RuntimeError("Request to Jina API timed out")
-        except httpx.RequestError as e:
-            raise RuntimeError(f"Network error calling Jina API: {str(e)}")
+        return results
 
     @property
     def provider(self) -> str:

--- a/src/esperanto/providers/embedding/jina.py
+++ b/src/esperanto/providers/embedding/jina.py
@@ -168,7 +168,7 @@ class JinaEmbeddingModel(EmbeddingModel):
                 response_data = response.json()
 
                 # Extract embeddings from response
-                for idx, item in enumerate(response_data.get("data", [])):
+                for idx, item in enumerate(response_data.get("data", []), start=len(results)):
                     embedding = item.get("embedding")
                     results.append(validate_and_decode_embedding(idx, embedding))
 
@@ -211,7 +211,7 @@ class JinaEmbeddingModel(EmbeddingModel):
                 response_data = response.json()
 
                 # Extract embeddings from response
-                for idx, item in enumerate(response_data.get("data", [])):
+                for idx, item in enumerate(response_data.get("data", []), start=len(results)):
                     embedding = item.get("embedding")
                     results.append(validate_and_decode_embedding(idx, embedding))
 

--- a/src/esperanto/providers/embedding/mistral.py
+++ b/src/esperanto/providers/embedding/mistral.py
@@ -72,7 +72,7 @@ class MistralEmbeddingModel(EmbeddingModel):
             self._handle_error(response)
 
             response_data = response.json()
-            for idx, data in enumerate(response_data["data"]):
+            for idx, data in enumerate(response_data["data"], start=len(results)):
                 raw = data.get("embedding")
                 results.append(validate_and_decode_embedding(idx, raw))
         return results
@@ -101,7 +101,7 @@ class MistralEmbeddingModel(EmbeddingModel):
             self._handle_error(response)
 
             response_data = response.json()
-            for idx, data in enumerate(response_data["data"]):
+            for idx, data in enumerate(response_data["data"], start=len(results)):
                 raw = data.get("embedding")
                 results.append(validate_and_decode_embedding(idx, raw))
         return results

--- a/src/esperanto/providers/embedding/mistral.py
+++ b/src/esperanto/providers/embedding/mistral.py
@@ -1,6 +1,6 @@
 """Mistral embedding model provider."""
 import os
-from typing import Dict, List
+from typing import ClassVar, Dict, List
 
 import httpx
 
@@ -10,6 +10,9 @@ from esperanto.utils import validate_and_decode_embedding
 
 class MistralEmbeddingModel(EmbeddingModel):
     """Mistral embedding model implementation."""
+
+    # Mistral accepts up to 64 inputs per embeddings request.
+    MAX_BATCH_SIZE: ClassVar[int] = 64
 
     def __post_init__(self):
         """Initialize HTTP clients."""
@@ -49,56 +52,58 @@ class MistralEmbeddingModel(EmbeddingModel):
         """Create embeddings for the given texts."""
         # Clean texts using enhanced text cleaning
         texts = [self._clean_text(text) for text in texts]
-        
-        # Prepare request payload - Mistral uses 'input' instead of 'inputs'
-        payload = {
-            "model": self.get_model_name(),
-            "input": texts,
-            **self._get_api_kwargs(),
-            **kwargs
-        }
 
-        # Make HTTP request
-        response = self.client.post(
-            f"{self.base_url}/embeddings",
-            headers=self._get_headers(),
-            json=payload
-        )
-        self._handle_error(response)
-        
-        response_data = response.json()
-        results = []
-        for idx, data in enumerate(response_data["data"]):
-            raw = data.get("embedding")
-            results.append(validate_and_decode_embedding(idx, raw))
+        results: List[List[float]] = []
+        for batch in self._iter_embed_batches(texts):
+            # Prepare request payload - Mistral uses 'input' instead of 'inputs'
+            payload = {
+                "model": self.get_model_name(),
+                "input": batch,
+                **self._get_api_kwargs(),
+                **kwargs
+            }
+
+            # Make HTTP request
+            response = self.client.post(
+                f"{self.base_url}/embeddings",
+                headers=self._get_headers(),
+                json=payload
+            )
+            self._handle_error(response)
+
+            response_data = response.json()
+            for idx, data in enumerate(response_data["data"]):
+                raw = data.get("embedding")
+                results.append(validate_and_decode_embedding(idx, raw))
         return results
 
     async def aembed(self, texts: List[str], **kwargs) -> List[List[float]]:
         """Create embeddings for the given texts asynchronously."""
         # Clean texts using enhanced text cleaning
         texts = [self._clean_text(text) for text in texts]
-        
-        # Prepare request payload - Mistral uses 'input' instead of 'inputs'
-        payload = {
-            "model": self.get_model_name(),
-            "input": texts,
-            **self._get_api_kwargs(),
-            **kwargs
-        }
 
-        # Make async HTTP request
-        response = await self.async_client.post(
-            f"{self.base_url}/embeddings",
-            headers=self._get_headers(),
-            json=payload
-        )
-        self._handle_error(response)
-        
-        response_data = response.json()
-        results = []
-        for idx, data in enumerate(response_data["data"]):
-            raw = data.get("embedding")
-            results.append(validate_and_decode_embedding(idx, raw))
+        results: List[List[float]] = []
+        for batch in self._iter_embed_batches(texts):
+            # Prepare request payload - Mistral uses 'input' instead of 'inputs'
+            payload = {
+                "model": self.get_model_name(),
+                "input": batch,
+                **self._get_api_kwargs(),
+                **kwargs
+            }
+
+            # Make async HTTP request
+            response = await self.async_client.post(
+                f"{self.base_url}/embeddings",
+                headers=self._get_headers(),
+                json=payload
+            )
+            self._handle_error(response)
+
+            response_data = response.json()
+            for idx, data in enumerate(response_data["data"]):
+                raw = data.get("embedding")
+                results.append(validate_and_decode_embedding(idx, raw))
         return results
 
     def _get_default_model(self) -> str:

--- a/src/esperanto/providers/embedding/ollama.py
+++ b/src/esperanto/providers/embedding/ollama.py
@@ -65,7 +65,7 @@ class OllamaEmbeddingModel(EmbeddingModel):
             ValueError: If text is None or empty.
         """
         if not texts:
-            raise ValueError("Texts cannot be empty")
+            return []
 
         # Validate texts
         for text in texts:
@@ -97,7 +97,7 @@ class OllamaEmbeddingModel(EmbeddingModel):
                 self._handle_error(response)
 
                 response_data = response.json()
-                for idx, embedding in enumerate(response_data["embeddings"]):
+                for idx, embedding in enumerate(response_data["embeddings"], start=len(results)):
                     results.append(validate_and_decode_embedding(idx, embedding))
             except Exception as e:
                 raise RuntimeError(f"Failed to get embeddings: {str(e)}") from e
@@ -118,7 +118,7 @@ class OllamaEmbeddingModel(EmbeddingModel):
             ValueError: If text is None or empty.
         """
         if not texts:
-            raise ValueError("Texts cannot be empty")
+            return []
 
         # Validate texts
         for text in texts:
@@ -150,7 +150,7 @@ class OllamaEmbeddingModel(EmbeddingModel):
                 self._handle_error(response)
 
                 response_data = response.json()
-                for idx, embedding in enumerate(response_data["embeddings"]):
+                for idx, embedding in enumerate(response_data["embeddings"], start=len(results)):
                     results.append(validate_and_decode_embedding(idx, embedding))
             except Exception as e:
                 raise RuntimeError(f"Failed to get embeddings: {str(e)}") from e

--- a/src/esperanto/providers/embedding/ollama.py
+++ b/src/esperanto/providers/embedding/ollama.py
@@ -1,7 +1,7 @@
 """Ollama embedding model provider."""
 
 import os
-from typing import Any, Dict, List
+from typing import Any, ClassVar, Dict, List
 
 import httpx
 
@@ -11,6 +11,10 @@ from esperanto.utils import validate_and_decode_embedding
 
 class OllamaEmbeddingModel(EmbeddingModel):
     """Ollama embedding model implementation."""
+
+    # Ollama imposes no documented per-request cap; send the whole list in one
+    # request by default (users may still lower it via embed_batch_size).
+    MAX_BATCH_SIZE: ClassVar[int] = 0
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -73,30 +77,31 @@ class OllamaEmbeddingModel(EmbeddingModel):
         # Clean all texts
         cleaned_texts = [self._clean_text(text) for text in texts]
 
-        # Prepare request payload - use batch processing with input array
-        payload = {
-            "model": self.get_model_name(),
-            "input": cleaned_texts,
-            **self._get_api_kwargs(),
-            **kwargs
-        }
+        results: List[List[float]] = []
+        for batch in self._iter_embed_batches(cleaned_texts):
+            # Prepare request payload - use batch processing with input array
+            payload = {
+                "model": self.get_model_name(),
+                "input": batch,
+                **self._get_api_kwargs(),
+                **kwargs
+            }
 
-        try:
-            # Make HTTP request to new /api/embed endpoint
-            response = self.client.post(
-                f"{self.base_url}/api/embed",
-                headers=self._get_headers(),
-                json=payload
-            )
-            self._handle_error(response)
+            try:
+                # Make HTTP request to new /api/embed endpoint
+                response = self.client.post(
+                    f"{self.base_url}/api/embed",
+                    headers=self._get_headers(),
+                    json=payload
+                )
+                self._handle_error(response)
 
-            response_data = response.json()
-            results = []
-            for idx, embedding in enumerate(response_data["embeddings"]):
-                results.append(validate_and_decode_embedding(idx, embedding))
-            return results
-        except Exception as e:
-            raise RuntimeError(f"Failed to get embeddings: {str(e)}") from e
+                response_data = response.json()
+                for idx, embedding in enumerate(response_data["embeddings"]):
+                    results.append(validate_and_decode_embedding(idx, embedding))
+            except Exception as e:
+                raise RuntimeError(f"Failed to get embeddings: {str(e)}") from e
+        return results
 
     async def aembed(self, texts: List[str], **kwargs) -> List[List[float]]:
         """Create embeddings for the given texts asynchronously.
@@ -125,30 +130,31 @@ class OllamaEmbeddingModel(EmbeddingModel):
         # Clean all texts
         cleaned_texts = [self._clean_text(text) for text in texts]
 
-        # Prepare request payload - use batch processing with input array
-        payload = {
-            "model": self.get_model_name(),
-            "input": cleaned_texts,
-            **self._get_api_kwargs(),
-            **kwargs
-        }
+        results: List[List[float]] = []
+        for batch in self._iter_embed_batches(cleaned_texts):
+            # Prepare request payload - use batch processing with input array
+            payload = {
+                "model": self.get_model_name(),
+                "input": batch,
+                **self._get_api_kwargs(),
+                **kwargs
+            }
 
-        try:
-            # Make async HTTP request to new /api/embed endpoint
-            response = await self.async_client.post(
-                f"{self.base_url}/api/embed",
-                headers=self._get_headers(),
-                json=payload
-            )
-            self._handle_error(response)
+            try:
+                # Make async HTTP request to new /api/embed endpoint
+                response = await self.async_client.post(
+                    f"{self.base_url}/api/embed",
+                    headers=self._get_headers(),
+                    json=payload
+                )
+                self._handle_error(response)
 
-            response_data = response.json()
-            results = []
-            for idx, embedding in enumerate(response_data["embeddings"]):
-                results.append(validate_and_decode_embedding(idx, embedding))
-            return results
-        except Exception as e:
-            raise RuntimeError(f"Failed to get embeddings: {str(e)}") from e
+                response_data = response.json()
+                for idx, embedding in enumerate(response_data["embeddings"]):
+                    results.append(validate_and_decode_embedding(idx, embedding))
+            except Exception as e:
+                raise RuntimeError(f"Failed to get embeddings: {str(e)}") from e
+        return results
 
     def _get_default_model(self) -> str:
         """Get the default model name."""

--- a/src/esperanto/providers/embedding/openai.py
+++ b/src/esperanto/providers/embedding/openai.py
@@ -90,7 +90,7 @@ class OpenAIEmbeddingModel(EmbeddingModel):
 
             # Parse response
             response_data = response.json()
-            for idx, data in enumerate(response_data["data"]):
+            for idx, data in enumerate(response_data["data"], start=len(results)):
                 raw = data.get("embedding")
                 results.append(validate_and_decode_embedding(idx, raw))
         return results
@@ -127,7 +127,7 @@ class OpenAIEmbeddingModel(EmbeddingModel):
 
             # Parse response
             response_data = response.json()
-            for idx, data in enumerate(response_data["data"]):
+            for idx, data in enumerate(response_data["data"], start=len(results)):
                 raw = data.get("embedding")
                 results.append(validate_and_decode_embedding(idx, raw))
         return results

--- a/src/esperanto/providers/embedding/openai.py
+++ b/src/esperanto/providers/embedding/openai.py
@@ -1,6 +1,6 @@
 """OpenAI embedding model provider."""
 import os
-from typing import Dict, List
+from typing import ClassVar, Dict, List
 
 import httpx
 
@@ -10,6 +10,9 @@ from esperanto.utils import validate_and_decode_embedding
 
 class OpenAIEmbeddingModel(EmbeddingModel):
     """OpenAI embedding model implementation."""
+
+    # OpenAI accepts up to 2048 inputs per embeddings request.
+    MAX_BATCH_SIZE: ClassVar[int] = 2048
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -68,27 +71,28 @@ class OpenAIEmbeddingModel(EmbeddingModel):
         # Clean texts using enhanced text cleaning
         texts = [self._clean_text(text) for text in texts]
 
-        # Prepare request payload
-        payload = {
-            "input": texts,
-            "model": self.get_model_name(),
-            **{**self._get_api_kwargs(), **kwargs}
-        }
+        results: List[List[float]] = []
+        for batch in self._iter_embed_batches(texts):
+            # Prepare request payload
+            payload = {
+                "input": batch,
+                "model": self.get_model_name(),
+                **{**self._get_api_kwargs(), **kwargs}
+            }
 
-        # Make HTTP request
-        response = self.client.post(
-            f"{self.base_url}/embeddings",
-            headers=self._get_headers(),
-            json=payload
-        )
-        self._handle_error(response)
+            # Make HTTP request
+            response = self.client.post(
+                f"{self.base_url}/embeddings",
+                headers=self._get_headers(),
+                json=payload
+            )
+            self._handle_error(response)
 
-        # Parse response
-        response_data = response.json()
-        results = []
-        for idx, data in enumerate(response_data["data"]):
-            raw = data.get("embedding")
-            results.append(validate_and_decode_embedding(idx, raw))
+            # Parse response
+            response_data = response.json()
+            for idx, data in enumerate(response_data["data"]):
+                raw = data.get("embedding")
+                results.append(validate_and_decode_embedding(idx, raw))
         return results
 
     async def aembed(self, texts: List[str], **kwargs) -> List[List[float]]:
@@ -104,27 +108,28 @@ class OpenAIEmbeddingModel(EmbeddingModel):
         # Clean texts using enhanced text cleaning
         texts = [self._clean_text(text) for text in texts]
 
-        # Prepare request payload
-        payload = {
-            "input": texts,
-            "model": self.get_model_name(),
-            **{**self._get_api_kwargs(), **kwargs}
-        }
+        results: List[List[float]] = []
+        for batch in self._iter_embed_batches(texts):
+            # Prepare request payload
+            payload = {
+                "input": batch,
+                "model": self.get_model_name(),
+                **{**self._get_api_kwargs(), **kwargs}
+            }
 
-        # Make HTTP request
-        response = await self.async_client.post(
-            f"{self.base_url}/embeddings",
-            headers=self._get_headers(),
-            json=payload
-        )
-        self._handle_error(response)
+            # Make HTTP request
+            response = await self.async_client.post(
+                f"{self.base_url}/embeddings",
+                headers=self._get_headers(),
+                json=payload
+            )
+            self._handle_error(response)
 
-        # Parse response
-        response_data = response.json()
-        results = []
-        for idx, data in enumerate(response_data["data"]):
-            raw = data.get("embedding")
-            results.append(validate_and_decode_embedding(idx, raw))
+            # Parse response
+            response_data = response.json()
+            for idx, data in enumerate(response_data["data"]):
+                raw = data.get("embedding")
+                results.append(validate_and_decode_embedding(idx, raw))
         return results
 
     def _get_default_model(self) -> str:

--- a/src/esperanto/providers/embedding/openrouter.py
+++ b/src/esperanto/providers/embedding/openrouter.py
@@ -2,7 +2,7 @@
 
 import os
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import ClassVar, Dict, List, Optional
 
 from esperanto.common_types import Model
 from esperanto.providers.embedding.openai import OpenAIEmbeddingModel
@@ -11,6 +11,9 @@ from esperanto.providers.embedding.openai import OpenAIEmbeddingModel
 @dataclass
 class OpenRouterEmbeddingModel(OpenAIEmbeddingModel):
     """OpenRouter embedding model implementation using OpenAI-compatible API."""
+
+    # OpenRouter accepts up to 96 inputs per embeddings request.
+    MAX_BATCH_SIZE: ClassVar[int] = 96
 
     base_url: Optional[str] = None
     api_key: Optional[str] = None
@@ -72,23 +75,29 @@ class OpenRouterEmbeddingModel(OpenAIEmbeddingModel):
         # Clean texts using enhanced text cleaning
         texts = [self._clean_text(text) for text in texts]
 
-        # Prepare request payload
-        payload = {
-            "input": texts,
-            "model": self.get_model_name(),
-            **{**self._get_api_kwargs(), **kwargs}
-        }
+        results: List[List[float]] = []
+        for batch in self._iter_embed_batches(texts):
+            # Prepare request payload
+            payload = {
+                "input": batch,
+                "model": self.get_model_name(),
+                **{**self._get_api_kwargs(), **kwargs}
+            }
 
-        response = self.client.post(
-            f"{self.base_url}/embeddings",
-            headers=self._get_headers(),
-            json=payload
-        )
-        self._handle_error(response)
+            response = self.client.post(
+                f"{self.base_url}/embeddings",
+                headers=self._get_headers(),
+                json=payload
+            )
+            self._handle_error(response)
 
-        # Parse response
-        response_data = response.json()
-        return [[float(value) for value in data["embedding"]] for data in response_data["data"]]
+            # Parse response
+            response_data = response.json()
+            results.extend(
+                [float(value) for value in data["embedding"]]
+                for data in response_data["data"]
+            )
+        return results
 
     async def aembed(self, texts: List[str], **kwargs) -> List[List[float]]:
         """Create embeddings for the given texts asynchronously.
@@ -103,23 +112,29 @@ class OpenRouterEmbeddingModel(OpenAIEmbeddingModel):
         # Clean texts using enhanced text cleaning
         texts = [self._clean_text(text) for text in texts]
 
-        # Prepare request payload
-        payload = {
-            "input": texts,
-            "model": self.get_model_name(),
-            **{**self._get_api_kwargs(), **kwargs}
-        }
+        results: List[List[float]] = []
+        for batch in self._iter_embed_batches(texts):
+            # Prepare request payload
+            payload = {
+                "input": batch,
+                "model": self.get_model_name(),
+                **{**self._get_api_kwargs(), **kwargs}
+            }
 
-        response = await self.async_client.post(
-            f"{self.base_url}/embeddings",
-            headers=self._get_headers(),
-            json=payload
-        )
-        self._handle_error(response)
+            response = await self.async_client.post(
+                f"{self.base_url}/embeddings",
+                headers=self._get_headers(),
+                json=payload
+            )
+            self._handle_error(response)
 
-        # Parse response
-        response_data = response.json()
-        return [[float(value) for value in data["embedding"]] for data in response_data["data"]]
+            # Parse response
+            response_data = response.json()
+            results.extend(
+                [float(value) for value in data["embedding"]]
+                for data in response_data["data"]
+            )
+        return results
 
     def _get_default_model(self) -> str:
         """Get the default model name."""

--- a/src/esperanto/providers/embedding/voyage.py
+++ b/src/esperanto/providers/embedding/voyage.py
@@ -89,7 +89,7 @@ class VoyageEmbeddingModel(EmbeddingModel):
             self._handle_error(response)
 
             response_data = response.json()
-            for idx, data in enumerate(response_data["data"]):
+            for idx, data in enumerate(response_data["data"], start=len(results)):
                 raw = data.get("embedding")
                 results.append(validate_and_decode_embedding(idx, raw))
         return results
@@ -126,7 +126,7 @@ class VoyageEmbeddingModel(EmbeddingModel):
             self._handle_error(response)
 
             response_data = response.json()
-            for idx, data in enumerate(response_data["data"]):
+            for idx, data in enumerate(response_data["data"], start=len(results)):
                 raw = data.get("embedding")
                 results.append(validate_and_decode_embedding(idx, raw))
         return results

--- a/src/esperanto/providers/embedding/voyage.py
+++ b/src/esperanto/providers/embedding/voyage.py
@@ -1,7 +1,7 @@
 """Voyage AI embedding model provider."""
 
 import os
-from typing import Dict, List
+from typing import ClassVar, Dict, List
 
 import httpx
 
@@ -11,6 +11,9 @@ from esperanto.utils import validate_and_decode_embedding
 
 class VoyageEmbeddingModel(EmbeddingModel):
     """Voyage AI embedding model implementation."""
+
+    # Voyage accepts up to 1000 inputs per embeddings request.
+    MAX_BATCH_SIZE: ClassVar[int] = 1000
 
     def __init__(self, **kwargs):
         """Initialize the model.
@@ -67,27 +70,28 @@ class VoyageEmbeddingModel(EmbeddingModel):
         # Clean texts by replacing newlines with spaces
         texts = [self._clean_text(text) for text in texts]
 
-        # Prepare request payload
-        payload = {
-            "input": texts,
-            "model": self.get_model_name(),
-            **self._get_api_kwargs(),
-            **kwargs
-        }
+        results: List[List[float]] = []
+        for batch in self._iter_embed_batches(texts):
+            # Prepare request payload
+            payload = {
+                "input": batch,
+                "model": self.get_model_name(),
+                **self._get_api_kwargs(),
+                **kwargs
+            }
 
-        # Make HTTP request
-        response = self.client.post(
-            f"{self.base_url}/embeddings",
-            headers=self._get_headers(),
-            json=payload
-        )
-        self._handle_error(response)
-        
-        response_data = response.json()
-        results = []
-        for idx, data in enumerate(response_data["data"]):
-            raw = data.get("embedding")
-            results.append(validate_and_decode_embedding(idx, raw))
+            # Make HTTP request
+            response = self.client.post(
+                f"{self.base_url}/embeddings",
+                headers=self._get_headers(),
+                json=payload
+            )
+            self._handle_error(response)
+
+            response_data = response.json()
+            for idx, data in enumerate(response_data["data"]):
+                raw = data.get("embedding")
+                results.append(validate_and_decode_embedding(idx, raw))
         return results
 
     async def aembed(self, texts: List[str], **kwargs) -> List[List[float]]:
@@ -103,27 +107,28 @@ class VoyageEmbeddingModel(EmbeddingModel):
         # Clean texts by replacing newlines with spaces
         texts = [self._clean_text(text) for text in texts]
 
-        # Prepare request payload
-        payload = {
-            "input": texts,
-            "model": self.get_model_name(),
-            **self._get_api_kwargs(),
-            **kwargs
-        }
+        results: List[List[float]] = []
+        for batch in self._iter_embed_batches(texts):
+            # Prepare request payload
+            payload = {
+                "input": batch,
+                "model": self.get_model_name(),
+                **self._get_api_kwargs(),
+                **kwargs
+            }
 
-        # Make async HTTP request
-        response = await self.async_client.post(
-            f"{self.base_url}/embeddings",
-            headers=self._get_headers(),
-            json=payload
-        )
-        self._handle_error(response)
-        
-        response_data = response.json()
-        results = []
-        for idx, data in enumerate(response_data["data"]):
-            raw = data.get("embedding")
-            results.append(validate_and_decode_embedding(idx, raw))
+            # Make async HTTP request
+            response = await self.async_client.post(
+                f"{self.base_url}/embeddings",
+                headers=self._get_headers(),
+                json=payload
+            )
+            self._handle_error(response)
+
+            response_data = response.json()
+            for idx, data in enumerate(response_data["data"]):
+                raw = data.get("embedding")
+                results.append(validate_and_decode_embedding(idx, raw))
         return results
 
     def _get_default_model(self) -> str:

--- a/tests/providers/embedding/test_embed_batching.py
+++ b/tests/providers/embedding/test_embed_batching.py
@@ -1,0 +1,269 @@
+"""Tests for auto-batching of embedding requests across providers.
+
+These verify the batching envelope added on top of each provider's single-request
+body: an input longer than the effective batch size is split into
+``ceil(len / batch)`` ordered slices, each sent as its own HTTP request, with the
+decoded embeddings concatenated back in input order. Empty input makes zero
+requests. All tests are hermetic — no real HTTP clients are created.
+"""
+
+import math
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from esperanto.providers.embedding.base import EmbeddingModel
+from esperanto.providers.embedding.cohere import CohereEmbeddingModel
+from esperanto.providers.embedding.mistral import MistralEmbeddingModel
+from esperanto.providers.embedding.openai import OpenAIEmbeddingModel
+from esperanto.providers.embedding.voyage import VoyageEmbeddingModel
+
+# --- response builders -------------------------------------------------------
+# Each embedding encodes the numeric suffix of its text ("t7" -> [7.0]) so we can
+# assert both concatenation and ordering of the final result.
+
+
+def _text_value(text):
+    return float(int(text[1:]))
+
+
+def _data_response(batch):
+    """OpenAI/Voyage/Mistral-style response (``data`` -> list of embeddings)."""
+    return {"data": [{"embedding": [_text_value(t)]} for t in batch]}
+
+
+def _cohere_response(batch):
+    """Cohere v2-style response (``embeddings.float``)."""
+    return {"embeddings": {"float": [[_text_value(t)] for t in batch]}}
+
+
+# Provider -> (class, input payload key, response builder, MAX_BATCH_SIZE)
+PROVIDERS = {
+    "openai": (OpenAIEmbeddingModel, "input", _data_response, 2048),
+    "voyage": (VoyageEmbeddingModel, "input", _data_response, 1000),
+    "mistral": (MistralEmbeddingModel, "input", _data_response, 64),
+    "cohere": (CohereEmbeddingModel, "texts", _cohere_response, 96),
+}
+
+
+def _make_model(cls, response_builder, config=None):
+    """Build a provider instance with mocked sync/async HTTP clients.
+
+    Each POST inspects the request payload and returns a response sized to the
+    batch it was given, so batching behaviour is exercised end to end.
+    """
+    with patch.object(cls, "_create_http_clients", lambda self: None):
+        model = cls(model_name="test-model", api_key="test-key", config=config or {})
+
+    def _batch_from(kwargs):
+        payload = kwargs["json"]
+        return payload.get("input", payload.get("texts"))
+
+    def post(url, **kwargs):
+        resp = Mock()
+        resp.status_code = 200
+        resp.json.return_value = response_builder(_batch_from(kwargs))
+        return resp
+
+    async def apost(url, **kwargs):
+        resp = Mock()
+        resp.status_code = 200
+        resp.json.return_value = response_builder(_batch_from(kwargs))
+        return resp
+
+    mock_client = Mock()
+    mock_async_client = AsyncMock()
+    mock_client.post.side_effect = post
+    mock_async_client.post.side_effect = apost
+    model.client = mock_client
+    model.async_client = mock_async_client
+    return model
+
+
+def _sent_batches(mock_client):
+    """Reconstruct the list-of-batches actually sent, in call order."""
+    batches = []
+    for call in mock_client.post.call_args_list:
+        payload = call.kwargs["json"]
+        batches.append(payload.get("input", payload.get("texts")))
+    return batches
+
+
+@pytest.mark.parametrize("provider", list(PROVIDERS))
+def test_multi_batch_sync(provider):
+    cls, _key, builder, _max = PROVIDERS[provider]
+    model = _make_model(cls, builder, config={"embed_batch_size": 2})
+
+    texts = [f"t{i}" for i in range(5)]
+    result = model.embed(texts)
+
+    # 5 texts, batch 2 -> ceil(5/2) == 3 requests.
+    assert model.client.post.call_count == math.ceil(5 / 2)
+    # Correct ordered slices.
+    assert _sent_batches(model.client) == [["t0", "t1"], ["t2", "t3"], ["t4"]]
+    # Concatenated in input order.
+    assert result == [[0.0], [1.0], [2.0], [3.0], [4.0]]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", list(PROVIDERS))
+async def test_multi_batch_async(provider):
+    cls, _key, builder, _max = PROVIDERS[provider]
+    model = _make_model(cls, builder, config={"embed_batch_size": 2})
+
+    texts = [f"t{i}" for i in range(5)]
+    result = await model.aembed(texts)
+
+    assert model.async_client.post.await_count == math.ceil(5 / 2)
+    assert _sent_batches(model.async_client) == [["t0", "t1"], ["t2", "t3"], ["t4"]]
+    assert result == [[0.0], [1.0], [2.0], [3.0], [4.0]]
+
+
+@pytest.mark.parametrize("provider", list(PROVIDERS))
+def test_empty_input_makes_zero_requests(provider):
+    cls, _key, builder, _max = PROVIDERS[provider]
+    model = _make_model(cls, builder)
+
+    assert model.embed([]) == []
+    assert model.client.post.call_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", list(PROVIDERS))
+async def test_empty_input_makes_zero_requests_async(provider):
+    cls, _key, builder, _max = PROVIDERS[provider]
+    model = _make_model(cls, builder)
+
+    assert await model.aembed([]) == []
+    assert model.async_client.post.await_count == 0
+
+
+@pytest.mark.parametrize("provider", list(PROVIDERS))
+def test_input_within_batch_is_single_request(provider):
+    cls, _key, builder, _max = PROVIDERS[provider]
+    model = _make_model(cls, builder)  # no override -> MAX_BATCH_SIZE (large)
+
+    texts = [f"t{i}" for i in range(3)]
+    result = model.embed(texts)
+
+    assert model.client.post.call_count == 1
+    assert _sent_batches(model.client) == [["t0", "t1", "t2"]]
+    assert result == [[0.0], [1.0], [2.0]]
+
+
+@pytest.mark.parametrize("provider", list(PROVIDERS))
+def test_override_above_max_clamps_to_max(provider):
+    cls, _key, _builder, expected_max = PROVIDERS[provider]
+    model = _make_model(cls, _builder, config={"embed_batch_size": expected_max + 10_000})
+
+    # Effective batch size is clamped to the provider ceiling.
+    assert model._get_embed_batch_size() == expected_max
+
+
+def test_clamp_is_functional_for_mistral():
+    # Mistral MAX == 64. Override 1000 clamps to 64, so 65 texts -> 2 requests.
+    cls, _key, builder, _max = PROVIDERS["mistral"]
+    model = _make_model(cls, builder, config={"embed_batch_size": 1000})
+
+    texts = [f"t{i}" for i in range(65)]
+    result = model.embed(texts)
+
+    assert model.client.post.call_count == 2
+    batches = _sent_batches(model.client)
+    assert [len(b) for b in batches] == [64, 1]
+    assert result == [[float(i)] for i in range(65)]
+
+
+@pytest.mark.parametrize("provider", list(PROVIDERS))
+@pytest.mark.parametrize("bad", [0, -1, -50])
+def test_non_positive_batch_size_raises(provider, bad):
+    cls, _key, builder, _max = PROVIDERS[provider]
+    model = _make_model(cls, builder, config={"embed_batch_size": bad})
+
+    with pytest.raises(ValueError, match="embed_batch_size must be a positive integer"):
+        model.embed(["t0"])
+    assert model.client.post.call_count == 0
+
+
+# --- base resolver / iterator unit tests -------------------------------------
+
+
+class _DummyEmbed(EmbeddingModel):
+    """Minimal concrete provider (MAX_BATCH_SIZE=10) for base-logic tests."""
+
+    MAX_BATCH_SIZE = 10
+
+    def embed(self, texts, **kwargs):  # pragma: no cover - not exercised
+        return []
+
+    async def aembed(self, texts, **kwargs):  # pragma: no cover - not exercised
+        return []
+
+    def _get_models(self):
+        return []
+
+    def _get_default_model(self):
+        return "dummy"
+
+    @property
+    def provider(self):
+        return "dummy"
+
+
+class _NoCapEmbed(_DummyEmbed):
+    """Provider with no batch cap (MAX_BATCH_SIZE=0)."""
+
+    MAX_BATCH_SIZE = 0
+
+
+def test_resolver_default_is_max():
+    model = _DummyEmbed()
+    assert model._get_embed_batch_size() == 10
+
+
+def test_resolver_override_below_max():
+    model = _DummyEmbed(config={"embed_batch_size": 4})
+    assert model._get_embed_batch_size() == 4
+
+
+def test_resolver_override_above_max_clamps():
+    model = _DummyEmbed(config={"embed_batch_size": 999})
+    assert model._get_embed_batch_size() == 10
+
+
+def test_resolver_no_cap_returns_none():
+    model = _NoCapEmbed()
+    assert model._get_embed_batch_size() is None
+
+
+def test_resolver_no_cap_override_applies():
+    model = _NoCapEmbed(config={"embed_batch_size": 3})
+    assert model._get_embed_batch_size() == 3
+
+
+@pytest.mark.parametrize("bad", [0, -1, True, 2.5, "5"])
+def test_resolver_invalid_override_raises(bad):
+    model = _DummyEmbed(config={"embed_batch_size": bad})
+    with pytest.raises(ValueError, match="embed_batch_size must be a positive integer"):
+        model._get_embed_batch_size()
+
+
+def test_iter_batches_slices_in_order():
+    model = _DummyEmbed(config={"embed_batch_size": 10})
+    texts = [f"t{i}" for i in range(25)]
+    batches = list(model._iter_embed_batches(texts))
+    assert [len(b) for b in batches] == [10, 10, 5]
+    # Slices reassemble to the original input, in order.
+    assert [t for b in batches for t in b] == texts
+
+
+def test_iter_batches_empty_yields_nothing():
+    model = _DummyEmbed()
+    assert list(model._iter_embed_batches([])) == []
+
+
+def test_iter_batches_no_cap_single_yield():
+    model = _NoCapEmbed()
+    texts = [f"t{i}" for i in range(50)]
+    batches = list(model._iter_embed_batches(texts))
+    assert batches == [texts]

--- a/tests/providers/embedding/test_embed_batching.py
+++ b/tests/providers/embedding/test_embed_batching.py
@@ -12,10 +12,13 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from esperanto.providers.embedding.azure import AzureEmbeddingModel
 from esperanto.providers.embedding.base import EmbeddingModel
 from esperanto.providers.embedding.cohere import CohereEmbeddingModel
 from esperanto.providers.embedding.mistral import MistralEmbeddingModel
+from esperanto.providers.embedding.ollama import OllamaEmbeddingModel
 from esperanto.providers.embedding.openai import OpenAIEmbeddingModel
+from esperanto.providers.embedding.openrouter import OpenRouterEmbeddingModel
 from esperanto.providers.embedding.voyage import VoyageEmbeddingModel
 
 # --- response builders -------------------------------------------------------
@@ -43,17 +46,21 @@ PROVIDERS = {
     "voyage": (VoyageEmbeddingModel, "input", _data_response, 1000),
     "mistral": (MistralEmbeddingModel, "input", _data_response, 64),
     "cohere": (CohereEmbeddingModel, "texts", _cohere_response, 96),
+    "openrouter": (OpenRouterEmbeddingModel, "input", _data_response, 96),
 }
 
 
-def _make_model(cls, response_builder, config=None):
+def _make_model(cls, response_builder, config=None, **extra):
     """Build a provider instance with mocked sync/async HTTP clients.
 
     Each POST inspects the request payload and returns a response sized to the
-    batch it was given, so batching behaviour is exercised end to end.
+    batch it was given, so batching behaviour is exercised end to end. ``extra``
+    forwards provider-specific constructor kwargs (e.g. Azure's endpoint).
     """
+    ctor = {"model_name": "test-model", "api_key": "test-key", "config": config or {}}
+    ctor.update(extra)
     with patch.object(cls, "_create_http_clients", lambda self: None):
-        model = cls(model_name="test-model", api_key="test-key", config=config or {})
+        model = cls(**ctor)
 
     def _batch_from(kwargs):
         payload = kwargs["json"]
@@ -267,3 +274,102 @@ def test_iter_batches_no_cap_single_yield():
     texts = [f"t{i}" for i in range(50)]
     batches = list(model._iter_embed_batches(texts))
     assert batches == [texts]
+
+
+# --- regression: embed_batch_size must stay client-side ----------------------
+
+
+@pytest.mark.parametrize("provider", list(PROVIDERS))
+def test_embed_batch_size_not_leaked_into_payload(provider):
+    """The override is a client-side control; it must never reach the API body."""
+    cls, _key, builder, _max = PROVIDERS[provider]
+    model = _make_model(cls, builder, config={"embed_batch_size": 2})
+
+    model.embed([f"t{i}" for i in range(3)])
+
+    for call in model.client.post.call_args_list:
+        assert "embed_batch_size" not in call.kwargs["json"]
+
+
+# --- regression: batch offset preserves the original input index -------------
+
+
+def test_error_index_is_global_across_batches():
+    """An invalid embedding in a later batch reports its original input index."""
+    model = _make_model(OpenAIEmbeddingModel, _data_response, config={"embed_batch_size": 2})
+
+    seen = []
+
+    def spy(idx, raw):
+        seen.append(idx)
+        return [float(idx)]
+
+    with patch("esperanto.providers.embedding.openai.validate_and_decode_embedding", spy):
+        model.embed([f"t{i}" for i in range(5)])
+
+    # Global indices, not per-batch (which would be [0, 1, 0, 1, 0]).
+    assert seen == [0, 1, 2, 3, 4]
+
+
+# --- Azure: distinct payload/construction path -------------------------------
+
+
+def _make_azure(config=None):
+    return _make_model(
+        AzureEmbeddingModel,
+        _data_response,
+        config=config,
+        azure_endpoint="https://test.openai.azure.com",
+        api_version="2024-02-01",
+    )
+
+
+def test_azure_multi_batch_sync():
+    model = _make_azure(config={"embed_batch_size": 2})
+    result = model.embed([f"t{i}" for i in range(5)])
+    assert model.client.post.call_count == 3
+    assert _sent_batches(model.client) == [["t0", "t1"], ["t2", "t3"], ["t4"]]
+    assert result == [[0.0], [1.0], [2.0], [3.0], [4.0]]
+
+
+@pytest.mark.asyncio
+async def test_azure_multi_batch_async():
+    model = _make_azure(config={"embed_batch_size": 2})
+    result = await model.aembed([f"t{i}" for i in range(5)])
+    assert model.async_client.post.await_count == 3
+    assert result == [[0.0], [1.0], [2.0], [3.0], [4.0]]
+
+
+def test_azure_empty_input_makes_zero_requests():
+    model = _make_azure()
+    assert model.embed([]) == []
+    assert model.client.post.call_count == 0
+
+
+# --- Ollama: empty input returns [] (batching contract), no request ----------
+
+
+def _ollama_response(batch):
+    return {"embeddings": [[_text_value(t)] for t in batch]}
+
+
+def _make_ollama(config=None):
+    return _make_model(
+        OllamaEmbeddingModel,
+        _ollama_response,
+        config=config,
+        base_url="http://localhost:11434",
+    )
+
+
+def test_ollama_empty_input_returns_empty():
+    model = _make_ollama()
+    assert model.embed([]) == []
+    assert model.client.post.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_ollama_empty_input_returns_empty_async():
+    model = _make_ollama()
+    assert await model.aembed([]) == []
+    assert model.async_client.post.await_count == 0


### PR DESCRIPTION
## Summary

Part 1 of #108 — standardize automatic batching across the HTTP embedding providers so `embed()`/`aembed()` succeed regardless of input size, chunking under the hood and concatenating results in input order. This applies the **Hot-Swap-First Defaults** principle (ARCHITECTURE.md) to embeddings: a large list that worked on OpenAI no longer breaks when you switch to Cohere/Mistral/etc.

## Design

Mirrors the pattern Cohere already used. The base class gains:
- `MAX_BATCH_SIZE: ClassVar[int] = 0` — per-provider hard ceiling (0 = no cap).
- `_get_embed_batch_size()` — resolves the effective size; `config={"embed_batch_size": N}` lowers it, clamped to the provider max with a `logging.debug` (a request-shape sanitize, not a feature drop); `N <= 0` raises `ValueError`.
- `_iter_embed_batches(texts)` — yields ordered slices; empty input yields nothing (zero API calls).

Each provider sets its `MAX_BATCH_SIZE` and wraps its existing single-request body in `for batch in self._iter_embed_batches(...)`. Payload/parse/quirks per provider are unchanged.

| Provider | MAX_BATCH_SIZE |
|---|---|
| OpenAI / Azure / OpenAI-compatible / Jina | 2048 |
| Voyage | 1000 |
| Cohere / OpenRouter | 96 |
| Mistral | 64 |
| Ollama | 0 (passthrough) |
| transformers | unchanged (own internal batching) |

## Scope

- **In:** base infra + openai, azure, cohere (migrated to the shared resolver), jina, mistral, ollama, openrouter, voyage + tests.
- **Deferred to part 2** (which will close #108 and #203): Google + Vertex via the native `:batchEmbedContents` endpoint (Google currently makes one HTTP call per text), plus the docs update and CHANGELOG entry for the whole feature.

## Behavior contract (tested)

- `len(texts) > batch_size` → `ceil(len/batch_size)` requests, ordered slices, concatenated in input order.
- `embed([])` → zero API calls, returns `[]`.
- `embed_batch_size` override clamps above-max (debug log) and rejects `<= 0`.
- Async mirrors sync.

## Validation

- `tests/providers tests/unit tests/common_types tests/test_deprecation_warnings.py` → **1532 passed, 1 skipped, 1 xfailed** (+50 new batching tests).
- `ruff check .` clean; `mypy src/esperanto` clean.

Part of #108. Refs #203.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

