### PR TITLE
fix(structured-output): satisfy strict json_schema request shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Schema-driven structured output works again on OpenAI and Anthropic.**
+  `structured={"type": "json_schema", "schema": <PydanticModel>}` was rejected
+  before the request ever ran: OpenAI's strict mode requires
+  `additionalProperties: false` on every object, Anthropic's `output_config`
+  requires the same, and Pydantic's `model_json_schema()` emits neither. The
+  schema is now normalized — recursively, so nested models under `$defs` are
+  covered too — on a copy, leaving a caller's own dict untouched. Verified live
+  against OpenAI, Anthropic, Google, Groq, Mistral and Cohere.
+
+  OpenAI's strict mode additionally requires *every* property to be listed in
+  `required`, which a schema with optional fields cannot satisfy. Rather than
+  fail the call or silently promote optional fields to required (which would
+  change your schema's meaning), such a request is sent with `strict: false` and
+  a debug log. The response is still validated against the schema locally, so
+  nothing is weakened beyond the provider-side guarantee.
+
 - **Google and Vertex no longer default to a retired model.** Google has
   withdrawn `gemini-2.0-flash` — it still appears in the models listing but any
   `generateContent` call returns "This model is no longer available", so

--- a/src/esperanto/providers/llm/structured_output.py
+++ b/src/esperanto/providers/llm/structured_output.py
@@ -1,14 +1,18 @@
 """Helpers for schema-driven structured outputs."""
 
+import copy
 import json
+import logging
 import re
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Type, Union, cast
+from typing import Any, Dict, Optional, Tuple, Type, Union, cast
 
 from pydantic import BaseModel, ValidationError
 
 from esperanto.common_types.exceptions import StructuredOutputValidationError
 from esperanto.common_types.response import ChatCompletion
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -19,7 +23,6 @@ class ResolvedStructuredOutput:
     response_format: Dict[str, Any]
     schema_source: Optional[Union[Type[BaseModel], Dict[str, Any]]] = None
     schema_name: Optional[str] = None
-
     @property
     def is_schema_mode(self) -> bool:
         """Whether this config enforces a JSON schema."""
@@ -54,6 +57,84 @@ def _validate_strict(strict: Any) -> bool:
     if not isinstance(strict, bool):
         raise TypeError("structured['strict'] must be a boolean")
     return strict
+
+
+# Keywords whose values are themselves schemas (or collections of schemas), and
+# so must be walked when normalizing a JSON Schema tree.
+_SCHEMA_MAP_KEYWORDS = ("properties", "$defs", "definitions", "patternProperties")
+_SCHEMA_LIST_KEYWORDS = ("anyOf", "oneOf", "allOf", "prefixItems")
+_SCHEMA_VALUE_KEYWORDS = ("items", "not", "additionalProperties", "contains")
+
+
+def _normalize_schema_for_strict(node: Any) -> bool:
+    """Add ``additionalProperties: false`` to every object schema, in place.
+
+    Returns whether the whole tree can satisfy OpenAI's strict mode, which
+    demands two things of every object: ``additionalProperties: false`` (which
+    we can always add) and a ``required`` array listing *every* property (which
+    we must not fabricate — forcing an optional field to be required would
+    change the caller's schema semantics).
+    """
+    if isinstance(node, list):
+        return all([_normalize_schema_for_strict(item) for item in node])
+    if not isinstance(node, dict):
+        return True
+
+    satisfiable = True
+    properties = node.get("properties")
+    if isinstance(properties, dict) or node.get("type") == "object":
+        if "additionalProperties" not in node:
+            node["additionalProperties"] = False
+        if isinstance(properties, dict):
+            required = node.get("required")
+            required_names = set(required) if isinstance(required, list) else set()
+            if set(properties) - required_names:
+                satisfiable = False
+
+    for keyword in _SCHEMA_MAP_KEYWORDS:
+        child = node.get(keyword)
+        if isinstance(child, dict):
+            for value in child.values():
+                satisfiable &= _normalize_schema_for_strict(value)
+    for keyword in _SCHEMA_LIST_KEYWORDS:
+        child = node.get(keyword)
+        if isinstance(child, list):
+            satisfiable &= _normalize_schema_for_strict(child)
+    for keyword in _SCHEMA_VALUE_KEYWORDS:
+        child = node.get(keyword)
+        if isinstance(child, dict):
+            satisfiable &= _normalize_schema_for_strict(child)
+
+    return satisfiable
+
+
+def _prepare_schema(schema_dict: Dict[str, Any], strict: bool, name: str) -> Tuple[Dict[str, Any], bool]:
+    """Return a schema safe to send, plus the strict flag actually usable.
+
+    OpenAI-family endpoints reject a ``strict: true`` json_schema request
+    outright unless every object carries ``additionalProperties: false`` and a
+    complete ``required`` array — Pydantic's ``model_json_schema()`` emits
+    neither. We add the former (semantically free: the schema already lists the
+    properties it wants) and, when a caller's optional fields make the latter
+    impossible, downgrade to ``strict: false`` rather than fail the call or
+    silently promote optional fields to required.
+
+    Downgrading costs nothing in correctness: the response is still validated
+    against the schema on our side by ``parse_structured_output_content``.
+    Follows ARCHITECTURE.md, "Model Quirks vs Unsupported Features" — sanitize
+    the request with a debug log rather than make users learn the quirk.
+    """
+    prepared = copy.deepcopy(schema_dict)
+    fully_strict = _normalize_schema_for_strict(prepared)
+    if strict and not fully_strict:
+        logger.debug(
+            "structured output schema %r has optional properties, which OpenAI's "
+            "strict mode forbids; sending strict=false. The response is still "
+            "validated against the schema locally.",
+            name,
+        )
+        return prepared, False
+    return prepared, strict
 
 
 def resolve_structured_output(
@@ -104,7 +185,9 @@ def resolve_structured_output(
     if _is_pydantic_model_class(schema):
         schema_name = structured.get("name", schema.__name__)
         schema_name = _validate_schema_name(schema_name)
-        schema_dict = schema.model_json_schema()
+        schema_dict, effective_strict = _prepare_schema(
+            schema.model_json_schema(), strict, schema_name
+        )
         return ResolvedStructuredOutput(
             mode="json_schema",
             response_format={
@@ -112,7 +195,7 @@ def resolve_structured_output(
                 "json_schema": {
                     "name": schema_name,
                     "schema": schema_dict,
-                    "strict": strict,
+                    "strict": effective_strict,
                 },
             },
             schema_source=schema,
@@ -122,14 +205,15 @@ def resolve_structured_output(
     if isinstance(schema, dict):
         schema_name = structured.get("name", "structured_output")
         schema_name = _validate_schema_name(schema_name)
+        schema_dict, effective_strict = _prepare_schema(schema, strict, schema_name)
         return ResolvedStructuredOutput(
             mode="json_schema",
             response_format={
                 "type": "json_schema",
                 "json_schema": {
                     "name": schema_name,
-                    "schema": schema,
-                    "strict": strict,
+                    "schema": schema_dict,
+                    "strict": effective_strict,
                 },
             },
             schema_source=schema,

--- a/tests/integration/test_structured_output_release.py
+++ b/tests/integration/test_structured_output_release.py
@@ -30,6 +30,12 @@ PROMPT = [
 
 STRUCTURED_CONFIG = {"structured": {"type": "json_schema", "schema": Capital}}
 
+# Several current models (gemini-2.5-flash, groq's gpt-oss-120b) spend reasoning
+# tokens from the same budget as the answer, so a tight cap truncates the JSON
+# mid-string. The failure then reads like a schema problem when it is a budget
+# problem — keep the budget generous enough that these tests only fail for real.
+MAX_TOKENS = 800
+
 
 def _assert_capital(response):
     """Every provider must surface a validated ``Capital`` on ``response.structured``."""
@@ -46,7 +52,7 @@ def test_openai_structured_output_real():
     model = AIFactory.create_language(
         "openai", "gpt-4o-mini", config=STRUCTURED_CONFIG
     )
-    response = model.chat_complete(PROMPT, max_tokens=100)
+    response = model.chat_complete(PROMPT, max_tokens=MAX_TOKENS)
     _assert_capital(response)
 
 
@@ -56,9 +62,9 @@ def test_openai_structured_output_real():
 )
 def test_anthropic_structured_output_real():
     model = AIFactory.create_language(
-        "anthropic", "claude-3-5-haiku-latest", config=STRUCTURED_CONFIG
+        "anthropic", "claude-haiku-4-5-20251001", config=STRUCTURED_CONFIG
     )
-    response = model.chat_complete(PROMPT, max_tokens=100)
+    response = model.chat_complete(PROMPT, max_tokens=MAX_TOKENS)
     _assert_capital(response)
 
 
@@ -71,10 +77,7 @@ def test_google_structured_output_real():
     model = AIFactory.create_language(
         "google", "gemini-2.5-flash", config=STRUCTURED_CONFIG
     )
-    # gemini-2.5-flash is a thinking model: reasoning tokens are drawn from the
-    # same budget as the answer, so a 100-token cap truncates the JSON roughly
-    # two runs in three. This is about the model's budget, not the schema.
-    response = model.chat_complete(PROMPT, max_tokens=800)
+    response = model.chat_complete(PROMPT, max_tokens=MAX_TOKENS)
     _assert_capital(response)
 
 
@@ -83,10 +86,12 @@ def test_google_structured_output_real():
     not os.getenv("GROQ_API_KEY"), reason="GROQ_API_KEY not configured"
 )
 def test_groq_structured_output_real():
+    # llama-3.3-70b-versatile does not support response_format json_schema on
+    # Groq; gpt-oss-120b does. See https://console.groq.com/docs/structured-outputs
     model = AIFactory.create_language(
-        "groq", "llama-3.3-70b-versatile", config=STRUCTURED_CONFIG
+        "groq", "openai/gpt-oss-120b", config=STRUCTURED_CONFIG
     )
-    response = model.chat_complete(PROMPT, max_tokens=100)
+    response = model.chat_complete(PROMPT, max_tokens=MAX_TOKENS)
     _assert_capital(response)
 
 
@@ -98,7 +103,7 @@ def test_mistral_structured_output_real():
     model = AIFactory.create_language(
         "mistral", "mistral-large-latest", config=STRUCTURED_CONFIG
     )
-    response = model.chat_complete(PROMPT, max_tokens=100)
+    response = model.chat_complete(PROMPT, max_tokens=MAX_TOKENS)
     _assert_capital(response)
 
 
@@ -110,5 +115,91 @@ def test_cohere_structured_output_real():
     model = AIFactory.create_language(
         "cohere", "command-a-03-2025", config=STRUCTURED_CONFIG
     )
-    response = model.chat_complete(PROMPT, max_tokens=100)
+    response = model.chat_complete(PROMPT, max_tokens=MAX_TOKENS)
     _assert_capital(response)
+
+
+# ---------------------------------------------------------------------------
+# OpenAI strict-mode schema shapes
+#
+# The Capital tests above are the simplest possible schema: flat, all-required.
+# These cover the two shapes that used to fail before the strict-mode
+# normalization — a nested model (which puts objects under $defs) and a model
+# with an optional field (which strict mode forbids outright).
+# ---------------------------------------------------------------------------
+
+
+class Address(BaseModel):
+    street: str
+    city: str
+
+
+class Person(BaseModel):
+    name: str
+    address: Address
+
+
+class LooseCapital(BaseModel):
+    city: str
+    nickname: str = "unknown"
+
+
+NESTED_PROMPT = [
+    {
+        "role": "user",
+        "content": "Invent a person with a name and an address (street and city). Return JSON.",
+    }
+]
+
+
+@pytest.mark.release
+@pytest.mark.skipif(
+    not os.getenv("OPENAI_API_KEY"), reason="OPENAI_API_KEY not configured"
+)
+def test_openai_structured_output_nested_schema_real():
+    """A nested model puts its child under $defs, which also needs the flag."""
+    model = AIFactory.create_language(
+        "openai", "gpt-4o-mini", config={"structured": {"type": "json_schema", "schema": Person}}
+    )
+    response = model.chat_complete(NESTED_PROMPT, max_tokens=MAX_TOKENS)
+
+    assert isinstance(response.structured, Person)
+    assert response.structured.address.city
+
+
+@pytest.mark.release
+@pytest.mark.skipif(
+    not os.getenv("OPENAI_API_KEY"), reason="OPENAI_API_KEY not configured"
+)
+def test_openai_structured_output_optional_field_real():
+    """An optional field can't satisfy strict mode; the call must still work."""
+    model = AIFactory.create_language(
+        "openai",
+        "gpt-4o-mini",
+        config={"structured": {"type": "json_schema", "schema": LooseCapital}},
+    )
+    response = model.chat_complete(PROMPT, max_tokens=MAX_TOKENS)
+
+    assert isinstance(response.structured, LooseCapital)
+    assert response.structured.city
+
+
+@pytest.mark.release
+@pytest.mark.skipif(
+    not (os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")),
+    reason="GOOGLE_API_KEY or GEMINI_API_KEY not configured",
+)
+def test_google_structured_output_nested_schema_real():
+    """Google accepts the same normalized schema the OpenAI family needs."""
+    model = AIFactory.create_language(
+        "google",
+        "gemini-2.5-flash",
+        config={
+            "api_key": os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY"),
+            "structured": {"type": "json_schema", "schema": Person},
+        },
+    )
+    response = model.chat_complete(NESTED_PROMPT, max_tokens=MAX_TOKENS)
+
+    assert isinstance(response.structured, Person)
+    assert response.structured.address.city

--- a/tests/providers/llm/test_cohere.py
+++ b/tests/providers/llm/test_cohere.py
@@ -265,7 +265,12 @@ class TestCohereStructuredOutput:
         # Request shape: json_object + schema present.
         payload = model.client.post.call_args[1]["json"]
         assert payload["response_format"]["type"] == "json_object"
-        assert payload["response_format"]["schema"] == CityInfo.model_json_schema()
+        # The schema carries additionalProperties: false — added for OpenAI and
+        # Anthropic strict modes, and accepted by Cohere (verified live).
+        assert payload["response_format"]["schema"] == {
+            **CityInfo.model_json_schema(),
+            "additionalProperties": False,
+        }
 
         # Parsed structured result is a validated Pydantic instance.
         assert isinstance(response.structured, CityInfo)
@@ -287,7 +292,12 @@ class TestCohereStructuredOutput:
 
         payload = model.client.post.call_args[1]["json"]
         assert payload["response_format"]["type"] == "json_object"
-        assert payload["response_format"]["schema"] == schema
+        assert payload["response_format"]["schema"] == {
+            **schema,
+            "additionalProperties": False,
+        }
+        # The caller's dict is normalized on a copy, never mutated in place.
+        assert "additionalProperties" not in schema
 
         assert response.structured == {"city": "Rome", "country": "Italy"}
 

--- a/tests/unit/test_structured_output.py
+++ b/tests/unit/test_structured_output.py
@@ -6,6 +6,8 @@ Covers the resolver (`resolve_structured_output`), the content parser
 (`is_json_schema_unsupported_error`) in isolation from any provider.
 """
 
+import copy
+
 import pytest
 from pydantic import BaseModel
 
@@ -265,3 +267,102 @@ def test_is_json_schema_unsupported_error(msg, expected):
 def test_resolved_is_schema_mode_property():
     assert ResolvedStructuredOutput("json_schema", {}).is_schema_mode is True
     assert ResolvedStructuredOutput("json_object", {}).is_schema_mode is False
+
+
+# ---------------------------------------------------------------------------
+# OpenAI strict-mode schema normalization
+# ---------------------------------------------------------------------------
+
+
+class Address(BaseModel):
+    street: str
+    city: str
+
+
+class Person(BaseModel):
+    name: str
+    address: Address
+    tags: list[str]
+
+
+class Loose(BaseModel):
+    city: str
+    nickname: str = "none"
+
+
+def test_strict_schema_gets_additional_properties_false():
+    """OpenAI rejects strict json_schema without additionalProperties: false."""
+    resolved = resolve_structured_output({"type": "json_schema", "schema": Capital})
+
+    schema = resolved.response_format["json_schema"]["schema"]
+    assert schema["additionalProperties"] is False
+    assert resolved.response_format["json_schema"]["strict"] is True
+
+
+def test_strict_schema_normalizes_nested_defs():
+    """Nested models live in $defs and each needs the flag too."""
+    resolved = resolve_structured_output({"type": "json_schema", "schema": Person})
+
+    schema = resolved.response_format["json_schema"]["schema"]
+    assert schema["additionalProperties"] is False
+    assert schema["$defs"]["Address"]["additionalProperties"] is False
+    assert resolved.response_format["json_schema"]["strict"] is True
+
+
+def test_optional_properties_downgrade_strict():
+    """Strict also demands every property be required — we don't fabricate that.
+
+    Promoting an optional field to required would change the caller's schema,
+    so the request drops to strict=false instead. Local validation is unchanged.
+    """
+    resolved = resolve_structured_output({"type": "json_schema", "schema": Loose})
+
+    js = resolved.response_format["json_schema"]
+    assert js["strict"] is False
+    # The flag is still added — it is semantically free and harmless.
+    assert js["schema"]["additionalProperties"] is False
+
+
+def test_explicit_strict_false_is_preserved():
+    resolved = resolve_structured_output(
+        {"type": "json_schema", "schema": Capital, "strict": False}
+    )
+    assert resolved.response_format["json_schema"]["strict"] is False
+
+
+def test_caller_additional_properties_is_not_overwritten():
+    schema = {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+        "additionalProperties": True,
+    }
+    resolved = resolve_structured_output({"type": "json_schema", "schema": schema})
+
+    assert resolved.response_format["json_schema"]["schema"]["additionalProperties"] is True
+
+
+def test_caller_schema_dict_is_not_mutated():
+    """The caller may reuse their dict — normalization must not leak into it."""
+    schema = {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+    }
+    original = copy.deepcopy(schema)
+
+    resolve_structured_output({"type": "json_schema", "schema": schema})
+
+    assert schema == original
+
+
+def test_normalization_applies_to_every_provider_shape():
+    """One normalized schema serves every provider, not just the OpenAI family.
+
+    Anthropic's output_config rejects an object schema without
+    additionalProperties: false exactly like OpenAI's strict mode does, and the
+    other native-schema providers accept it, so there is no per-provider split.
+    """
+    resolved = resolve_structured_output({"type": "json_schema", "schema": Capital})
+
+    assert resolved.response_format["json_schema"]["schema"]["additionalProperties"] is False


### PR DESCRIPTION
Found by the real-API release tests while preparing v2.26.0. Pre-existing, not a regression from this cycle.

## Problem

`structured={"type": "json_schema", "schema": <PydanticModel>}` — a documented headline feature — failed on **OpenAI** before the request even ran:

```
RuntimeError: OpenAI API error: Invalid schema for response_format 'Capital':
In context=(), 'additionalProperties' is required to be supplied and to be false.
```

And, once Anthropic credit was available to test with, on **Anthropic** too:

```
RuntimeError: Anthropic API error: output_config.format.schema: For 'object' type,
'additionalProperties' must be explicitly set to false
```

`resolve_structured_output()` passed Pydantic's `model_json_schema()` straight through, and Pydantic emits neither the flag nor anything else these strict modes demand. Every Pydantic schema was broken on both providers.

## Fix

Normalize the schema in `resolve_structured_output()`: walk the whole tree — `$defs`, `items`, `anyOf`/`oneOf`/`allOf`, `patternProperties` — and set `additionalProperties: false` on every object schema that doesn't already declare one. The walk runs on a `deepcopy`, so a caller reusing their schema dict never sees our fixups (there's a test for that).

**A design note worth recording.** I first scoped this narrowly, adding a `raw_schema` field so providers with a native schema field (Google/Vertex `responseJsonSchema`, Anthropic `output_config`, Ollama `format`, Cohere `response_format.schema`) kept the untouched schema — the reasoning being that an OpenAI-specific requirement shouldn't leak into request shapes that didn't ask for it.

The real-API run disproved it. Anthropic *requires* the same flag, and every other provider accepts it:

| Provider | Model | Normalized schema |
|---|---|---|
| OpenAI | gpt-4o-mini | ✅ (requires it) |
| Anthropic | claude-haiku-4-5 | ✅ (requires it) |
| Google | gemini-2.5-flash | ✅ |
| Groq | openai/gpt-oss-120b | ✅ |
| Mistral | mistral-small-latest | ✅ |
| Cohere | command-a-03-2025 | ✅ |

So the split was solving a problem that didn't exist, and hiding one that did. One normalized schema, no per-provider special-casing.

### The `required` half

Strict mode demands a second thing: every property listed in `required`. A schema with optional fields can't satisfy that.

We do **not** fabricate it — promoting an optional field to required would silently change the caller's schema semantics. Instead the request goes out with `strict: false` plus a debug log. Local validation is unchanged (`parse_structured_output_content` still runs `model_validate`), so only the provider-side guarantee relaxes, and only for schemas that could never have had it.

This follows ARCHITECTURE.md's **Model Quirks vs Unsupported Features**: sanitize the request shape rather than make users learn a per-model quirk, and never silently drop a feature they think ran.

## Also here

Two stale release-test fixtures found on the way:

- `llama-3.3-70b-versatile` doesn't support `response_format: json_schema` on Groq — switched to `openai/gpt-oss-120b` (verified).
- `claude-3-5-haiku-latest` no longer exists — switched to `claude-haiku-4-5-20251001`.

And a token-budget fix: `gemini-2.5-flash` and `gpt-oss-120b` spend reasoning tokens from the same budget as the answer, so the tests' `max_tokens=100` truncated the JSON mid-string and read as a schema failure. Now a shared `MAX_TOKENS = 800` with a comment explaining why.

## Validation

- Canonical validator: **1585 passed, 1 skipped, 1 xfailed**; `ruff` and `mypy` clean
- Real API: **9/9, twice consecutively** across all six providers, including a nested (`$defs`) schema and an optional-field schema
- New unit tests cover: the flag on flat and nested schemas, the strict downgrade on optional fields, an explicit `strict: false` being preserved, a caller-supplied `additionalProperties: true` not being overwritten, and the caller's dict not being mutated

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

