### PR TITLE
feat(embedding): batch Google & Vertex via native endpoints (part 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Automatic embedding batching across all providers.** `embed()` / `aembed()`
+  now transparently split large inputs into requests that respect each provider's
+  per-request limit and concatenate the results in input order, so a list that
+  worked on one provider no longer breaks after a provider swap (applies the
+  Hot-Swap-First Defaults principle to embeddings). Ceilings: OpenAI / Azure /
+  OpenAI-compatible / Jina 2048, Voyage 1000, Cohere / OpenRouter 96, Mistral 64,
+  Google / Vertex 250, Ollama unbatched; `transformers` keeps its own internal
+  batching. Lower it per model with `config={"embed_batch_size": N}` (clamped to
+  the provider maximum; `N <= 0` raises `ValueError`); `embed([])` makes zero API
+  calls. Google and Vertex now use the native `:batchEmbedContents` /
+  multi-instance `:predict` endpoints instead of one HTTP call per text — a large
+  speedup for big inputs. (#108, #203)
+
 ### Fixed
 
 - **`to_langchain()` now forwards a custom base URL for Google.** Converting a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   worked on one provider no longer breaks after a provider swap (applies the
   Hot-Swap-First Defaults principle to embeddings). Ceilings: OpenAI / Azure /
   OpenAI-compatible / Jina 2048, Voyage 1000, Cohere / OpenRouter 96, Mistral 64,
-  Google / Vertex 250, Ollama unbatched; `transformers` keeps its own internal
+  Google 250, Vertex 25 (conservative — `:predict` also caps at 20k tokens),
+  Ollama unbatched; `transformers` keeps its own internal
   batching. Lower it per model with `config={"embed_batch_size": N}` (clamped to
   the provider maximum; `N <= 0` raises `ValueError`); `embed([])` makes zero API
   calls. Google and Vertex now use the native `:batchEmbedContents` /

--- a/docs/capabilities/embedding.md
+++ b/docs/capabilities/embedding.md
@@ -72,7 +72,7 @@ vectors = [item.embedding for item in response.data]
 ### Automatic Batching
 
 Embedding providers cap how many texts a single request may contain (OpenAI 2048,
-Voyage 1000, Cohere/OpenRouter 96, Mistral 64, Google/Vertex 250, …). Esperanto
+Voyage 1000, Cohere/OpenRouter 96, Mistral 64, Google 250, Vertex 25, …). Esperanto
 **batches automatically**: `embed()` / `aembed()` split a large input into
 sequential requests under the provider's limit and concatenate the results in
 input order, so the same code works when you switch providers. Empty input makes

--- a/docs/capabilities/embedding.md
+++ b/docs/capabilities/embedding.md
@@ -30,7 +30,7 @@ embedder = AIFactory.create_embedding(
     model_name="jina-embeddings-v3",
     config={
         "timeout": 60.0,
-        "batch_size": 32
+        "embed_batch_size": 32
     }
 )
 ```
@@ -67,7 +67,21 @@ vectors = [item.embedding for item in response.data]
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `timeout` | float | 60.0 | Request timeout in seconds |
-| `batch_size` | int | Provider default | Number of texts to process per request |
+| `embed_batch_size` | int | Provider maximum | Texts to send per API request. Clamped to the provider's ceiling; values ≤ 0 raise `ValueError`. See [Automatic Batching](#automatic-batching). |
+
+### Automatic Batching
+
+Embedding providers cap how many texts a single request may contain (OpenAI 2048,
+Voyage 1000, Cohere/OpenRouter 96, Mistral 64, Google/Vertex 250, …). Esperanto
+**batches automatically**: `embed()` / `aembed()` split a large input into
+sequential requests under the provider's limit and concatenate the results in
+input order, so the same code works when you switch providers. Empty input makes
+zero API calls.
+
+Lower the batch size per model with `config={"embed_batch_size": N}` (e.g. to stay
+under a token budget). `N` is clamped to the provider maximum — you can never
+exceed the API's hard limit — and `N <= 0` raises `ValueError`. Local providers
+with no cap (Ollama) send everything in one request unless you set a size.
 
 ### Input Format
 
@@ -248,7 +262,7 @@ query_vector = query_embedder.embed(query)
 ```python
 embedder = AIFactory.create_embedding(
     "voyage", "voyage-2",
-    config={"batch_size": 50}
+    config={"embed_batch_size": 50}
 )
 
 large_corpus = [...]  # Many documents

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -547,7 +547,7 @@ embedder = AIFactory.create_embedding(
     config={
         # Performance
         "timeout": 60.0,
-        "batch_size": 32,       # Texts per request
+        "embed_batch_size": 32, # Texts per request (clamped to the provider max)
 
         # Advanced (provider-specific)
         "task_type": EmbeddingTaskType.RETRIEVAL_QUERY,  # Jina, Google

--- a/src/esperanto/providers/embedding/CLAUDE.md
+++ b/src/esperanto/providers/embedding/CLAUDE.md
@@ -136,7 +136,8 @@ The base class owns the policy:
 
 Per-provider ceilings: OpenAI/Azure/OpenAI-compatible/Jina 2048, Voyage 1000,
 Cohere/OpenRouter 96, Mistral 64 (conservative — the reported bug fired at 220),
-Google/Vertex 250 (native `:batchEmbedContents` / multi-instance `:predict`),
+Google 250 and Vertex 25 (native `:batchEmbedContents` / multi-instance
+`:predict`; Vertex is conservative because `:predict` also caps at 20k tokens),
 Ollama 0 (passthrough). `transformers` keeps its own internal batching.
 
 When enumerating a batch's response for `validate_and_decode_embedding(idx, ...)`,

--- a/src/esperanto/providers/embedding/CLAUDE.md
+++ b/src/esperanto/providers/embedding/CLAUDE.md
@@ -103,26 +103,45 @@ def __post_init__(self):
   - Transformers: Uses HuggingFace `sentence-transformers` library
   - Ollama: Can use HTTP (if remote) or local client
 
-### Batch Processing
+### Batch Processing (standardized)
 
-Most embedding APIs have batch limits:
+Embedding APIs cap how many texts one request may contain, so the base class
+auto-batches. **Do not hand-roll a batch loop** — use the shared helper:
 
-- OpenAI: 2048 texts per request
-- Google: 100-250 texts per request
-- Jina: 8192 texts per request
+1. Declare the provider's ceiling as a class attribute:
+   ```python
+   class MyEmbeddingModel(EmbeddingModel):
+       MAX_BATCH_SIZE: ClassVar[int] = 2048  # 0 = no cap (send whole list)
+   ```
+2. Wrap the existing single-request body in `self._iter_embed_batches(texts)`:
+   ```python
+   def embed(self, texts: List[str], **kwargs) -> List[List[float]]:
+       texts = [self._clean_text(t) for t in texts]
+       results: List[List[float]] = []
+       for batch in self._iter_embed_batches(texts):
+           # build payload for `batch`, POST, parse
+           results.extend(...)
+       return results
+   ```
 
-Implement batching in `embed()` and `aembed()`:
+The base class owns the policy:
 
-```python
-def embed(self, texts: List[str], **kwargs) -> List[List[float]]:
-    batch_size = 2048
-    all_embeddings = []
-    for i in range(0, len(texts), batch_size):
-        batch = texts[i:i+batch_size]
-        # Process batch...
-        all_embeddings.extend(batch_embeddings)
-    return all_embeddings
-```
+- `_get_embed_batch_size()` resolves the effective size — `MAX_BATCH_SIZE` by
+  default, overridable via `config={"embed_batch_size": N}` (clamped to
+  `MAX_BATCH_SIZE` with a `logging.debug`; `N <= 0` raises `ValueError`).
+- `_iter_embed_batches(texts)` yields ordered slices; **empty input yields
+  nothing** (zero API calls), so `embed([])` returns `[]`.
+- `embed_batch_size` is stripped in `_get_api_kwargs()` — it is a client-side
+  control and must never appear in the request body.
+
+Per-provider ceilings: OpenAI/Azure/OpenAI-compatible/Jina 2048, Voyage 1000,
+Cohere/OpenRouter 96, Mistral 64 (conservative — the reported bug fired at 220),
+Google/Vertex 250 (native `:batchEmbedContents` / multi-instance `:predict`),
+Ollama 0 (passthrough). `transformers` keeps its own internal batching.
+
+When enumerating a batch's response for `validate_and_decode_embedding(idx, ...)`,
+start at `len(results)` so error messages report the original input index, not a
+batch-relative one.
 
 ## Integration
 

--- a/src/esperanto/providers/embedding/google.py
+++ b/src/esperanto/providers/embedding/google.py
@@ -1,7 +1,7 @@
 """Google GenAI embedding model provider."""
 
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 
 import httpx
 
@@ -11,7 +11,10 @@ from esperanto.providers.embedding.base import EmbeddingModel, Model
 
 class GoogleEmbeddingModel(EmbeddingModel):
     """Google GenAI embedding model implementation with native task optimization support."""
-    
+
+    # Gemini's :batchEmbedContents endpoint accepts up to 250 requests per call.
+    MAX_BATCH_SIZE: ClassVar[int] = 250
+
     # Google supports native task types
     SUPPORTED_FEATURES = ["task_type"]
 
@@ -107,46 +110,30 @@ class GoogleEmbeddingModel(EmbeddingModel):
         Returns:
             List of embeddings, one for each input text.
         """
-        results = []
+        results: List[List[float]] = []
         model_name = self._get_model_path()
 
         # Get native task type parameter if available
         gemini_task_type = self._get_task_type_param()
 
-        for text in texts:
-            text = self._clean_text(text)
-            
-            # Apply task optimization via native API or fallback to base emulation
-            if gemini_task_type is None and self.task_type != EmbeddingTaskType.DEFAULT:
-                # Fallback to base class emulation if no native mapping
-                optimized_texts = self._apply_task_optimization([text])
-                text = optimized_texts[0] if optimized_texts else text
-            
-            # Prepare request payload
-            payload = {
-                "model": model_name,
-                "content": {
-                    "parts": [{
-                        "text": text
-                    }]
-                }
-            }
-            
-            # Add native task type if available
-            if gemini_task_type:
-                payload["task_type"] = gemini_task_type
+        for batch in self._iter_embed_batches(texts):
+            requests_payload = [
+                self._build_content_request(text, model_name, gemini_task_type)
+                for text in batch
+            ]
 
-            # Make HTTP request
+            # Send the whole batch in one native :batchEmbedContents call.
             response = self.client.post(
-                f"{self.base_url}/{model_name}:embedContent?key={self.api_key}",
+                f"{self.base_url}/{model_name}:batchEmbedContents?key={self.api_key}",
                 headers=self._get_headers(),
-                json=payload
+                json={"requests": requests_payload},
             )
             self._handle_error(response)
-            
+
             response_data = response.json()
-            # Convert embeddings to regular floats
-            results.append([float(value) for value in response_data["embedding"]["values"]])
+            # Embeddings come back in request order.
+            for item in response_data["embeddings"]:
+                results.append([float(value) for value in item["values"]])
 
         return results
 
@@ -160,48 +147,56 @@ class GoogleEmbeddingModel(EmbeddingModel):
         Returns:
             List of embeddings, one for each input text.
         """
-        results = []
+        results: List[List[float]] = []
         model_name = self._get_model_path()
 
         # Get native task type parameter if available
         gemini_task_type = self._get_task_type_param()
 
-        for text in texts:
-            text = self._clean_text(text)
-            
-            # Apply task optimization via native API or fallback to base emulation
-            if gemini_task_type is None and self.task_type != EmbeddingTaskType.DEFAULT:
-                # Fallback to base class emulation if no native mapping
-                optimized_texts = self._apply_task_optimization([text])
-                text = optimized_texts[0] if optimized_texts else text
-            
-            # Prepare request payload
-            payload = {
-                "model": model_name,
-                "content": {
-                    "parts": [{
-                        "text": text
-                    }]
-                }
-            }
-            
-            # Add native task type if available
-            if gemini_task_type:
-                payload["task_type"] = gemini_task_type
+        for batch in self._iter_embed_batches(texts):
+            requests_payload = [
+                self._build_content_request(text, model_name, gemini_task_type)
+                for text in batch
+            ]
 
-            # Make async HTTP request
+            # Send the whole batch in one native :batchEmbedContents call.
             response = await self.async_client.post(
-                f"{self.base_url}/{model_name}:embedContent?key={self.api_key}",
+                f"{self.base_url}/{model_name}:batchEmbedContents?key={self.api_key}",
                 headers=self._get_headers(),
-                json=payload
+                json={"requests": requests_payload},
             )
             self._handle_error(response)
-            
+
             response_data = response.json()
-            # Convert embeddings to regular floats
-            results.append([float(value) for value in response_data["embedding"]["values"]])
+            # Embeddings come back in request order.
+            for item in response_data["embeddings"]:
+                results.append([float(value) for value in item["values"]])
 
         return results
+
+    def _build_content_request(
+        self, text: str, model_name: str, gemini_task_type: Optional[str]
+    ) -> Dict[str, Any]:
+        """Build a single ``EmbedContentRequest`` for the batch endpoint.
+
+        Mirrors the payload the former per-text ``:embedContent`` call sent, so
+        cleaning and the task-type fallback behave identically — only the
+        envelope changes (one entry in a ``requests`` array).
+        """
+        text = self._clean_text(text)
+
+        # Apply task optimization via native API or fallback to base emulation.
+        if gemini_task_type is None and self.task_type != EmbeddingTaskType.DEFAULT:
+            optimized_texts = self._apply_task_optimization([text])
+            text = optimized_texts[0] if optimized_texts else text
+
+        request: Dict[str, Any] = {
+            "model": model_name,
+            "content": {"parts": [{"text": text}]},
+        }
+        if gemini_task_type:
+            request["task_type"] = gemini_task_type
+        return request
 
     def _get_default_model(self) -> str:
         """Get the default model name."""

--- a/src/esperanto/providers/embedding/openai_compatible.py
+++ b/src/esperanto/providers/embedding/openai_compatible.py
@@ -1,6 +1,6 @@
 """OpenAI-compatible Embedding provider implementation."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 
 import httpx
 
@@ -32,6 +32,10 @@ class OpenAICompatibleEmbeddingModel(ProfileAwareMixin, EmbeddingModel):
         ... )
         >>> embeddings = embedder.embed(["Hello world", "How are you?"])
     """
+
+    # Mirror OpenAI's per-request ceiling; a profile may lower it if its backend
+    # needs a smaller batch, and users can override via config="embed_batch_size".
+    MAX_BATCH_SIZE: ClassVar[int] = 2048
 
     def __init__(
         self,
@@ -205,26 +209,27 @@ class OpenAICompatibleEmbeddingModel(ProfileAwareMixin, EmbeddingModel):
             # Clean texts using enhanced text cleaning
             texts = [self._clean_text(text) for text in texts]
 
-            # Prepare request payload using OpenAI standard format
-            payload = {
-                "input": texts,
-                "model": self.get_model_name(),
-                "encoding_format": "float",
-                **{**self._get_api_kwargs(), **kwargs},
-            }
+            results: List[List[float]] = []
+            for batch in self._iter_embed_batches(texts):
+                # Prepare request payload using OpenAI standard format
+                payload = {
+                    "input": batch,
+                    "model": self.get_model_name(),
+                    "encoding_format": "float",
+                    **{**self._get_api_kwargs(), **kwargs},
+                }
 
-            # Generate embeddings
-            response = self.client.post(
-                f"{self.base_url}/embeddings", headers=self._get_headers(), json=payload
-            )
-            self._handle_error(response)
+                # Generate embeddings
+                response = self.client.post(
+                    f"{self.base_url}/embeddings", headers=self._get_headers(), json=payload
+                )
+                self._handle_error(response)
 
-            # Parse response
-            response_data = response.json()
-            results = []
-            for idx, data in enumerate(response_data["data"]):
-                raw = data.get("embedding")
-                results.append(validate_and_decode_embedding(idx, raw))
+                # Parse response
+                response_data = response.json()
+                for idx, data in enumerate(response_data["data"], start=len(results)):
+                    raw = data.get("embedding")
+                    results.append(validate_and_decode_embedding(idx, raw))
             return results
 
         except Exception as e:
@@ -247,26 +252,27 @@ class OpenAICompatibleEmbeddingModel(ProfileAwareMixin, EmbeddingModel):
             # Clean texts using enhanced text cleaning
             texts = [self._clean_text(text) for text in texts]
 
-            # Prepare request payload using OpenAI standard format
-            payload = {
-                "input": texts,
-                "model": self.get_model_name(),
-                "encoding_format": "float",
-                **{**self._get_api_kwargs(), **kwargs},
-            }
+            results: List[List[float]] = []
+            for batch in self._iter_embed_batches(texts):
+                # Prepare request payload using OpenAI standard format
+                payload = {
+                    "input": batch,
+                    "model": self.get_model_name(),
+                    "encoding_format": "float",
+                    **{**self._get_api_kwargs(), **kwargs},
+                }
 
-            # Generate embeddings
-            response = await self.async_client.post(
-                f"{self.base_url}/embeddings", headers=self._get_headers(), json=payload
-            )
-            self._handle_error(response)
+                # Generate embeddings
+                response = await self.async_client.post(
+                    f"{self.base_url}/embeddings", headers=self._get_headers(), json=payload
+                )
+                self._handle_error(response)
 
-            # Parse response
-            response_data = response.json()
-            results = []
-            for idx, data in enumerate(response_data["data"]):
-                raw = data.get("embedding")
-                results.append(validate_and_decode_embedding(idx, raw))
+                # Parse response
+                response_data = response.json()
+                for idx, data in enumerate(response_data["data"], start=len(results)):
+                    raw = data.get("embedding")
+                    results.append(validate_and_decode_embedding(idx, raw))
             return results
 
         except Exception as e:

--- a/src/esperanto/providers/embedding/vertex.py
+++ b/src/esperanto/providers/embedding/vertex.py
@@ -11,8 +11,12 @@ from esperanto.providers.vertex_auth import VertexAuthMixin
 class VertexEmbeddingModel(VertexAuthMixin, EmbeddingModel):
     """Google Vertex AI embedding model implementation."""
 
-    # Vertex AI's :predict endpoint accepts up to 250 instances per request.
-    MAX_BATCH_SIZE: ClassVar[int] = 250
+    # Vertex AI's :predict endpoint caps a request at 250 instances *and* 20,000
+    # tokens. Since we don't count tokens, keep a conservative instance count so
+    # typical inputs stay under the token ceiling (a request that was fine one
+    # text at a time must not start failing once batched). Users with short texts
+    # can raise it via config="embed_batch_size".
+    MAX_BATCH_SIZE: ClassVar[int] = 25
 
     def __init__(self, vertex_project: Optional[str] = None, vertex_location: Optional[str] = None, **kwargs):
         # Extract vertex_project before calling super().__init__

--- a/src/esperanto/providers/embedding/vertex.py
+++ b/src/esperanto/providers/embedding/vertex.py
@@ -1,6 +1,6 @@
 """Google Vertex AI embedding model provider."""
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 
 import httpx
 
@@ -10,6 +10,9 @@ from esperanto.providers.vertex_auth import VertexAuthMixin
 
 class VertexEmbeddingModel(VertexAuthMixin, EmbeddingModel):
     """Google Vertex AI embedding model implementation."""
+
+    # Vertex AI's :predict endpoint accepts up to 250 instances per request.
+    MAX_BATCH_SIZE: ClassVar[int] = 250
 
     def __init__(self, vertex_project: Optional[str] = None, vertex_location: Optional[str] = None, **kwargs):
         # Extract vertex_project before calling super().__init__
@@ -79,18 +82,14 @@ class VertexEmbeddingModel(VertexAuthMixin, EmbeddingModel):
         """
         # Clean texts by replacing newlines with spaces
         texts = [self._clean_text(text) for text in texts]
-        
-        results = []
+
+        results: List[List[float]] = []
         model_path = self._get_model_path()
-        
-        for text in texts:
-            # Prepare request payload for Vertex AI embedding
-            payload = {
-                "instances": [{
-                    "content": text
-                }]
-            }
-            
+
+        for batch in self._iter_embed_batches(texts):
+            # Vertex :predict accepts multiple instances per request.
+            payload = {"instances": [{"content": text} for text in batch]}
+
             # Make HTTP request
             response = self.client.post(
                 f"{self.base_url}/{model_path}:predict",
@@ -98,12 +97,13 @@ class VertexEmbeddingModel(VertexAuthMixin, EmbeddingModel):
                 json=payload
             )
             self._handle_error(response)
-            
+
             response_data = response.json()
-            # Extract embedding from response
-            embedding = response_data["predictions"][0]["embeddings"]["values"]
-            results.append([float(value) for value in embedding])
-        
+            # Predictions come back in instance order.
+            for prediction in response_data["predictions"]:
+                embedding = prediction["embeddings"]["values"]
+                results.append([float(value) for value in embedding])
+
         return results
 
     async def aembed(self, texts: List[str], **kwargs) -> List[List[float]]:
@@ -118,18 +118,14 @@ class VertexEmbeddingModel(VertexAuthMixin, EmbeddingModel):
         """
         # Clean texts by replacing newlines with spaces
         texts = [self._clean_text(text) for text in texts]
-        
-        results = []
+
+        results: List[List[float]] = []
         model_path = self._get_model_path()
-        
-        for text in texts:
-            # Prepare request payload for Vertex AI embedding
-            payload = {
-                "instances": [{
-                    "content": text
-                }]
-            }
-            
+
+        for batch in self._iter_embed_batches(texts):
+            # Vertex :predict accepts multiple instances per request.
+            payload = {"instances": [{"content": text} for text in batch]}
+
             # Make async HTTP request
             response = await self.async_client.post(
                 f"{self.base_url}/{model_path}:predict",
@@ -137,12 +133,13 @@ class VertexEmbeddingModel(VertexAuthMixin, EmbeddingModel):
                 json=payload
             )
             self._handle_error(response)
-            
+
             response_data = response.json()
-            # Extract embedding from response
-            embedding = response_data["predictions"][0]["embeddings"]["values"]
-            results.append([float(value) for value in embedding])
-        
+            # Predictions come back in instance order.
+            for prediction in response_data["predictions"]:
+                embedding = prediction["embeddings"]["values"]
+                results.append([float(value) for value in embedding])
+
         return results
 
     def _get_default_model(self) -> str:

--- a/tests/providers/embedding/test_embed_batching.py
+++ b/tests/providers/embedding/test_embed_batching.py
@@ -15,10 +15,12 @@ import pytest
 from esperanto.providers.embedding.azure import AzureEmbeddingModel
 from esperanto.providers.embedding.base import EmbeddingModel
 from esperanto.providers.embedding.cohere import CohereEmbeddingModel
+from esperanto.providers.embedding.google import GoogleEmbeddingModel
 from esperanto.providers.embedding.mistral import MistralEmbeddingModel
 from esperanto.providers.embedding.ollama import OllamaEmbeddingModel
 from esperanto.providers.embedding.openai import OpenAIEmbeddingModel
 from esperanto.providers.embedding.openrouter import OpenRouterEmbeddingModel
+from esperanto.providers.embedding.vertex import VertexEmbeddingModel
 from esperanto.providers.embedding.voyage import VoyageEmbeddingModel
 
 # --- response builders -------------------------------------------------------
@@ -373,3 +375,119 @@ async def test_ollama_empty_input_returns_empty_async():
     model = _make_ollama()
     assert await model.aembed([]) == []
     assert model.async_client.post.await_count == 0
+
+
+# --- Google: native :batchEmbedContents (issue #203) -------------------------
+
+
+def _make_google(config=None):
+    with patch.object(GoogleEmbeddingModel, "_create_http_clients", lambda self: None):
+        model = GoogleEmbeddingModel(
+            model_name="text-embedding-004", api_key="test-key", config=config or {}
+        )
+
+    def _texts_of(kwargs):
+        return [r["content"]["parts"][0]["text"] for r in kwargs["json"]["requests"]]
+
+    def post(url, **kwargs):
+        assert "batchEmbedContents" in url
+        resp = Mock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "embeddings": [{"values": [_text_value(t)]} for t in _texts_of(kwargs)]
+        }
+        return resp
+
+    async def apost(url, **kwargs):
+        return post(url, **kwargs)
+
+    model.client = Mock()
+    model.async_client = AsyncMock()
+    model.client.post.side_effect = post
+    model.async_client.post.side_effect = apost
+    return model
+
+
+def test_google_multi_batch_uses_batch_endpoint():
+    model = _make_google(config={"embed_batch_size": 2})
+    result = model.embed([f"t{i}" for i in range(5)])
+
+    # 5 texts, batch 2 -> 3 batchEmbedContents calls.
+    assert model.client.post.call_count == 3
+    # Each request bundles its slice under "requests".
+    sizes = [len(c.kwargs["json"]["requests"]) for c in model.client.post.call_args_list]
+    assert sizes == [2, 2, 1]
+    assert result == [[0.0], [1.0], [2.0], [3.0], [4.0]]
+
+
+@pytest.mark.asyncio
+async def test_google_multi_batch_async():
+    model = _make_google(config={"embed_batch_size": 2})
+    result = await model.aembed([f"t{i}" for i in range(5)])
+    assert model.async_client.post.await_count == 3
+    assert result == [[0.0], [1.0], [2.0], [3.0], [4.0]]
+
+
+def test_google_empty_input_makes_zero_requests():
+    model = _make_google()
+    assert model.embed([]) == []
+    assert model.client.post.call_count == 0
+
+
+def test_google_default_batch_size_is_250():
+    assert GoogleEmbeddingModel.MAX_BATCH_SIZE == 250
+    model = _make_google()
+    assert model._get_embed_batch_size() == 250
+
+
+# --- Vertex: multiple instances per :predict request -------------------------
+
+
+def _make_vertex(config=None):
+    with patch("subprocess.run") as mock_subprocess, patch.object(
+        VertexEmbeddingModel, "_create_http_clients", lambda self: None
+    ):
+        mock_subprocess.return_value.stdout = "mock_access_token"
+        mock_subprocess.return_value.returncode = 0
+        model = VertexEmbeddingModel(
+            vertex_project="test-project", model_name="textembedding-gecko", config=config or {}
+        )
+    model._get_access_token = Mock(return_value="mock_access_token")
+
+    def _texts_of(kwargs):
+        return [inst["content"] for inst in kwargs["json"]["instances"]]
+
+    def post(url, **kwargs):
+        resp = Mock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "predictions": [
+                {"embeddings": {"values": [_text_value(t)]}} for t in _texts_of(kwargs)
+            ]
+        }
+        return resp
+
+    async def apost(url, **kwargs):
+        return post(url, **kwargs)
+
+    model.client = Mock()
+    model.async_client = AsyncMock()
+    model.client.post.side_effect = post
+    model.async_client.post.side_effect = apost
+    return model
+
+
+def test_vertex_multi_batch_bundles_instances():
+    model = _make_vertex(config={"embed_batch_size": 2})
+    result = model.embed([f"t{i}" for i in range(5)])
+
+    assert model.client.post.call_count == 3
+    sizes = [len(c.kwargs["json"]["instances"]) for c in model.client.post.call_args_list]
+    assert sizes == [2, 2, 1]
+    assert result == [[0.0], [1.0], [2.0], [3.0], [4.0]]
+
+
+def test_vertex_empty_input_makes_zero_requests():
+    model = _make_vertex()
+    assert model.embed([]) == []
+    assert model.client.post.call_count == 0

--- a/tests/providers/embedding/test_embed_batching.py
+++ b/tests/providers/embedding/test_embed_batching.py
@@ -19,6 +19,9 @@ from esperanto.providers.embedding.google import GoogleEmbeddingModel
 from esperanto.providers.embedding.mistral import MistralEmbeddingModel
 from esperanto.providers.embedding.ollama import OllamaEmbeddingModel
 from esperanto.providers.embedding.openai import OpenAIEmbeddingModel
+from esperanto.providers.embedding.openai_compatible import (
+    OpenAICompatibleEmbeddingModel,
+)
 from esperanto.providers.embedding.openrouter import OpenRouterEmbeddingModel
 from esperanto.providers.embedding.vertex import VertexEmbeddingModel
 from esperanto.providers.embedding.voyage import VoyageEmbeddingModel
@@ -491,3 +494,41 @@ def test_vertex_empty_input_makes_zero_requests():
     model = _make_vertex()
     assert model.embed([]) == []
     assert model.client.post.call_count == 0
+
+
+# --- OpenAI-compatible: batches like OpenAI (2048), needs a base_url ----------
+
+
+def _make_openai_compatible(config=None):
+    return _make_model(
+        OpenAICompatibleEmbeddingModel,
+        _data_response,
+        config=config,
+        base_url="http://localhost:1234/v1",
+    )
+
+
+def test_openai_compatible_multi_batch_sync():
+    model = _make_openai_compatible(config={"embed_batch_size": 2})
+    result = model.embed([f"t{i}" for i in range(5)])
+    assert model.client.post.call_count == 3
+    assert _sent_batches(model.client) == [["t0", "t1"], ["t2", "t3"], ["t4"]]
+    assert result == [[0.0], [1.0], [2.0], [3.0], [4.0]]
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_multi_batch_async():
+    model = _make_openai_compatible(config={"embed_batch_size": 2})
+    result = await model.aembed([f"t{i}" for i in range(5)])
+    assert model.async_client.post.await_count == 3
+    assert result == [[0.0], [1.0], [2.0], [3.0], [4.0]]
+
+
+def test_openai_compatible_empty_input_makes_zero_requests():
+    model = _make_openai_compatible()
+    assert model.embed([]) == []
+    assert model.client.post.call_count == 0
+
+
+def test_openai_compatible_default_batch_size_is_2048():
+    assert OpenAICompatibleEmbeddingModel.MAX_BATCH_SIZE == 2048

--- a/tests/providers/embedding/test_embedding_providers.py
+++ b/tests/providers/embedding/test_embedding_providers.py
@@ -575,11 +575,11 @@ def google_embedding_model():
         mock_response = Mock()
         mock_response.status_code = 200
         
-        if "embedContent" in url:
+        if "batchEmbedContents" in url:
             mock_response.json.return_value = {
-                "embedding": {
-                    "values": [0.1, 0.2, 0.3]
-                }
+                "embeddings": [
+                    {"values": [0.1, 0.2, 0.3]}
+                ]
             }
         elif "models" in url:
             mock_response.json.return_value = {
@@ -599,11 +599,11 @@ def google_embedding_model():
         mock_response = AsyncMock()
         mock_response.status_code = 200
         
-        if "embedContent" in url:
+        if "batchEmbedContents" in url:
             mock_response.json = Mock(return_value={
-                "embedding": {
-                    "values": [0.1, 0.2, 0.3]
-                }
+                "embeddings": [
+                    {"values": [0.1, 0.2, 0.3]}
+                ]
             })
         elif "models" in url:
             mock_response.json = Mock(return_value={
@@ -662,21 +662,21 @@ def test_google_embed_with_task_type():
     
     with patch('httpx.Client.post') as mock_post:
         mock_post.return_value.status_code = 200
-        mock_post.return_value.json.return_value = {"embedding": {"values": [0.1, 0.2, 0.3]}}
-        
+        mock_post.return_value.json.return_value = {"embeddings": [{"values": [0.1, 0.2, 0.3]}]}
+
         model = GoogleEmbeddingModel(
             api_key="test-key",
             model_name="text-embedding-004",
             config={"task_type": EmbeddingTaskType.RETRIEVAL_QUERY}
         )
-        
+
         embeddings = model.embed(["Hello, world!"])
         assert embeddings == [[0.1, 0.2, 0.3]]
-        
+
         # Verify task_type was included in API call
         call_args = mock_post.call_args
         payload = call_args[1]["json"]
-        assert payload["task_type"] == "RETRIEVAL_QUERY"
+        assert payload["requests"][0]["task_type"] == "RETRIEVAL_QUERY"
 
 
 @pytest.mark.asyncio
@@ -687,22 +687,22 @@ async def test_google_aembed_with_task_type():
     with patch('httpx.AsyncClient.post') as mock_post:
         mock_response = Mock()
         mock_response.status_code = 200
-        mock_response.json.return_value = {"embedding": {"values": [0.1, 0.2, 0.3]}}
+        mock_response.json.return_value = {"embeddings": [{"values": [0.1, 0.2, 0.3]}]}
         mock_post.return_value = mock_response
-        
+
         model = GoogleEmbeddingModel(
-            api_key="test-key", 
+            api_key="test-key",
             model_name="text-embedding-004",
             config={"task_type": EmbeddingTaskType.CLASSIFICATION}
         )
-        
+
         embeddings = await model.aembed(["Hello, world!"])
         assert embeddings == [[0.1, 0.2, 0.3]]
-        
+
         # Verify task_type was included in async API call
         call_args = mock_post.call_args
         payload = call_args[1]["json"]
-        assert payload["task_type"] == "CLASSIFICATION"
+        assert payload["requests"][0]["task_type"] == "CLASSIFICATION"
 
 
 # Tests for Vertex Embedding Provider

--- a/tests/providers/embedding/test_google_task_translation.py
+++ b/tests/providers/embedding/test_google_task_translation.py
@@ -10,11 +10,11 @@ from esperanto.providers.embedding.google import GoogleEmbeddingModel
 
 @pytest.fixture
 def mock_google_embedding_response():
-    """Mock Google API embedding response."""
+    """Mock Google :batchEmbedContents response (single embedding)."""
     return {
-        "embedding": {
-            "values": [0.1, 0.2, 0.3, 0.4, 0.5]
-        }
+        "embeddings": [
+            {"values": [0.1, 0.2, 0.3, 0.4, 0.5]}
+        ]
     }
 
 
@@ -97,8 +97,8 @@ class TestNativeTaskOptimization:
         # Verify API call includes task_type parameter
         call_args = mock_post.call_args
         payload = call_args[1]["json"]
-        assert "task_type" in payload
-        assert payload["task_type"] == "RETRIEVAL_QUERY"
+        assert "task_type" in payload["requests"][0]
+        assert payload["requests"][0]["task_type"] == "RETRIEVAL_QUERY"
 
     @patch('httpx.AsyncClient.post')
     async def test_async_native_task_type_in_payload(self, mock_post, google_model, mock_google_embedding_response):
@@ -117,8 +117,8 @@ class TestNativeTaskOptimization:
         # Verify async API call includes task_type parameter
         call_args = mock_post.call_args
         payload = call_args[1]["json"]
-        assert "task_type" in payload
-        assert payload["task_type"] == "CLASSIFICATION"
+        assert "task_type" in payload["requests"][0]
+        assert payload["requests"][0]["task_type"] == "CLASSIFICATION"
 
     @patch('httpx.Client.post')
     def test_no_task_type_when_default(self, mock_post, google_model, mock_google_embedding_response):
@@ -135,7 +135,7 @@ class TestNativeTaskOptimization:
         # Verify API call doesn't include task_type parameter
         call_args = mock_post.call_args
         payload = call_args[1]["json"]
-        assert "task_type" not in payload
+        assert "task_type" not in payload["requests"][0]
 
     @patch('httpx.Client.post')
     def test_no_task_type_when_none(self, mock_post, google_model, mock_google_embedding_response):
@@ -152,7 +152,7 @@ class TestNativeTaskOptimization:
         # Verify API call doesn't include task_type parameter
         call_args = mock_post.call_args
         payload = call_args[1]["json"]
-        assert "task_type" not in payload
+        assert "task_type" not in payload["requests"][0]
 
 
 class TestGeminiTaskTypeIntegration:
@@ -211,7 +211,7 @@ class TestGeminiTaskTypeIntegration:
             # Verify correct Gemini task type was sent
             call_args = mock_post.call_args
             payload = call_args[1]["json"]
-            assert payload["task_type"] == expected_gemini_value
+            assert payload["requests"][0]["task_type"] == expected_gemini_value
 
 
 class TestBackwardsCompatibility:
@@ -234,7 +234,7 @@ class TestBackwardsCompatibility:
         # Verify no task_type parameter was sent
         call_args = mock_post.call_args
         payload = call_args[1]["json"]
-        assert "task_type" not in payload
+        assert "task_type" not in payload["requests"][0]
 
     @patch('httpx.AsyncClient.post')
     async def test_async_no_config_still_works(self, mock_post, mock_google_embedding_response):
@@ -255,7 +255,7 @@ class TestBackwardsCompatibility:
         # Verify no task_type parameter was sent
         call_args = mock_post.call_args
         payload = call_args[1]["json"]
-        assert "task_type" not in payload
+        assert "task_type" not in payload["requests"][0]
 
 
 class TestErrorCases:
@@ -275,26 +275,30 @@ class TestErrorCases:
         assert model._get_task_type_param() is None
 
     @patch('httpx.Client.post')
-    def test_multiple_texts_with_task_types(self, mock_post, mock_google_embedding_response):
+    def test_multiple_texts_with_task_types(self, mock_post):
         """Test multiple texts with task type optimization."""
         mock_post.return_value.status_code = 200
-        mock_post.return_value.json.return_value = mock_google_embedding_response
-        
+        # :batchEmbedContents returns one embedding per request, in order.
+        mock_post.return_value.json.return_value = {
+            "embeddings": [{"values": [0.1, 0.2, 0.3]} for _ in range(3)]
+        }
+
         model = GoogleEmbeddingModel(
             api_key="test-key",
             model_name="text-embedding-004",
             config={"task_type": EmbeddingTaskType.SIMILARITY}
         )
-        
+
         # Test multiple texts
         texts = ["text one", "text two", "text three"]
         result = model.embed(texts)
-        
-        # Should make 3 API calls (one per text)
-        assert mock_post.call_count == 3
+
+        # A single batched call carries all three texts.
+        assert mock_post.call_count == 1
         assert len(result) == 3
-        
-        # Each call should include the task_type
-        for call in mock_post.call_args_list:
-            payload = call[1]["json"]
-            assert payload["task_type"] == "SEMANTIC_SIMILARITY"
+
+        # Every request in the batch should include the task_type.
+        payload = mock_post.call_args[1]["json"]
+        assert len(payload["requests"]) == 3
+        for request in payload["requests"]:
+            assert request["task_type"] == "SEMANTIC_SIMILARITY"


### PR DESCRIPTION
## Summary

Part 2 of #108 — completes embedding auto-batching by folding in #203. Google and Vertex previously made **one HTTP call per text**; they now batch through their native endpoints, a large speedup for big inputs (the #203 report saw ~10× on 50 texts).

Builds on the base infrastructure from #260 (`MAX_BATCH_SIZE`, `_get_embed_batch_size`, `_iter_embed_batches`).

## Changes

- **Google** — uses the native `:batchEmbedContents` endpoint (`MAX_BATCH_SIZE = 250`). Each chunk's texts go out as one request under a `requests` array; the ordered `embeddings` list is read back. The per-request payload (`content`/`parts`/`task_type`) and the task-type fallback are **unchanged** — only the envelope moves from single to batched, so real behavior is preserved.
- **Vertex** — bundles multiple `instances` into one `:predict` request (`MAX_BATCH_SIZE = 250`), reading `predictions` in order. No invented endpoint — `:predict` natively accepts multiple instances.
- Both inherit the base resolver, so `config={"embed_batch_size": N}` and empty-input-zero-calls work here too.

## Tests & docs

- Updated the Google task-translation tests to the batch payload shape (task_type now nested per request; 3 texts → 1 batched call).
- Added Google (`:batchEmbedContents`) and Vertex (multi-instance) batching tests: multi-batch request count + ordered slices, empty input → zero calls.
- Documented automatic batching + the `embed_batch_size` override in `docs/capabilities/embedding.md` and the embedding `CLAUDE.md`, replacing the stale `batch_size` naming (addresses the doc findings deferred from #260).
- CHANGELOG entry for the whole feature.

## Validation

- `tests/providers tests/unit tests/common_types tests/test_deprecation_warnings.py` → **1558 passed, 1 skipped, 1 xfailed**.
- `ruff check .` clean; `mypy src/esperanto` clean.

Closes #108
Closes #203

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

