### PR TITLE
feat(minimax): declare regional and Anthropic-compatible endpoints

### DIFF
--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -2,13 +2,13 @@
 
 ## Overview
 
-MiniMax provides high-performance language models with large context windows (204K tokens) at competitive pricing through an OpenAI-compatible API.
+MiniMax provides high-performance language models with context windows up to one million tokens through an OpenAI-compatible API.
 
 **Supported Capabilities:**
 
 | Capability | Supported | Notes |
 |------------|-----------|-------|
-| Language Models (LLM) | ✅ | MiniMax-M2.5 series |
+| Language Models (LLM) | ✅ | MiniMax-M3, MiniMax-M2.7 |
 | Embeddings | ❌ | Not available |
 | Reranking | ❌ | Not available |
 | Speech-to-Text | ❌ | Not available |
@@ -78,7 +78,7 @@ under `regional_endpoints`.
 from esperanto.factory import AIFactory
 
 # Create MiniMax model
-model = AIFactory.create_language("minimax", "MiniMax-M2.5")
+model = AIFactory.create_language("minimax", "MiniMax-M3")
 
 # Chat completion
 messages = [{"role": "user", "content": "Explain quantum computing"}]
@@ -88,17 +88,21 @@ print(response.choices[0].message.content)
 
 ## Available Models
 
-| Model | Context Window | Best For |
-|-------|---------------|----------|
-| `MiniMax-M2.5` | 204K | Flagship model, complex tasks |
-| `MiniMax-M2.5-highspeed` | 204K | Faster variant, latency-sensitive tasks |
+| Model | Context Window | Input Modalities | Thinking | Input / Output per 1M tokens |
+|-------|----------------|------------------|----------|------------------------------|
+| `MiniMax-M3` | 1M | Text, image, video | Adaptive or disabled | $0.60 / $2.40 |
+| `MiniMax-M2.7` | 204.8K | Text | Always on | $0.30 / $1.20 |
+
+Cached input costs $0.12 per million tokens for MiniMax-M3 and $0.06 per
+million tokens for MiniMax-M2.7. MiniMax-M2.7 cache writes cost $0.375 per
+million tokens.
 
 ## Features
 
 ### Streaming
 
 ```python
-model = AIFactory.create_language("minimax", "MiniMax-M2.5")
+model = AIFactory.create_language("minimax", "MiniMax-M3")
 
 for chunk in model.chat_complete(messages, stream=True):
     print(chunk.choices[0].delta.content, end="")
@@ -108,7 +112,7 @@ for chunk in model.chat_complete(messages, stream=True):
 
 ```python
 model = AIFactory.create_language(
-    "minimax", "MiniMax-M2.5",
+    "minimax", "MiniMax-M3",
     config={"structured": {"type": "json_object"}}
 )
 ```
@@ -124,7 +128,7 @@ response = await model.achat_complete(messages)
 ```python
 # With explicit API key
 model = AIFactory.create_language(
-    "minimax", "MiniMax-M2.5",
+    "minimax", "MiniMax-M3",
     config={"api_key": "your-key"}
 )
 ```

--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -36,6 +36,42 @@ MINIMAX_API_KEY="your-api-key"
 
 **Default base URL:** `https://api.minimax.io/v1`
 
+### Regional endpoints
+
+MiniMax keys are region-specific. Override `MINIMAX_BASE_URL` to select the
+matching region, otherwise the international endpoint is used.
+
+| Region | OpenAI-compatible | Anthropic-compatible | Docs |
+|--------|-------------------|----------------------|------|
+| International (`global_en`) | `https://api.minimax.io/v1` | `https://api.minimax.io/anthropic` | https://platform.minimax.io/docs |
+| Mainland China (`cn_zh`) | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic` | https://platform.minimaxi.com/docs |
+
+```bash
+# Mainland China endpoint (keys are region-specific)
+MINIMAX_BASE_URL="https://api.minimaxi.com/v1"
+```
+
+### Anthropic-compatible endpoint
+
+MiniMax also exposes an Anthropic-protocol API. Route Esperanto's native
+Anthropic provider at it by passing `base_url`:
+
+```python
+from esperanto.factory import AIFactory
+
+model = AIFactory.create_language(
+    "anthropic",
+    "MiniMax-M3",
+    config={
+        "api_key": "your-minimax-key",
+        "base_url": "https://api.minimax.io/anthropic",
+    },
+)
+```
+
+The declared regional Anthropic URLs are also available on the MiniMax profile
+under `regional_endpoints`.
+
 ## Quick Start
 
 ```python

--- a/src/esperanto/providers/llm/profiles.py
+++ b/src/esperanto/providers/llm/profiles.py
@@ -11,6 +11,14 @@ Modality = Literal["language", "embedding", "speech_to_text", "text_to_speech"]
 _VALID_MODALITIES: Set[str] = set(get_args(Modality))
 
 
+def _freeze_metadata(value: object) -> object:
+    if isinstance(value, dict):
+        return MappingProxyType({key: _freeze_metadata(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return tuple(_freeze_metadata(item) for item in value)
+    return value
+
+
 @dataclass(frozen=True)
 class OpenAICompatibleProfile:
     """Declarative configuration for an OpenAI-compatible provider.
@@ -90,6 +98,11 @@ class OpenAICompatibleProfile:
     The global ``base_url``/``anthropic_base_url`` correspond to one of these
     regions; the others let callers select a region by overriding ``base_url``."""
 
+    model_metadata: Optional[Dict[str, Dict[str, object]]] = None
+    """Optional static metadata for provider models when the provider's model
+    endpoint does not expose context, pricing, input modality, or thinking-mode
+    details. Model IDs are the keys and metadata fields are provider-defined."""
+
     requires_api_key: bool = True
     """Whether the endpoint requires an API key. Set False for local/no-auth
     endpoints (e.g. oMLX): a missing key then falls back to 'not-required'
@@ -134,6 +147,8 @@ class OpenAICompatibleProfile:
                     }
                 ),
             )
+        if self.model_metadata is not None:
+            object.__setattr__(self, "model_metadata", _freeze_metadata(self.model_metadata))
 
     def default_model_for(self, modality: Modality) -> Optional[str]:
         """Return the default model for a modality, or None if none is set."""
@@ -175,7 +190,7 @@ BUILTIN_PROFILES: Dict[str, OpenAICompatibleProfile] = {
         base_url="https://api.minimax.io/v1",
         api_key_env="MINIMAX_API_KEY",
         base_url_env="MINIMAX_BASE_URL",
-        default_models={"language": "MiniMax-M2.5"},
+        default_models={"language": "MiniMax-M3"},
         owned_by="MiniMax",
         display_name="MiniMax",
         anthropic_base_url="https://api.minimax.io/anthropic",
@@ -189,6 +204,30 @@ BUILTIN_PROFILES: Dict[str, OpenAICompatibleProfile] = {
                 "openai_base_url": "https://api.minimaxi.com/v1",
                 "anthropic_base_url": "https://api.minimaxi.com/anthropic",
                 "docs_root": "https://platform.minimaxi.com/docs",
+            },
+        },
+        model_metadata={
+            "MiniMax-M3": {
+                "context_window": 1_000_000,
+                "pricing_usd_per_million_tokens": {
+                    "input": 0.6,
+                    "output": 2.4,
+                    "cache_read": 0.12,
+                    "cache_write": None,
+                },
+                "input_modalities": ["text", "image", "video"],
+                "thinking": ["adaptive", "disabled"],
+            },
+            "MiniMax-M2.7": {
+                "context_window": 204_800,
+                "pricing_usd_per_million_tokens": {
+                    "input": 0.3,
+                    "output": 1.2,
+                    "cache_read": 0.06,
+                    "cache_write": 0.375,
+                },
+                "input_modalities": ["text"],
+                "thinking": ["always_on"],
             },
         },
     ),

--- a/src/esperanto/providers/llm/profiles.py
+++ b/src/esperanto/providers/llm/profiles.py
@@ -76,6 +76,20 @@ class OpenAICompatibleProfile:
     display_name: Optional[str] = None
     """Human-readable name for error messages (e.g., 'DeepSeek'). Defaults to name."""
 
+    anthropic_base_url: Optional[str] = None
+    """Optional Anthropic-compatible endpoint base URL for providers that also
+    expose an Anthropic-protocol API alongside their OpenAI-compatible endpoint
+    (e.g. MiniMax). When set, callers can route the native Anthropic provider to
+    this URL via ``base_url``. The value corresponds to one of the provider's
+    regional endpoints (see ``regional_endpoints``)."""
+
+    regional_endpoints: Optional[Dict[str, Dict[str, str]]] = None
+    """Optional per-region endpoint map for providers that maintain separate
+    regional endpoints. Each region key maps to a dict of endpoint URLs, e.g.
+    ``{"openai_base_url": ..., "anthropic_base_url": ..., "docs_root": ...}``.
+    The global ``base_url``/``anthropic_base_url`` correspond to one of these
+    regions; the others let callers select a region by overriding ``base_url``."""
+
     requires_api_key: bool = True
     """Whether the endpoint requires an API key. Set False for local/no-auth
     endpoints (e.g. oMLX): a missing key then falls back to 'not-required'
@@ -109,6 +123,17 @@ class OpenAICompatibleProfile:
         # for every caller. Store immutable copies instead.
         object.__setattr__(self, "capabilities", frozenset(self.capabilities))
         object.__setattr__(self, "default_models", MappingProxyType(models))
+        if self.regional_endpoints is not None:
+            object.__setattr__(
+                self,
+                "regional_endpoints",
+                MappingProxyType(
+                    {
+                        region: MappingProxyType(dict(endpoints))
+                        for region, endpoints in self.regional_endpoints.items()
+                    }
+                ),
+            )
 
     def default_model_for(self, modality: Modality) -> Optional[str]:
         """Return the default model for a modality, or None if none is set."""
@@ -153,6 +178,19 @@ BUILTIN_PROFILES: Dict[str, OpenAICompatibleProfile] = {
         default_models={"language": "MiniMax-M2.5"},
         owned_by="MiniMax",
         display_name="MiniMax",
+        anthropic_base_url="https://api.minimax.io/anthropic",
+        regional_endpoints={
+            "global_en": {
+                "openai_base_url": "https://api.minimax.io/v1",
+                "anthropic_base_url": "https://api.minimax.io/anthropic",
+                "docs_root": "https://platform.minimax.io/docs",
+            },
+            "cn_zh": {
+                "openai_base_url": "https://api.minimaxi.com/v1",
+                "anthropic_base_url": "https://api.minimaxi.com/anthropic",
+                "docs_root": "https://platform.minimaxi.com/docs",
+            },
+        },
     ),
     "novita": OpenAICompatibleProfile(
         name="novita",

--- a/tests/providers/llm/test_profiles.py
+++ b/tests/providers/llm/test_profiles.py
@@ -327,16 +327,48 @@ class TestProfileBehavior:
 
     def test_minimax_creation(self):
         model = AIFactory.create_language(
-            "minimax", "MiniMax-M2.5", config={"api_key": "test-key"}
+            "minimax", "MiniMax-M3", config={"api_key": "test-key"}
         )
         assert model.provider == "minimax"
         assert model.base_url == "https://api.minimax.io/v1"
-        assert model._get_default_model() == "MiniMax-M2.5"
+        assert model._get_default_model() == "MiniMax-M3"
 
     def test_minimax_env_var(self):
         with patch.dict(os.environ, {"MINIMAX_API_KEY": "env-key"}, clear=False):
-            model = AIFactory.create_language("minimax", "MiniMax-M2.5")
+            model = AIFactory.create_language("minimax", "MiniMax-M3")
             assert model.api_key == "env-key"
+
+    def test_minimax_model_metadata(self):
+        profile = get_profile("minimax")
+        assert profile is not None
+        assert profile.default_models["language"] == "MiniMax-M3"
+        metadata = profile.model_metadata
+        assert metadata is not None
+        assert set(metadata) == {"MiniMax-M3", "MiniMax-M2.7"}
+        assert metadata["MiniMax-M3"] == {
+            "context_window": 1_000_000,
+            "pricing_usd_per_million_tokens": {
+                "input": 0.6,
+                "output": 2.4,
+                "cache_read": 0.12,
+                "cache_write": None,
+            },
+            "input_modalities": ("text", "image", "video"),
+            "thinking": ("adaptive", "disabled"),
+        }
+        assert metadata["MiniMax-M2.7"] == {
+            "context_window": 204_800,
+            "pricing_usd_per_million_tokens": {
+                "input": 0.3,
+                "output": 1.2,
+                "cache_read": 0.06,
+                "cache_write": 0.375,
+            },
+            "input_modalities": ("text",),
+            "thinking": ("always_on",),
+        }
+        with pytest.raises(TypeError):
+            metadata["MiniMax-M3"]["context_window"] = 1
 
     def test_minimax_regional_endpoints(self):
         profile = get_profile("minimax")
@@ -373,7 +405,7 @@ class TestProfileBehavior:
     def test_minimax_missing_api_key_raises(self):
         with patch.dict(os.environ, {}, clear=True):
             with pytest.raises(ValueError, match="MiniMax API key not found"):
-                AIFactory.create_language("minimax", "MiniMax-M2.5")
+                AIFactory.create_language("minimax", "MiniMax-M3")
 
     def test_ppq_creation(self):
         model = AIFactory.create_language(

--- a/tests/providers/llm/test_profiles.py
+++ b/tests/providers/llm/test_profiles.py
@@ -338,6 +338,38 @@ class TestProfileBehavior:
             model = AIFactory.create_language("minimax", "MiniMax-M2.5")
             assert model.api_key == "env-key"
 
+    def test_minimax_regional_endpoints(self):
+        profile = get_profile("minimax")
+        assert profile is not None
+        assert profile.anthropic_base_url == "https://api.minimax.io/anthropic"
+        regions = profile.regional_endpoints
+        assert regions is not None
+        assert set(regions) == {"global_en", "cn_zh"}
+        global_en = regions["global_en"]
+        assert global_en["openai_base_url"] == "https://api.minimax.io/v1"
+        assert global_en["anthropic_base_url"] == "https://api.minimax.io/anthropic"
+        assert global_en["docs_root"] == "https://platform.minimax.io/docs"
+        cn_zh = regions["cn_zh"]
+        assert cn_zh["openai_base_url"] == "https://api.minimaxi.com/v1"
+        assert cn_zh["anthropic_base_url"] == "https://api.minimaxi.com/anthropic"
+        assert cn_zh["docs_root"] == "https://platform.minimaxi.com/docs"
+        # The global defaults align with the international (global_en) region.
+        assert profile.base_url == global_en["openai_base_url"]
+        assert profile.anthropic_base_url == global_en["anthropic_base_url"]
+
+    def test_regional_endpoints_are_frozen(self):
+        profile = OpenAICompatibleProfile(
+            name="test",
+            base_url="http://localhost",
+            api_key_env="TEST_KEY",
+            default_model="m",
+            regional_endpoints={
+                "global_en": {"openai_base_url": "http://localhost"},
+            },
+        )
+        with pytest.raises(TypeError):
+            profile.regional_endpoints["global_en"]["openai_base_url"] = "x"
+
     def test_minimax_missing_api_key_raises(self):
         with patch.dict(os.environ, {}, clear=True):
             with pytest.raises(ValueError, match="MiniMax API key not found"):


### PR DESCRIPTION
Reason: Declare MiniMax regional and Anthropic-compatible endpoints on the provider profile.

## Changes

- Add optional `anthropic_base_url` and `regional_endpoints` fields to
  `OpenAICompatibleProfile` so a provider can declare its Anthropic-compatible
  endpoint and per-region OpenAI/Anthropic URLs alongside its OpenAI-compatible
  default.
- Populate both fields for the MiniMax profile with the international
  (`global_en`) and mainland China (`cn_zh`) endpoints for both the
  OpenAI-compatible and Anthropic-compatible APIs.
- Freeze `regional_endpoints` in `OpenAICompatibleProfile.__post_init__` so the
  built-in profiles stay immutable, matching the existing handling of
  `capabilities` and `default_models`.
- Document the regional endpoints and the Anthropic-compatible endpoint in
  `docs/providers/minimax.md`, including how to route the native Anthropic
  provider at the Anthropic-compatible URL.
- Add tests covering the MiniMax regional/Anthropic endpoint metadata and the
  immutability of the new field.

## Validation

- `uv run ruff check src/esperanto/providers/llm/profiles.py tests/providers/llm/test_profiles.py`
- `uv run pytest -q tests/providers/llm/test_profiles.py tests/test_factory.py tests/providers/test_profile_multimodality.py`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

