### PR TITLE
test(embedding): exercise auto-batching against real provider APIs

### DIFF
--- a/tests/integration/test_embedding_real.py
+++ b/tests/integration/test_embedding_real.py
@@ -43,6 +43,38 @@ def _assert_valid_embedding(result: list, expected_len: int) -> None:
         assert all(isinstance(v, float) for v in emb), "Embedding values must be floats"
 
 
+# --- Auto-batching (split + concatenate) -----------------------------------
+#
+# The plain test_batch_embed cases above send 3 texts, which is under every
+# provider ceiling — they never exercise the split. These helpers force a small
+# batch size so the request actually fans out against the real API, then check
+# the results come back in input order across the batch boundaries.
+
+# 10 texts at batch size 4 => 3 requests (4 + 4 + 2). The last text repeats the
+# first, so it lands in a different request: if the concatenation ever scrambled
+# order, these two vectors would stop matching.
+BATCH_SPLIT_SIZE = 4
+TEXTS_OVER_CEILING = [f"Batch item number {i}" for i in range(9)] + ["Batch item number 0"]
+
+
+def _assert_batches_in_input_order(result: list) -> None:
+    """Identical texts must embed identically regardless of which request they landed in."""
+    _assert_valid_embedding(result, len(TEXTS_OVER_CEILING))
+    assert result[0] == result[-1], (
+        "First and last text are identical but embedded differently — "
+        "results were not concatenated in input order across batches"
+    )
+    assert result[0] != result[1], "Distinct texts unexpectedly produced identical vectors"
+
+
+def _assert_splits_across_requests(provider: str, model: str, **config) -> None:
+    """Embed more texts than the forced batch size and verify order survives."""
+    embed_model = AIFactory.create_embedding(
+        provider, model, config={"embed_batch_size": BATCH_SPLIT_SIZE, **config}
+    )
+    _assert_batches_in_input_order(embed_model.embed(TEXTS_OVER_CEILING))
+
+
 # =============================================================================
 # OpenAI Tests
 # =============================================================================
@@ -103,6 +135,10 @@ class TestOpenAIEmbedding:
         result = model.embed(TEXTS_BATCH)
         _assert_valid_embedding(result, 3)
 
+    def test_batch_embed_splits_across_requests(self):
+        """Input above the batch size fans out and comes back in order."""
+        _assert_splits_across_requests("openai", "text-embedding-3-small")
+
 
 # =============================================================================
 # Google Tests
@@ -134,6 +170,13 @@ class TestGoogleEmbedding:
         model = AIFactory.create_embedding("google", "gemini-embedding-001", config={"api_key": api_key})
         result = model.embed(TEXTS_BATCH)
         _assert_valid_embedding(result, 3)
+
+    def test_batch_embed_splits_across_requests(self):
+        """Google fans out over the native :batchEmbedContents endpoint, in order."""
+        api_key = os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
+        _assert_splits_across_requests(
+            "google", "gemini-embedding-001", api_key=api_key
+        )
 
     def test_task_type_embed(self):
         api_key = os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
@@ -174,6 +217,18 @@ class TestVertexEmbedding:
         result = model.embed(TEXTS_BATCH)
         _assert_valid_embedding(result, 3)
 
+    def test_batch_embed_splits_across_requests(self):
+        """Vertex fans out over the multi-instance :predict endpoint, in order."""
+        _assert_splits_across_requests("vertex", "text-embedding-005")
+
+    def test_batch_embed_over_native_ceiling(self):
+        """Vertex's real default ceiling is 25 — cross it without forcing a size."""
+        model = AIFactory.create_embedding("vertex", "text-embedding-005")
+        texts = [f"Native ceiling item {i}" for i in range(29)] + ["Native ceiling item 0"]
+        result = model.embed(texts)
+        _assert_valid_embedding(result, 30)
+        assert result[0] == result[-1], "Vertex batches were not concatenated in input order"
+
 
 # =============================================================================
 # Azure Tests
@@ -191,7 +246,7 @@ class TestVertexEmbedding:
 class TestAzureEmbedding:
     """Real integration tests for Azure OpenAI embeddings."""
 
-    def _make_model(self):
+    def _make_model(self, **extra_config):
         return AIFactory.create_embedding(
             "azure",
             os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME_EMBEDDING", "text-embedding-3-small"),
@@ -205,6 +260,7 @@ class TestAzureEmbedding:
                     or os.getenv("OPENAI_API_VERSION")
                     or os.getenv("AZURE_OPENAI_API_VERSION", "2024-02-01")
                 ),
+                **extra_config,
             },
         )
 
@@ -222,6 +278,11 @@ class TestAzureEmbedding:
         model = self._make_model()
         result = model.embed(TEXTS_BATCH)
         _assert_valid_embedding(result, 3)
+
+    def test_batch_embed_splits_across_requests(self):
+        """Input above the batch size fans out and comes back in order."""
+        model = self._make_model(embed_batch_size=BATCH_SPLIT_SIZE)
+        _assert_batches_in_input_order(model.embed(TEXTS_OVER_CEILING))
 
 
 # =============================================================================
@@ -251,6 +312,10 @@ class TestJinaEmbedding:
         model = AIFactory.create_embedding("jina", "jina-embeddings-v3")
         result = model.embed(TEXTS_BATCH)
         _assert_valid_embedding(result, 3)
+
+    def test_batch_embed_splits_across_requests(self):
+        """Input above the batch size fans out and comes back in order."""
+        _assert_splits_across_requests("jina", "jina-embeddings-v3")
 
     def test_task_type_embed(self):
         model = AIFactory.create_embedding(
@@ -297,6 +362,10 @@ class TestVoyageEmbedding:
         result = model.embed(TEXTS_BATCH)
         _assert_valid_embedding(result, 3)
 
+    def test_batch_embed_splits_across_requests(self):
+        """Input above the batch size fans out and comes back in order."""
+        _assert_splits_across_requests("voyage", "voyage-3-large")
+
 
 # =============================================================================
 # Mistral Tests
@@ -325,6 +394,18 @@ class TestMistralEmbedding:
         model = AIFactory.create_embedding("mistral", "mistral-embed")
         result = model.embed(TEXTS_BATCH)
         _assert_valid_embedding(result, 3)
+
+    def test_batch_embed_splits_across_requests(self):
+        """Input above the batch size fans out and comes back in order."""
+        _assert_splits_across_requests("mistral", "mistral-embed")
+
+    def test_batch_embed_over_native_ceiling(self):
+        """Mistral's real default ceiling is 64 — cross it without forcing a size."""
+        model = AIFactory.create_embedding("mistral", "mistral-embed")
+        texts = [f"Native ceiling item {i}" for i in range(69)] + ["Native ceiling item 0"]
+        result = model.embed(texts)
+        _assert_valid_embedding(result, 70)
+        assert result[0] == result[-1], "Mistral batches were not concatenated in input order"
 
 
 # =============================================================================
@@ -355,6 +436,12 @@ class TestTransformersEmbedding:
         result = model.embed(TEXTS_BATCH)
         _assert_valid_embedding(result, 3)
 
+    def test_batch_embed_splits_across_requests(self):
+        """transformers keeps its own internal batching — order must still hold."""
+        _assert_splits_across_requests(
+            "transformers", "sentence-transformers/all-MiniLM-L6-v2"
+        )
+
 
 # =============================================================================
 # Ollama Tests
@@ -369,9 +456,11 @@ class TestTransformersEmbedding:
 class TestOllamaEmbedding:
     """Real integration tests for Ollama embeddings."""
 
-    def _make_model(self):
+    def _make_model(self, **extra_config):
         base_url = os.getenv("OLLAMA_BASE_URL") or os.getenv("OLLAMA_API_BASE")
-        return AIFactory.create_embedding("ollama", "nomic-embed-text", config={"base_url": base_url})
+        return AIFactory.create_embedding(
+            "ollama", "nomic-embed-text", config={"base_url": base_url, **extra_config}
+        )
 
     def test_sync_embed(self):
         model = self._make_model()
@@ -387,6 +476,11 @@ class TestOllamaEmbedding:
         model = self._make_model()
         result = model.embed(TEXTS_BATCH)
         _assert_valid_embedding(result, 3)
+
+    def test_batch_embed_splits_across_requests(self):
+        """Ollama is unbatched by default; an explicit size must still split cleanly."""
+        model = self._make_model(embed_batch_size=BATCH_SPLIT_SIZE)
+        _assert_batches_in_input_order(model.embed(TEXTS_OVER_CEILING))
 
 
 # =============================================================================
@@ -417,6 +511,10 @@ class TestOpenRouterEmbedding:
         result = model.embed(TEXTS_BATCH)
         _assert_valid_embedding(result, 3)
 
+    def test_batch_embed_splits_across_requests(self):
+        """Input above the batch size fans out and comes back in order."""
+        _assert_splits_across_requests("openrouter", "openai/text-embedding-3-small")
+
 
 # =============================================================================
 # OpenAI-Compatible Tests
@@ -434,7 +532,7 @@ class TestOpenRouterEmbedding:
 class TestOpenAICompatibleEmbedding:
     """Real integration tests for OpenAI-compatible embeddings."""
 
-    def _make_model(self):
+    def _make_model(self, **extra_config):
         api_key = (
             os.getenv("OPENAI_COMPATIBLE_API_KEY_EMBEDDING") or os.getenv("OPENAI_COMPATIBLE_API_KEY")
         )
@@ -445,7 +543,7 @@ class TestOpenAICompatibleEmbedding:
         return AIFactory.create_embedding(
             "openai-compatible",
             model_name,
-            config={"api_key": api_key, "base_url": base_url},
+            config={"api_key": api_key, "base_url": base_url, **extra_config},
         )
 
     def test_sync_embed(self):
@@ -462,3 +560,8 @@ class TestOpenAICompatibleEmbedding:
         model = self._make_model()
         result = model.embed(TEXTS_BATCH)
         _assert_valid_embedding(result, 3)
+
+    def test_batch_embed_splits_across_requests(self):
+        """Input above the batch size fans out and comes back in order."""
+        model = self._make_model(embed_batch_size=BATCH_SPLIT_SIZE)
+        _assert_batches_in_input_order(model.embed(TEXTS_OVER_CEILING))


### PR DESCRIPTION
Release-readiness gap found while running `/release` for v2.26.0.

## Problem

Auto-batching (#260, #261) is the headline feature of the upcoming release: `embed()` splits large inputs to respect each provider's per-request ceiling and concatenates the results in input order.

But every existing `test_batch_embed` in the real-API suite sends **3 texts** — under every ceiling in the table (Vertex 25, Mistral 64, Cohere/OpenRouter 96, Google 250, OpenAI/Azure/Jina 2048). So against real APIs, the split never happens and the concatenation is never observed. The mocked unit tests cover the logic; nothing proved it against a live endpoint.

That matters most for the parts that changed shape: Google and Vertex now use the native `:batchEmbedContents` / multi-instance `:predict` endpoints rather than one HTTP call per text.

## What this adds

`test_batch_embed_splits_across_requests` on all **eleven** embedding providers. Each forces `embed_batch_size=4` and embeds 10 texts → 3 real requests (4 + 4 + 2).

The ordering assertion is the interesting bit: the 10th text is a duplicate of the 1st, so the two land in **different requests**. Identical text embeds to an identical vector, so:

```python
assert result[0] == result[-1]   # order survived the batch boundary
assert result[0] != result[1]    # ...and we're not comparing degenerate vectors
```

An off-by-one in the split, or a concatenation that reorders, breaks this immediately — without needing a second API call to establish a reference vector.

Plus `test_batch_embed_over_native_ceiling` for **Vertex** (30 texts > 25) and **Mistral** (70 > 64): the two tightest real defaults, crossed without forcing anything, so the shipped default is what's under test. Vertex also exercises the new multi-instance `:predict` path there.

## Cost and skipping

Embeddings are the cheapest call in the suite; the added texts are a few words each. Providers without keys skip as they already do — no new required credentials.

## Validation

`test`-only change. Canonical validator: **1578 passed, 1 skipped, 1 xfailed**. `ruff` and `mypy` clean. The 13 new tests collect under `-m release`; they are excluded from CI by `addopts = -m 'not release'` as intended.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

