### PR TITLE
feat(minimax): add M3 and native TTS support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -147,7 +147,7 @@ Profiles are defined in `src/esperanto/providers/llm/profiles.py` and resolved b
     name="minimax",
     base_url="https://api.minimax.io/v1",
     api_key_env="MINIMAX_API_KEY",
-    default_model="MiniMax-M2.5",
+    default_model="MiniMax-M3",
     owned_by="MiniMax",
     display_name="MiniMax",
 ),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **MiniMax M3 and text-to-speech support.** MiniMax now defaults to
+  `MiniMax-M3` with its 1M-token context window and supports native TTS through
+  `/v1/t2a_v2`, including sync/async generation and account voice discovery.
+
 - **Automatic embedding batching across all providers.** `embed()` / `aembed()`
   now transparently split large inputs into requests that respect each provider's
   per-request limit and concatenate the results in input order, so a list that

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Whether you're building a quick prototype or a production application serving mi
   - Mistral (Mistral Large, Small, Embedding, etc.)
   - DeepSeek (deepseek-chat)
   - DashScope / Qwen (qwen-turbo, qwen-plus, qwen-max)
-  - MiniMax (MiniMax-M2.5)
+  - MiniMax (MiniMax-M3 with 1M context, Text-to-Speech)
   - PayPerQ / PPQ (pay-as-you-go gateway to hundreds of models)
   - Voyage (Embeddings, Reranking)
   - Jina (Advanced embedding models with task optimization, Reranking)
@@ -155,7 +155,7 @@ pip install "langchain_deepseek>=0.1.3"
 | Cohere       | ✅          | ✅               | ✅                | ❌             | ❌             | ✅        |
 | xAI          | ✅          | ❌               | ❌                | ❌             | ❌             | ❌        |
 | DashScope    | ✅          | ❌               | ❌                | ❌             | ❌             | ✅        |
-| MiniMax      | ✅          | ❌               | ❌                | ❌             | ❌             | ✅        |
+| MiniMax      | ✅          | ❌               | ❌                | ❌             | ✅             | ✅        |
 | OpenRouter   | ✅          | ❌               | ❌                | ❌             | ❌             | ✅        |
 | PayPerQ (PPQ)| ✅          | ✅               | ❌                | ✅             | ✅             | ✅        |
 
@@ -181,7 +181,7 @@ print(providers)
 #     'embedding': ['openai', 'openai-compatible', 'google', 'ollama', 'vertex', 'transformers', 'voyage', 'mistral', 'azure', 'jina', 'openrouter', 'cohere'],
 #     'reranker': ['jina', 'voyage', 'transformers', 'cohere'],
 #     'speech_to_text': ['openai', 'groq', 'elevenlabs', 'openai-compatible', 'azure', 'google', 'mistral', 'deepgram'],
-#     'text_to_speech': ['openai', 'elevenlabs', 'google', 'vertex', 'openai-compatible', 'azure', 'xai', 'mistral', 'deepgram']
+#     'text_to_speech': ['openai', 'elevenlabs', 'google', 'vertex', 'openai-compatible', 'azure', 'xai', 'mistral', 'deepgram', 'minimax']
 # }
 
 # Create model instances

--- a/docs/capabilities/text-to-speech.md
+++ b/docs/capabilities/text-to-speech.md
@@ -157,6 +157,7 @@ audio = speaker.generate_speech("Test audio", voice="alloy")
 - **ElevenLabs**: Best voice quality, voice cloning, emotional control
 - **Google**: Wide language support, neural voices, good quality
 - **Azure**: Enterprise compliance, custom neural voices
+- **MiniMax**: Multilingual speech, emotion control, cloned/generated voices
 - **OpenAI-Compatible**: Local deployment options
 
 ## Examples

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,8 +139,19 @@ DASHSCOPE_API_KEY=...
 → **[Full DashScope Setup Guide](./providers/dashscope.md)**
 
 #### MiniMax
+
+> [!IMPORTANT]
+> MiniMax keys are region-specific. Use `api.minimaxi.com` for mainland China
+> keys and `api.minimax.io` for international keys. A region mismatch is
+> returned by MiniMax as `invalid api key`.
+
 ```bash
 MINIMAX_API_KEY=...
+# International endpoint (default)
+MINIMAX_BASE_URL=https://api.minimax.io/v1
+
+# Mainland China endpoint (keys are region-specific)
+MINIMAX_BASE_URL=https://api.minimaxi.com/v1
 ```
 
 → **[Full MiniMax Setup Guide](./providers/minimax.md)**

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,7 +141,7 @@ DASHSCOPE_API_KEY=...
 #### MiniMax
 
 > [!IMPORTANT]
-> MiniMax keys are region-specific. Use `api.minimaxi.com` for mainland China
+> MiniMax keys are region-specific. Use `api.minimax.cn` for mainland China
 > keys and `api.minimax.io` for international keys. A region mismatch is
 > returned by MiniMax as `invalid api key`.
 
@@ -150,8 +150,8 @@ MINIMAX_API_KEY=...
 # International endpoint (default)
 MINIMAX_BASE_URL=https://api.minimax.io/v1
 
-# Mainland China endpoint (keys are region-specific)
-MINIMAX_BASE_URL=https://api.minimaxi.com/v1
+# Mainland China endpoint (keys are region-specific; legacy api.minimaxi.com also works)
+MINIMAX_BASE_URL=https://api.minimax.cn/v1
 ```
 
 → **[Full MiniMax Setup Guide](./providers/minimax.md)**

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -19,7 +19,7 @@ Welcome to the Esperanto provider guide. This page helps you choose the right AI
 | [Perplexity](./perplexity.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | [xAI](./xai.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | [DashScope (Qwen)](./dashscope.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| [MiniMax](./minimax.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| [MiniMax](./minimax.md) | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
 | [Novita](./openai-compatible.md)* | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | [oMLX](./openai-compatible.md)* | ✅ | ✅ | ❌ | ❌ | ❌ | ⚠️* |
 | [OpenRouter](./openrouter.md) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
@@ -53,7 +53,6 @@ Welcome to the Esperanto provider guide. This page helps you choose the right AI
 - **[Groq](./groq.md)**: LLM + STT (fastest inference)
 - **[Vertex AI](./vertex.md)**: LLM + Embedding + TTS (Google Cloud)
 - **[ElevenLabs](./elevenlabs.md)**: STT + TTS (premium voice quality)
-
 #### Need Privacy/Local Deployment?
 
 **Fully Local:**
@@ -215,7 +214,7 @@ Welcome to the Esperanto provider guide. This page helps you choose the right AI
 | [Perplexity](./perplexity.md) | ✅ | ✅ | ❌ | 32K |
 | [xAI](./xai.md) | ✅ | ❌ | ✅ | 128K |
 | [DashScope](./dashscope.md) | ✅ | ✅ | ✅ | 1M (qwen-max-longcontext) |
-| [MiniMax](./minimax.md) | ✅ | ✅ | ✅ | 204K |
+| [MiniMax](./minimax.md) | ✅ | ✅ | ✅ | 1M |
 | [Novita](./openai-compatible.md) | ✅ | ✅ | ✅ | Model-dependent |
 | [OpenRouter](./openrouter.md) | ✅ | ✅ | ✅ | Varies |
 | [Ollama](./ollama.md) | ✅ | ❌ | ✅ | Model-dependent |

--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -2,17 +2,24 @@
 
 ## Overview
 
-MiniMax provides high-performance language models with large context windows (204K tokens) at competitive pricing through an OpenAI-compatible API.
+MiniMax provides `MiniMax-M3` with a 1M-token context window through an
+OpenAI-compatible API, plus a native Text-to-Speech API.
+
+> [!IMPORTANT]
+> MiniMax API keys are region-specific. Mainland China keys must use
+> `https://api.minimaxi.com/v1`; international keys use
+> `https://api.minimax.io/v1`. Using the wrong endpoint returns an
+> `invalid api key` error even when the key is valid.
 
 **Supported Capabilities:**
 
 | Capability | Supported | Notes |
 |------------|-----------|-------|
-| Language Models (LLM) | ✅ | MiniMax-M2.5 series |
+| Language Models (LLM) | ✅ | MiniMax-M3 and M2 series |
 | Embeddings | ❌ | Not available |
 | Reranking | ❌ | Not available |
 | Speech-to-Text | ❌ | Not available |
-| Text-to-Speech | ❌ | Not available |
+| Text-to-Speech | ✅ | speech-2.8, speech-2.6, and speech-02 series |
 
 **Official Documentation:** https://platform.minimaxi.com/
 
@@ -30,39 +37,54 @@ MiniMax provides high-performance language models with large context windows (20
 ## Environment Variables
 
 ```bash
-# MiniMax API key (required)
 MINIMAX_API_KEY="your-api-key"
+
+# International endpoint (default)
+MINIMAX_BASE_URL="https://api.minimax.io/v1"
+
+# Mainland China endpoint
+MINIMAX_BASE_URL="https://api.minimaxi.com/v1"
 ```
 
-**Default base URL:** `https://api.minimax.io/v1`
+`MINIMAX_BASE_URL` is used for both LLM and TTS requests. The TTS provider
+normalizes the optional `/v1` suffix when building its native endpoints.
 
 ## Quick Start
 
 ```python
 from esperanto.factory import AIFactory
 
-# Create MiniMax model
-model = AIFactory.create_language("minimax", "MiniMax-M2.5")
+model = AIFactory.create_language("minimax", "MiniMax-M3")
 
-# Chat completion
 messages = [{"role": "user", "content": "Explain quantum computing"}]
 response = model.chat_complete(messages)
 print(response.choices[0].message.content)
 ```
 
+MiniMax language models use Esperanto's standard OpenAI-compatible path.
+
 ## Available Models
 
 | Model | Context Window | Best For |
 |-------|---------------|----------|
-| `MiniMax-M2.5` | 204K | Flagship model, complex tasks |
-| `MiniMax-M2.5-highspeed` | 204K | Faster variant, latency-sensitive tasks |
+| `MiniMax-M3` | 1,000,000 | Latest coding and agent workloads |
+| `MiniMax-M2.7` | 204,800 | General-purpose workloads |
+| `MiniMax-M2.7-highspeed` | 204,800 | Latency-sensitive workloads |
+| `MiniMax-M2.5` | 204,800 | Legacy workloads |
+| `MiniMax-M2.5-highspeed` | 204,800 | Legacy latency-sensitive workloads |
+
+The account model catalog can also be queried dynamically:
+
+```python
+models = AIFactory.get_provider_models("minimax", model_type="language")
+```
 
 ## Features
 
 ### Streaming
 
 ```python
-model = AIFactory.create_language("minimax", "MiniMax-M2.5")
+model = AIFactory.create_language("minimax", "MiniMax-M3")
 
 for chunk in model.chat_complete(messages, stream=True):
     print(chunk.choices[0].delta.content, end="")
@@ -72,7 +94,7 @@ for chunk in model.chat_complete(messages, stream=True):
 
 ```python
 model = AIFactory.create_language(
-    "minimax", "MiniMax-M2.5",
+    "minimax", "MiniMax-M3",
     config={"structured": {"type": "json_object"}}
 )
 ```
@@ -83,12 +105,77 @@ model = AIFactory.create_language(
 response = await model.achat_complete(messages)
 ```
 
+## Text-to-Speech
+
+```python
+speaker = AIFactory.create_text_to_speech(
+    "minimax",
+    "speech-2.8-hd",
+)
+
+audio = speaker.generate_speech(
+    text="Hello from MiniMax.",
+    voice="English_Graceful_Lady",
+    language_boost="English",
+)
+
+with open("minimax.mp3", "wb") as file:
+    file.write(audio.audio_data)
+```
+
+### TTS Models
+
+| Model |
+|-------|
+| `speech-2.8-hd` |
+| `speech-2.8-turbo` |
+| `speech-2.6-hd` |
+| `speech-2.6-turbo` |
+| `speech-02-hd` |
+| `speech-02-turbo` |
+
+### Voice Discovery
+
+```python
+for voice_id, voice in speaker.available_voices.items():
+    print(voice_id, voice.name)
+```
+
+### Voice and Audio Controls
+
+```python
+audio = speaker.generate_speech(
+    text="Welcome to the show!",
+    voice="English_Graceful_Lady",
+    response_format="wav",
+    speed=1.1,
+    volume=1.5,
+    pitch=1,
+    emotion="happy",
+    sample_rate=32000,
+    bitrate=128000,
+    channels=1,
+)
+```
+
+Provider-native options such as `language_boost`, `pronunciation_dict`,
+`voice_modify`, `voice_setting`, and `audio_setting` can be passed through as
+keyword arguments.
+
+### Async TTS
+
+```python
+audio = await speaker.agenerate_speech(
+    text="Generated asynchronously.",
+    voice="English_Graceful_Lady",
+)
+```
+
 ## Configuration
 
 ```python
-# With explicit API key
 model = AIFactory.create_language(
-    "minimax", "MiniMax-M2.5",
+    "minimax", "MiniMax-M3",
     config={"api_key": "your-key"}
 )
 ```

--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -7,9 +7,10 @@ OpenAI-compatible API, plus a native Text-to-Speech API.
 
 > [!IMPORTANT]
 > MiniMax API keys are region-specific. Mainland China keys must use
-> `https://api.minimaxi.com/v1`; international keys use
-> `https://api.minimax.io/v1`. Using the wrong endpoint returns an
-> `invalid api key` error even when the key is valid.
+> `https://api.minimax.cn/v1` (the legacy `https://api.minimaxi.com/v1` host
+> also responds); international keys use `https://api.minimax.io/v1`. Using
+> the wrong endpoint returns an `invalid api key` error even when the key is
+> valid.
 
 **Supported Capabilities:**
 
@@ -42,8 +43,8 @@ MINIMAX_API_KEY="your-api-key"
 # International endpoint (default)
 MINIMAX_BASE_URL="https://api.minimax.io/v1"
 
-# Mainland China endpoint
-MINIMAX_BASE_URL="https://api.minimaxi.com/v1"
+# Mainland China endpoint (legacy api.minimaxi.com also works)
+MINIMAX_BASE_URL="https://api.minimax.cn/v1"
 ```
 
 `MINIMAX_BASE_URL` is used for both LLM and TTS requests. The TTS provider

--- a/src/esperanto/__init__.py
+++ b/src/esperanto/__init__.py
@@ -144,6 +144,11 @@ except ImportError:
     OpenRouterSpeechToTextModel = None  # type: ignore[assignment,misc]
 
 try:
+    from esperanto.providers.tts.minimax import MiniMaxTextToSpeechModel
+except ImportError:
+    MiniMaxTextToSpeechModel = None  # type: ignore[assignment,misc]
+
+try:
     from esperanto.providers.llm.cohere import CohereLanguageModel
 except ImportError:
     CohereLanguageModel = None  # type: ignore[assignment,misc]
@@ -208,6 +213,7 @@ __all__ = [
     "DeepgramSpeechToTextModel",
     "OpenRouterTextToSpeechModel",
     "OpenRouterSpeechToTextModel",
+    "MiniMaxTextToSpeechModel",
     "CohereLanguageModel",
     "CohereEmbeddingModel",
     "CohereRerankerModel",

--- a/src/esperanto/factory.py
+++ b/src/esperanto/factory.py
@@ -69,6 +69,7 @@ class AIFactory:
             "mistral": "esperanto.providers.tts.mistral:MistralTextToSpeechModel",
             "deepgram": "esperanto.providers.tts.deepgram:DeepgramTextToSpeechModel",
             "openrouter": "esperanto.providers.tts.openrouter:OpenRouterTextToSpeechModel",
+            "minimax": "esperanto.providers.tts.minimax:MiniMaxTextToSpeechModel",
         },
         "reranker": {
             "jina": "esperanto.providers.reranker.jina:JinaRerankerModel",
@@ -260,8 +261,8 @@ class AIFactory:
         # Get the discovery function for this provider
         discovery_func = PROVIDER_MODELS_REGISTRY[provider]
 
-        # For OpenAI, pass model_type as a parameter if provided
-        if provider == "openai" and model_type is not None:
+        # Providers with multi-modality discovery use model_type for filtering.
+        if provider in {"openai", "minimax"} and model_type is not None:
             config["model_type"] = model_type
 
         # Call the discovery function with config

--- a/src/esperanto/model_discovery.py
+++ b/src/esperanto/model_discovery.py
@@ -942,6 +942,69 @@ def get_openai_compatible_models(
         raise RuntimeError(f"Failed to fetch OpenAI-compatible models: {e}")
 
 
+_MINIMAX_CONTEXT_WINDOWS = {
+    "MiniMax-M3": 1_000_000,
+    "MiniMax-M2.7": 204_800,
+    "MiniMax-M2.7-highspeed": 204_800,
+    "MiniMax-M2.5": 204_800,
+    "MiniMax-M2.5-highspeed": 204_800,
+    "MiniMax-M2.1": 204_800,
+    "MiniMax-M2.1-highspeed": 204_800,
+    "MiniMax-M2": 204_800,
+}
+
+
+def get_minimax_models(
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
+    model_type: Optional[str] = None,
+) -> List[Model]:
+    """Discover current MiniMax language models and known TTS models."""
+    models: List[Model] = []
+    if model_type in (None, "language"):
+        api_key = api_key or os.getenv("MINIMAX_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "MiniMax API key not found. Provide api_key or set MINIMAX_API_KEY "
+                "environment variable."
+            )
+        resolved_base_url = (
+            base_url
+            or os.getenv("MINIMAX_BASE_URL")
+            or "https://api.minimax.io/v1"
+        ).rstrip("/")
+        discovered = get_openai_compatible_models(
+            base_url=resolved_base_url,
+            api_key=api_key,
+        )
+        models.extend(
+            Model(
+                id=model.id,
+                owned_by=model.owned_by or "MiniMax",
+                context_window=_MINIMAX_CONTEXT_WINDOWS.get(
+                    model.id, model.context_window
+                ),
+                type="language",
+            )
+            for model in discovered
+        )
+
+    if model_type in (None, "text_to_speech"):
+        from esperanto.providers.tts.minimax import MINIMAX_TTS_MODELS
+
+        models.extend(
+            Model(
+                id=model_id,
+                owned_by="MiniMax",
+                context_window=None,
+                type="text_to_speech",
+            )
+            for model_id in MINIMAX_TTS_MODELS
+        )
+
+    return models
+
+
 def get_transformers_models(
     cache_dir: Optional[str] = None,
 ) -> List[Model]:
@@ -1119,4 +1182,5 @@ PROVIDER_MODELS_REGISTRY: Dict[str, Callable[..., List[Model]]] = {
     "transformers": get_transformers_models,
     "deepgram": get_deepgram_models,
     "cohere": get_cohere_models,
+    "minimax": get_minimax_models,
 }

--- a/src/esperanto/model_discovery.py
+++ b/src/esperanto/model_discovery.py
@@ -980,7 +980,7 @@ def get_minimax_models(
         models.extend(
             Model(
                 id=model.id,
-                owned_by=model.owned_by or "MiniMax",
+                owned_by="MiniMax",
                 context_window=_MINIMAX_CONTEXT_WINDOWS.get(
                     model.id, model.context_window
                 ),

--- a/src/esperanto/providers/llm/profiles.py
+++ b/src/esperanto/providers/llm/profiles.py
@@ -150,7 +150,7 @@ BUILTIN_PROFILES: Dict[str, OpenAICompatibleProfile] = {
         base_url="https://api.minimax.io/v1",
         api_key_env="MINIMAX_API_KEY",
         base_url_env="MINIMAX_BASE_URL",
-        default_models={"language": "MiniMax-M2.5"},
+        default_models={"language": "MiniMax-M3"},
         owned_by="MiniMax",
         display_name="MiniMax",
     ),

--- a/src/esperanto/providers/tts/CLAUDE.md
+++ b/src/esperanto/providers/tts/CLAUDE.md
@@ -11,6 +11,7 @@ Text-to-speech (TTS) provider implementations for generating audio from text.
 - **`vertex.py`**: Google Vertex AI TTS
 - **`azure.py`**: Azure Speech Service TTS
 - **`openai_compatible.py`**: Generic OpenAI-compatible TTS API
+- **`minimax.py`**: MiniMax native T2A v2 API (`/v1/t2a_v2`, hex-encoded audio)
 
 ## Patterns
 
@@ -212,6 +213,16 @@ return AudioResponse(
 - Google's Vertex AI TTS (different from Cloud TTS)
 - Similar to Google TTS but integrated with Vertex platform
 - Requires Vertex AI setup and permissions
+
+### MiniMax
+
+- Native `/v1/t2a_v2` endpoint (not OpenAI-compatible); audio comes back as a hex string inside JSON
+- Shares `MINIMAX_API_KEY` / `MINIMAX_BASE_URL` with the language profile; a trailing `/v1` on the base URL is normalized away
+- Keys are region-specific: international `api.minimax.io`, mainland China `api.minimax.cn` (legacy `api.minimaxi.com` still responds)
+- API errors can arrive as HTTP 200 with a non-zero `base_resp.status_code`; `_response_json()` checks both
+- Voice discovery via `POST /v1/get_voice` (system, cloned, generated voices); gender is not exposed, so voices are `NEUTRAL`
+- Flat kwargs (`speed`, `volume`, `pitch`, `emotion`, `sample_rate`, `bitrate`, `channels`) map to MiniMax's nested `voice_setting` / `audio_setting`
+- Streaming and non-hex `output_format` raise `ValueError` (not exposed through `generate_speech()`)
 
 ## Common Implementation Patterns
 

--- a/src/esperanto/providers/tts/minimax.py
+++ b/src/esperanto/providers/tts/minimax.py
@@ -1,0 +1,299 @@
+"""MiniMax text-to-speech provider implementation."""
+
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+import httpx
+
+from .base import AudioResponse, Model, TextToSpeechModel, Voice
+
+RESPONSE_FORMAT_TO_CONTENT_TYPE = {
+    "mp3": "audio/mpeg",
+    "pcm": "audio/pcm",
+    "flac": "audio/flac",
+    "wav": "audio/wav",
+    "pcmu_raw": "audio/basic",
+    "pcmu_wav": "audio/wav",
+    "opus": "audio/opus",
+}
+
+MINIMAX_TTS_MODELS = (
+    "speech-2.8-hd",
+    "speech-2.8-turbo",
+    "speech-2.6-hd",
+    "speech-2.6-turbo",
+    "speech-02-hd",
+    "speech-02-turbo",
+)
+
+
+class MiniMaxTextToSpeechModel(TextToSpeechModel):
+    """MiniMax T2A v2 implementation using direct HTTP requests."""
+
+    DEFAULT_MODEL = "speech-2.8-hd"
+    DEFAULT_VOICE = "English_Graceful_Lady"
+    DEFAULT_BASE_URL = "https://api.minimax.io"
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.api_key = self.api_key or os.getenv("MINIMAX_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "MiniMax API key not found. Set MINIMAX_API_KEY environment "
+                "variable, or provide it in config."
+            )
+
+        self.base_url = (
+            self.base_url
+            or os.getenv("MINIMAX_BASE_URL")
+            or self.DEFAULT_BASE_URL
+        ).rstrip("/")
+        self.model_name = self.model_name or self._get_default_model()
+        self._voices_cache: Optional[Dict[str, Voice]] = None
+        self._create_http_clients()
+
+    @property
+    def provider(self) -> str:
+        return "minimax"
+
+    def _get_default_model(self) -> str:
+        return self.DEFAULT_MODEL
+
+    def _get_models(self) -> List[Model]:
+        return [
+            Model(
+                id=model_id,
+                owned_by="MiniMax",
+                context_window=None,
+                type="text_to_speech",
+            )
+            for model_id in MINIMAX_TTS_MODELS
+        ]
+
+    def _build_url(self, path: str) -> str:
+        assert self.base_url is not None
+        base_url = self.base_url.rstrip("/")
+        # Accept the shared OpenAI-compatible MINIMAX_BASE_URL without adding /v1 twice.
+        if base_url.endswith("/v1"):
+            base_url = base_url[:-3]
+        return f"{base_url}/v1/{path.lstrip('/')}"
+
+    def _get_headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _response_json(self, response: httpx.Response) -> Dict[str, Any]:
+        if response.status_code >= 400:
+            try:
+                payload = response.json()
+                error_message = (
+                    payload.get("base_resp", {}).get("status_msg")
+                    or payload.get("error", {}).get("message")
+                    or payload.get("message")
+                    or f"HTTP {response.status_code}"
+                )
+            except Exception:
+                error_message = f"HTTP {response.status_code}: {response.text}"
+            raise RuntimeError(f"MiniMax API error: {error_message}")
+
+        try:
+            payload = response.json()
+        except Exception as exc:
+            raise RuntimeError("MiniMax API returned a non-JSON response") from exc
+
+        # MiniMax reports some API failures in base_resp while still returning HTTP 200.
+        base_resp = payload.get("base_resp") or {}
+        status_code = base_resp.get("status_code", 0)
+        if status_code != 0:
+            status_msg = base_resp.get("status_msg") or f"status code {status_code}"
+            raise RuntimeError(f"MiniMax API error: {status_msg}")
+        return payload
+
+    @property
+    def available_voices(self) -> Dict[str, Voice]:
+        if self._voices_cache is not None:
+            return self._voices_cache
+
+        response = self.client.post(
+            self._build_url("get_voice"),
+            headers=self._get_headers(),
+            json={"voice_type": "all"},
+        )
+        payload = self._response_json(response)
+
+        voices: Dict[str, Voice] = {}
+        categories = (
+            ("system_voice", "System voice"),
+            ("voice_cloning", "Cloned voice"),
+            ("voice_generation", "Generated voice"),
+        )
+        for field, category in categories:
+            for item in payload.get(field) or []:
+                voice_id = item.get("voice_id")
+                if not voice_id:
+                    continue
+                descriptions = item.get("description") or []
+                description = " ".join(str(value) for value in descriptions).strip()
+                voices[voice_id] = Voice(
+                    id=voice_id,
+                    name=item.get("voice_name") or voice_id,
+                    gender="NEUTRAL",
+                    description=description or category,
+                )
+
+        self._voices_cache = voices
+        return voices
+
+    @staticmethod
+    def _build_payload(
+        model_name: str,
+        text: str,
+        voice: str,
+        kwargs: Dict[str, Any],
+    ) -> tuple[Dict[str, Any], str]:
+        if kwargs.pop("stream", False):
+            raise ValueError(
+                "MiniMax streaming TTS is not exposed by generate_speech(); "
+                "use non-streaming output."
+            )
+
+        output_format = kwargs.pop("output_format", "hex")
+        if output_format != "hex":
+            raise ValueError(
+                "MiniMax output_format must be 'hex' so Esperanto can return "
+                "audio bytes."
+            )
+
+        response_format = kwargs.pop("response_format", None)
+        response_format = str(response_format or "mp3")
+
+        # Map Esperanto's flat TTS options to MiniMax's nested request objects.
+        voice_setting = dict(kwargs.pop("voice_setting", {}) or {})
+        voice_setting["voice_id"] = voice
+        voice_fields = {
+            "speed": "speed",
+            "volume": "vol",
+            "vol": "vol",
+            "pitch": "pitch",
+            "emotion": "emotion",
+            "text_normalization": "text_normalization",
+            "latex_read": "latex_read",
+        }
+        for source, target in voice_fields.items():
+            if source in kwargs:
+                voice_setting[target] = kwargs.pop(source)
+
+        audio_setting = dict(kwargs.pop("audio_setting", {}) or {})
+        audio_setting["format"] = response_format
+        audio_fields = {
+            "sample_rate": "sample_rate",
+            "bitrate": "bitrate",
+            "channel": "channel",
+            "channels": "channel",
+            "force_cbr": "force_cbr",
+        }
+        for source, target in audio_fields.items():
+            if source in kwargs:
+                audio_setting[target] = kwargs.pop(source)
+
+        payload: Dict[str, Any] = {
+            "model": model_name,
+            "text": text,
+            "stream": False,
+            "output_format": "hex",
+            "voice_setting": voice_setting,
+            "audio_setting": audio_setting,
+            **kwargs,
+        }
+        return payload, response_format
+
+    def _build_audio_response(
+        self,
+        payload: Dict[str, Any],
+        text: str,
+        voice: str,
+        response_format: str,
+        output_file: Optional[Union[str, Path]],
+    ) -> AudioResponse:
+        data = payload.get("data") or {}
+        audio_hex = data.get("audio")
+        if not audio_hex:
+            raise RuntimeError("MiniMax API response did not include audio data")
+        try:
+            # Non-streaming T2A responses carry the audio bytes as a hex JSON field.
+            audio_data = bytes.fromhex(audio_hex)
+        except ValueError as exc:
+            raise RuntimeError("MiniMax API returned invalid hex audio data") from exc
+
+        if output_file:
+            self.save_audio(audio_data, output_file)
+
+        extra_info = payload.get("extra_info") or {}
+        duration_ms = extra_info.get("audio_length")
+        duration = float(duration_ms) / 1000 if duration_ms is not None else None
+        metadata: Dict[str, Any] = {
+            "text": text,
+            "trace_id": payload.get("trace_id"),
+            "extra_info": extra_info,
+        }
+        if data.get("subtitle_file"):
+            metadata["subtitle_file"] = data["subtitle_file"]
+
+        return AudioResponse(
+            audio_data=audio_data,
+            duration=duration,
+            content_type=RESPONSE_FORMAT_TO_CONTENT_TYPE.get(
+                response_format, f"audio/{response_format}"
+            ),
+            model=self.model_name,
+            voice=voice,
+            provider=self.provider,
+            metadata=metadata,
+        )
+
+    def generate_speech(
+        self,
+        text: str,
+        voice: str = DEFAULT_VOICE,
+        output_file: Optional[Union[str, Path]] = None,
+        **kwargs: Any,
+    ) -> AudioResponse:
+        self.validate_parameters(text, voice, self.model_name)
+        model_name = self.model_name or self._get_default_model()
+        request_payload, response_format = self._build_payload(
+            model_name, text, voice, kwargs
+        )
+        response = self.client.post(
+            self._build_url("t2a_v2"),
+            headers=self._get_headers(),
+            json=request_payload,
+        )
+        payload = self._response_json(response)
+        return self._build_audio_response(
+            payload, text, voice, response_format, output_file
+        )
+
+    async def agenerate_speech(
+        self,
+        text: str,
+        voice: str = DEFAULT_VOICE,
+        output_file: Optional[Union[str, Path]] = None,
+        **kwargs: Any,
+    ) -> AudioResponse:
+        self.validate_parameters(text, voice, self.model_name)
+        model_name = self.model_name or self._get_default_model()
+        request_payload, response_format = self._build_payload(
+            model_name, text, voice, kwargs
+        )
+        response = await self.async_client.post(
+            self._build_url("t2a_v2"),
+            headers=self._get_headers(),
+            json=request_payload,
+        )
+        payload = self._response_json(response)
+        return self._build_audio_response(
+            payload, text, voice, response_format, output_file
+        )

--- a/tests/integration/test_chat_completion_real.py
+++ b/tests/integration/test_chat_completion_real.py
@@ -765,21 +765,21 @@ class TestMiniMaxChat:
     """Real integration tests for MiniMax chat completion."""
 
     def test_sync_chat_complete(self):
-        model = AIFactory.create_language("minimax", "MiniMax-M2.5")
+        model = AIFactory.create_language("minimax", "MiniMax-M3")
         response = model.chat_complete(messages=MESSAGES)
         assert isinstance(response, ChatCompletion)
         assert response.choices[0].message.content is not None
         assert len(response.choices[0].message.content) > 0
 
     async def test_async_chat_complete(self):
-        model = AIFactory.create_language("minimax", "MiniMax-M2.5")
+        model = AIFactory.create_language("minimax", "MiniMax-M3")
         response = await model.achat_complete(messages=MESSAGES)
         assert isinstance(response, ChatCompletion)
         assert response.choices[0].message.content is not None
         assert len(response.choices[0].message.content) > 0
 
     def test_sync_streaming(self):
-        model = AIFactory.create_language("minimax", "MiniMax-M2.5")
+        model = AIFactory.create_language("minimax", "MiniMax-M3")
         response = model.chat_complete(messages=MESSAGES, stream=True)
         total_content = ""
         for chunk in response:
@@ -789,7 +789,7 @@ class TestMiniMaxChat:
         assert len(total_content) > 0
 
     async def test_async_streaming(self):
-        model = AIFactory.create_language("minimax", "MiniMax-M2.5")
+        model = AIFactory.create_language("minimax", "MiniMax-M3")
         response = await model.achat_complete(messages=MESSAGES, stream=True)
         total_content = ""
         async for chunk in response:

--- a/tests/integration/test_tts_real.py
+++ b/tests/integration/test_tts_real.py
@@ -243,6 +243,46 @@ class TestXAITTS:
 
 
 # =============================================================================
+# MiniMax Tests
+# =============================================================================
+
+
+@pytest.mark.release
+@pytest.mark.skipif(
+    not os.getenv("MINIMAX_API_KEY"),
+    reason="MINIMAX_API_KEY not configured",
+)
+class TestMiniMaxTTS:
+    """Real integration tests for MiniMax text-to-speech."""
+
+    def test_sync_generate_speech(self):
+        model = AIFactory.create_text_to_speech("minimax", "speech-2.8-hd")
+        response = model.generate_speech(
+            TEST_TEXT,
+            voice="English_Graceful_Lady",
+            language_boost="English",
+        )
+        assert response.audio_data
+        assert response.content_type.startswith("audio/")
+        assert response.provider == "minimax"
+
+    def test_async_agenerate_speech(self):
+        model = AIFactory.create_text_to_speech("minimax", "speech-2.8-hd")
+
+        async def _run() -> object:
+            return await model.agenerate_speech(
+                TEST_TEXT,
+                voice="English_Graceful_Lady",
+                language_boost="English",
+            )
+
+        response = asyncio.run(_run())
+        assert response.audio_data
+        assert response.content_type.startswith("audio/")
+        assert response.provider == "minimax"
+
+
+# =============================================================================
 # Mistral Tests
 # =============================================================================
 

--- a/tests/providers/llm/test_profiles.py
+++ b/tests/providers/llm/test_profiles.py
@@ -327,21 +327,21 @@ class TestProfileBehavior:
 
     def test_minimax_creation(self):
         model = AIFactory.create_language(
-            "minimax", "MiniMax-M2.5", config={"api_key": "test-key"}
+            "minimax", "MiniMax-M3", config={"api_key": "test-key"}
         )
         assert model.provider == "minimax"
         assert model.base_url == "https://api.minimax.io/v1"
-        assert model._get_default_model() == "MiniMax-M2.5"
+        assert model._get_default_model() == "MiniMax-M3"
 
     def test_minimax_env_var(self):
         with patch.dict(os.environ, {"MINIMAX_API_KEY": "env-key"}, clear=False):
-            model = AIFactory.create_language("minimax", "MiniMax-M2.5")
+            model = AIFactory.create_language("minimax", "MiniMax-M3")
             assert model.api_key == "env-key"
 
     def test_minimax_missing_api_key_raises(self):
         with patch.dict(os.environ, {}, clear=True):
             with pytest.raises(ValueError, match="MiniMax API key not found"):
-                AIFactory.create_language("minimax", "MiniMax-M2.5")
+                AIFactory.create_language("minimax", "MiniMax-M3")
 
     def test_ppq_creation(self):
         model = AIFactory.create_language(

--- a/tests/providers/tts/test_minimax.py
+++ b/tests/providers/tts/test_minimax.py
@@ -1,0 +1,258 @@
+"""Tests for the MiniMax text-to-speech provider."""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from esperanto.factory import AIFactory
+from esperanto.providers.tts.minimax import MiniMaxTextToSpeechModel
+
+RAW_AUDIO = b"mock minimax audio"
+TTS_RESPONSE = {
+    "data": {
+        "audio": RAW_AUDIO.hex(),
+        "status": 2,
+        "subtitle_file": "https://example.test/subtitles.json",
+    },
+    "extra_info": {
+        "audio_length": 1250,
+        "audio_format": "mp3",
+        "usage_characters": 12,
+    },
+    "trace_id": "trace-123",
+    "base_resp": {"status_code": 0, "status_msg": "success"},
+}
+
+VOICES_RESPONSE = {
+    "system_voice": [
+        {
+            "voice_id": "English_Graceful_Lady",
+            "voice_name": "Graceful Lady",
+            "description": ["Expressive English system voice"],
+        }
+    ],
+    "voice_cloning": [
+        {
+            "voice_id": "cloned-voice",
+            "description": ["Account voice clone"],
+        }
+    ],
+    "voice_generation": [
+        {
+            "voice_id": "generated-voice",
+            "description": [],
+        }
+    ],
+    "base_resp": {"status_code": 0, "status_msg": "success"},
+}
+
+
+def _response(status_code: int, payload: dict) -> Mock:
+    response = Mock()
+    response.status_code = status_code
+    response.json.return_value = payload
+    response.text = ""
+    return response
+
+
+@pytest.fixture
+def tts_model() -> MiniMaxTextToSpeechModel:
+    model = MiniMaxTextToSpeechModel(api_key="test-key")
+    model.client = Mock()
+    model.async_client = AsyncMock()
+
+    def post(url: str, **kwargs):
+        if url.endswith("/v1/t2a_v2"):
+            return _response(200, TTS_RESPONSE)
+        if url.endswith("/v1/get_voice"):
+            return _response(200, VOICES_RESPONSE)
+        return _response(404, {"message": "not found"})
+
+    async def async_post(url: str, **kwargs):
+        return post(url, **kwargs)
+
+    model.client.post.side_effect = post
+    model.async_client.post.side_effect = async_post
+    return model
+
+
+def test_init_defaults(tts_model):
+    assert tts_model.provider == "minimax"
+    assert tts_model.model_name == "speech-2.8-hd"
+    assert tts_model.base_url == "https://api.minimax.io"
+
+
+def test_init_from_environment(monkeypatch):
+    monkeypatch.setenv("MINIMAX_API_KEY", "env-key")
+    monkeypatch.setenv("MINIMAX_BASE_URL", "https://custom.minimax.test/v1")
+
+    model = MiniMaxTextToSpeechModel()
+
+    assert model.api_key == "env-key"
+    assert model.base_url == "https://custom.minimax.test/v1"
+    assert model._build_url("t2a_v2") == "https://custom.minimax.test/v1/t2a_v2"
+
+
+def test_mainland_china_base_url_is_normalized():
+    model = MiniMaxTextToSpeechModel(
+        api_key="test-key",
+        base_url="https://api.minimaxi.com/v1",
+    )
+    assert model._build_url("t2a_v2") == "https://api.minimaxi.com/v1/t2a_v2"
+
+
+def test_missing_api_key(monkeypatch):
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="MiniMax API key not found"):
+        MiniMaxTextToSpeechModel()
+
+
+def test_factory_registration():
+    model = AIFactory.create_text_to_speech(
+        "minimax",
+        config={"api_key": "test-key"},
+    )
+    assert isinstance(model, MiniMaxTextToSpeechModel)
+
+
+def test_available_providers_include_minimax_tts():
+    providers = AIFactory.get_available_providers()
+    assert "minimax" in providers["language"]
+    assert "minimax" in providers["text_to_speech"]
+    assert "minimax" not in providers["speech_to_text"]
+
+
+def test_get_models(tts_model):
+    models = tts_model._get_models()
+    assert models[0].id == "speech-2.8-hd"
+    assert all(model.type == "text_to_speech" for model in models)
+
+
+def test_available_voices(tts_model):
+    voices = tts_model.available_voices
+
+    assert set(voices) == {
+        "English_Graceful_Lady",
+        "cloned-voice",
+        "generated-voice",
+    }
+    assert voices["English_Graceful_Lady"].name == "Graceful Lady"
+    assert voices["cloned-voice"].description == "Account voice clone"
+    assert voices["generated-voice"].description == "Generated voice"
+
+    _ = tts_model.available_voices
+    assert tts_model.client.post.call_count == 1
+    assert tts_model.client.post.call_args.kwargs["json"] == {"voice_type": "all"}
+
+
+def test_generate_speech_maps_common_and_native_parameters(tts_model):
+    response = tts_model.generate_speech(
+        "Hello MiniMax",
+        voice="English_Graceful_Lady",
+        response_format="wav",
+        speed=1.2,
+        volume=2,
+        pitch=1,
+        emotion="happy",
+        sample_rate=32000,
+        bitrate=128000,
+        channels=2,
+        language_boost="English",
+        pronunciation_dict={"tone": ["API/A P I"]},
+    )
+
+    call = tts_model.client.post.call_args
+    assert call.args[0] == "https://api.minimax.io/v1/t2a_v2"
+    assert call.kwargs["headers"]["Authorization"] == "Bearer test-key"
+    payload = call.kwargs["json"]
+    assert payload["model"] == "speech-2.8-hd"
+    assert payload["text"] == "Hello MiniMax"
+    assert payload["stream"] is False
+    assert payload["output_format"] == "hex"
+    assert payload["voice_setting"] == {
+        "voice_id": "English_Graceful_Lady",
+        "speed": 1.2,
+        "vol": 2,
+        "pitch": 1,
+        "emotion": "happy",
+    }
+    assert payload["audio_setting"] == {
+        "format": "wav",
+        "sample_rate": 32000,
+        "bitrate": 128000,
+        "channel": 2,
+    }
+    assert payload["language_boost"] == "English"
+
+    assert response.audio_data == RAW_AUDIO
+    assert response.duration == 1.25
+    assert response.content_type == "audio/wav"
+    assert response.model == "speech-2.8-hd"
+    assert response.voice == "English_Graceful_Lady"
+    assert response.provider == "minimax"
+    assert response.metadata["trace_id"] == "trace-123"
+    assert response.metadata["subtitle_file"].endswith("subtitles.json")
+
+
+@pytest.mark.asyncio
+async def test_agenerate_speech(tts_model):
+    response = await tts_model.agenerate_speech(
+        "Hello MiniMax",
+        voice="English_Graceful_Lady",
+    )
+
+    assert response.audio_data == RAW_AUDIO
+    assert response.content_type == "audio/mpeg"
+    assert tts_model.async_client.post.call_args.args[0].endswith("/v1/t2a_v2")
+
+
+def test_generate_speech_saves_output(tts_model, tmp_path):
+    output_file = tmp_path / "speech.mp3"
+    tts_model.generate_speech(
+        "Hello MiniMax",
+        voice="English_Graceful_Lady",
+        output_file=output_file,
+    )
+    assert output_file.read_bytes() == RAW_AUDIO
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"stream": True}, "streaming TTS is not exposed"),
+        ({"output_format": "url"}, "output_format must be 'hex'"),
+    ],
+)
+def test_unsupported_response_modes(tts_model, kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        tts_model.generate_speech(
+            "Hello MiniMax",
+            voice="English_Graceful_Lady",
+            **kwargs,
+        )
+
+
+def test_api_error_in_successful_http_response(tts_model):
+    tts_model.client.post.side_effect = None
+    tts_model.client.post.return_value = _response(
+        200,
+        {"base_resp": {"status_code": 2013, "status_msg": "invalid input"}},
+    )
+    with pytest.raises(RuntimeError, match="MiniMax API error: invalid input"):
+        tts_model.generate_speech(
+            "Hello MiniMax",
+            voice="English_Graceful_Lady",
+        )
+
+
+def test_missing_audio_data(tts_model):
+    tts_model.client.post.side_effect = None
+    tts_model.client.post.return_value = _response(
+        200,
+        {"data": None, "base_resp": {"status_code": 0, "status_msg": "success"}},
+    )
+    with pytest.raises(RuntimeError, match="did not include audio data"):
+        tts_model.generate_speech(
+            "Hello MiniMax",
+            voice="English_Graceful_Lady",
+        )

--- a/tests/providers/tts/test_minimax.py
+++ b/tests/providers/tts/test_minimax.py
@@ -96,9 +96,9 @@ def test_init_from_environment(monkeypatch):
 def test_mainland_china_base_url_is_normalized():
     model = MiniMaxTextToSpeechModel(
         api_key="test-key",
-        base_url="https://api.minimaxi.com/v1",
+        base_url="https://api.minimax.cn/v1",
     )
-    assert model._build_url("t2a_v2") == "https://api.minimaxi.com/v1/t2a_v2"
+    assert model._build_url("t2a_v2") == "https://api.minimax.cn/v1/t2a_v2"
 
 
 def test_missing_api_key(monkeypatch):
@@ -183,6 +183,7 @@ def test_generate_speech_maps_common_and_native_parameters(tts_model):
         "channel": 2,
     }
     assert payload["language_boost"] == "English"
+    assert payload["pronunciation_dict"] == {"tone": ["API/A P I"]}
 
     assert response.audio_data == RAW_AUDIO
     assert response.duration == 1.25

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -17,6 +17,7 @@ from esperanto.model_discovery import (
     get_anthropic_models,
     get_cohere_models,
     get_google_models,
+    get_minimax_models,
     get_openai_compatible_models,
     get_openai_models,
 )
@@ -430,6 +431,42 @@ class TestOpenAICompatibleDiscovery:
         assert call_args.args[0] == "http://localhost:1234/v1/models"
 
 
+class TestMiniMaxDiscovery:
+    """Test MiniMax language and TTS model discovery."""
+
+    @patch("esperanto.model_discovery.get_openai_compatible_models")
+    def test_get_minimax_models_enriches_context_and_adds_tts(self, mock_discovery):
+        mock_discovery.return_value = [
+            Model(id="MiniMax-M3", owned_by="minimax"),
+            Model(id="MiniMax-M2.7", owned_by="minimax"),
+        ]
+
+        models = get_minimax_models(api_key="test-key")
+
+        by_id = {model.id: model for model in models}
+        assert by_id["MiniMax-M3"].context_window == 1_000_000
+        assert by_id["MiniMax-M3"].type == "language"
+        assert by_id["MiniMax-M2.7"].context_window == 204_800
+        assert by_id["speech-2.8-hd"].type == "text_to_speech"
+        mock_discovery.assert_called_once_with(
+            base_url="https://api.minimax.io/v1",
+            api_key="test-key",
+        )
+
+    @patch("esperanto.model_discovery.get_openai_compatible_models")
+    def test_get_minimax_models_can_filter_tts_without_http(self, mock_discovery):
+        with patch.dict(os.environ, {}, clear=True):
+            models = get_minimax_models(model_type="text_to_speech")
+
+        assert models
+        assert all(model.type == "text_to_speech" for model in models)
+        mock_discovery.assert_not_called()
+
+    def test_get_minimax_models_requires_api_key(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="MiniMax API key not found"):
+                get_minimax_models()
+
 class TestProviderRegistry:
     """Test the provider registry."""
 
@@ -438,7 +475,7 @@ class TestProviderRegistry:
         expected_providers = [
             "openai", "openai-compatible", "anthropic", "google", "vertex", "mistral",
             "groq", "deepseek", "ollama", "openrouter", "xai",
-            "perplexity", "jina", "voyage", "azure", "transformers"
+            "perplexity", "jina", "voyage", "azure", "transformers", "minimax"
         ]
 
         for provider in expected_providers:
@@ -494,6 +531,19 @@ class TestAIFactoryIntegration:
             # Should pass model_type in config
             call_args = mock_func.call_args
             assert call_args.kwargs.get("model_type") == "embedding"
+
+    def test_get_provider_models_passes_model_type_to_minimax(self):
+        with patch.dict("esperanto.model_discovery.PROVIDER_MODELS_REGISTRY") as mock_registry:
+            mock_func = MagicMock(return_value=[])
+            mock_registry["minimax"] = mock_func
+
+            AIFactory.get_provider_models(
+                "minimax", api_key="test", model_type="text_to_speech"
+            )
+
+            mock_func.assert_called_once_with(
+                api_key="test", model_type="text_to_speech"
+            )
 
     def test_get_provider_models_flattens_config_dict(self):
         """Test provider model discovery accepts the same config dict shape as factory creation."""


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #265.

#### What does this implement/fix? Explain your changes.

This updates Esperanto's MiniMax support to the current model and speech APIs:

- Changes the default language model from `MiniMax-M2.5` to `MiniMax-M3`.
- Adds MiniMax model discovery with a 1,000,000-token context window for M3 and current M2-series metadata.
- Keeps MiniMax language generation on the existing OpenAI-compatible provider path.
- Adds a dedicated native TTS provider using MiniMax's `/v1/t2a_v2` endpoint.
- Supports sync/async speech generation, system/cloned/generated voice discovery, common voice and audio controls, hex-audio decoding, file output, and normalized `AudioResponse` metadata.
- Documents the region-specific endpoints prominently:
  - Mainland China: `https://api.minimaxi.com/v1`
  - International: `https://api.minimax.io/v1`

The mainland and international endpoints share the existing `MINIMAX_BASE_URL` setting. The TTS implementation normalizes an optional `/v1` suffix, so no additional endpoint environment variable is required.

The shared OpenAI-compatible implementation and error handling are unchanged.

#### Validation

- `uv run ruff check .`
- `uv run mypy --ignore-missing-imports src/esperanto/providers/tts/minimax.py src/esperanto/model_discovery.py src/esperanto/factory.py`
- `uv run pytest -q tests/providers/tts tests/providers/llm/test_profiles.py tests/test_factory.py tests/test_model_discovery.py` — 264 passed
- Real mainland China API-key release validation — 6 passed:
  - M3 sync and async chat completion
  - M3 sync and async streaming
  - Sync and async TTS
- Real model discovery and account voice discovery were also verified; voice discovery returned 303 voices.

#### Any other comments?

Full repository Mypy in the local minimal environment requires optional Transformers dependencies (`torch`, `transformers`, and `sentence-transformers`). The changed source files pass targeted type checking.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

