### PR TITLE
fix(anthropic): default to a model Anthropic still serves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Anthropic no longer defaults to a retired model.** Anthropic has withdrawn
+  the entire `claude-3` family, and every Anthropic model hardcoded in Esperanto
+  belonged to it — including the default, `claude-3-7-sonnet-20250219`, so
+  `create_language("anthropic")` without an explicit `model_name` failed
+  outright. The default is now `claude-sonnet-5`, and the provider's fallback
+  list plus `get_provider_models("anthropic")` now carry the current family
+  (`claude-opus-5`, `claude-sonnet-5`, `claude-opus-4-5-20251101`,
+  `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001`). Docs updated.
+
+  Note that `claude-sonnet-5` is an undated alias: it tracks Anthropic's current
+  Sonnet 5 release rather than staying fixed. Pass a dated id
+  (e.g. `claude-sonnet-4-5-20250929`) when you need the model pinned.
+
 - **Google and Vertex no longer default to a retired model.** Google has
   withdrawn `gemini-2.0-flash` — it still appears in the models listing but any
   `generateContent` call returns "This model is no longer available", so

--- a/README.md
+++ b/README.md
@@ -234,9 +234,9 @@ for model in claude_models:
     print(f"{model.id} - Context: {model.context_window} tokens")
 
 # Example output:
-# claude-3-5-sonnet-20241022 - Context: 200000 tokens
-# claude-3-5-haiku-20241022 - Context: 200000 tokens
-# claude-3-opus-20240229 - Context: 200000 tokens
+# claude-sonnet-5 - Context: 200000 tokens
+# claude-haiku-4-5-20251001 - Context: 200000 tokens
+# claude-opus-5 - Context: 200000 tokens
 
 # OpenAI-compatible endpoints (requires base_url)
 local_models = AIFactory.get_provider_models(

--- a/docs/README.md
+++ b/docs/README.md
@@ -136,7 +136,7 @@ Choose best-in-class for each capability:
 
 ```python
 # Best reasoning
-llm = AIFactory.create_language("anthropic", "claude-3-5-sonnet-20241022")
+llm = AIFactory.create_language("anthropic", "claude-sonnet-5")
 
 # Best embeddings with advanced features
 embedder = AIFactory.create_embedding("jina", "jina-embeddings-v3")
@@ -155,7 +155,7 @@ local_llm = AIFactory.create_language("ollama", "llama3.2")
 local_embedder = AIFactory.create_embedding("transformers", "BAAI/bge-large-en-v1.5")
 
 # Cloud for specialized needs
-cloud_llm = AIFactory.create_language("anthropic", "claude-3-5-sonnet-20241022")
+cloud_llm = AIFactory.create_language("anthropic", "claude-sonnet-5")
 ```
 
 ## 📖 Documentation Conventions

--- a/docs/advanced/langchain-integration.md
+++ b/docs/advanced/langchain-integration.md
@@ -59,7 +59,7 @@ from esperanto import AIFactory
 
 model = AIFactory.create_language(
     "anthropic",
-    "claude-3-5-sonnet-20241022",
+    "claude-sonnet-5",
     api_key="your-api-key"
 )
 
@@ -165,7 +165,7 @@ from langchain.chains import LLMChain
 from langchain.prompts import PromptTemplate
 
 # Create model
-model = AIFactory.create_language("anthropic", "claude-3-5-sonnet-20241022")
+model = AIFactory.create_language("anthropic", "claude-sonnet-5")
 langchain_model = model.to_langchain()
 
 # Create prompt template
@@ -411,7 +411,7 @@ fast_model = AIFactory.create_language("groq", "mixtral-8x7b-32768")
 fast_langchain = fast_model.to_langchain()
 
 # Powerful model for final output
-powerful_model = AIFactory.create_language("anthropic", "claude-3-5-sonnet-20241022")
+powerful_model = AIFactory.create_language("anthropic", "claude-sonnet-5")
 powerful_langchain = powerful_model.to_langchain()
 
 # Chain 1: Fast initial analysis
@@ -458,7 +458,7 @@ fast_model = AIFactory.create_language("groq", "llama3-8b-8192")
 fast_chain = LLMChain(llm=fast_model.to_langchain(), prompt=simple_prompt)
 
 # Use powerful models for complex reasoning
-powerful_model = AIFactory.create_language("anthropic", "claude-3-5-sonnet-20241022")
+powerful_model = AIFactory.create_language("anthropic", "claude-sonnet-5")
 complex_chain = LLMChain(llm=powerful_model.to_langchain(), prompt=complex_prompt)
 ```
 
@@ -471,7 +471,7 @@ def create_langchain_model(provider="openai", model_name="gpt-4"):
     return esperanto_model.to_langchain()
 
 # Switch providers with a config change
-langchain_model = create_langchain_model("anthropic", "claude-3-5-haiku-20241022")
+langchain_model = create_langchain_model("anthropic", "claude-haiku-4-5-20251001")
 ```
 
 ### 3. Handle Errors Gracefully

--- a/docs/advanced/model-discovery.md
+++ b/docs/advanced/model-discovery.md
@@ -195,9 +195,9 @@ for model in models:
     print(f"{model.id} - Context: {model.context_window} tokens")
 
 # Example output:
-# claude-3-5-sonnet-20241022 - Context: 200000 tokens
-# claude-3-5-haiku-20241022 - Context: 200000 tokens
-# claude-3-opus-20240229 - Context: 200000 tokens
+# claude-sonnet-5 - Context: 200000 tokens
+# claude-haiku-4-5-20251001 - Context: 200000 tokens
+# claude-opus-5 - Context: 200000 tokens
 ```
 
 ### Google/Gemini

--- a/docs/advanced/timeout-configuration.md
+++ b/docs/advanced/timeout-configuration.md
@@ -216,7 +216,7 @@ Maximum timeout for async background processing:
 # Long-running document analysis
 analyzer = AIFactory.create_language(
     "anthropic",
-    "claude-3-5-sonnet-20241022",
+    "claude-sonnet-5",
     config={"timeout": 3600.0}  # 1 hour max
 )
 
@@ -408,7 +408,7 @@ def create_model_with_fallback(primary_config, fallback_config):
         return model, "fallback"
 
 # Usage
-primary = {"provider": "anthropic", "model_name": "claude-3-5-sonnet-20241022"}
+primary = {"provider": "anthropic", "model_name": "claude-sonnet-5"}
 fallback = {"provider": "groq", "model_name": "mixtral-8x7b-32768"}
 
 model, used = create_model_with_fallback(primary, fallback)
@@ -577,7 +577,7 @@ groq_model = AIFactory.create_language(
 
 # Slower providers - longer timeout
 anthropic_model = AIFactory.create_language(
-    "anthropic", "claude-3-5-sonnet-20241022",
+    "anthropic", "claude-sonnet-5",
     config={"timeout": 120.0}  # Claude can be slower
 )
 ```
@@ -626,7 +626,7 @@ class ModelFactory:
     @staticmethod
     def create_analysis_model():
         return AIFactory.create_language(
-            "anthropic", "claude-3-5-sonnet-20241022",
+            "anthropic", "claude-sonnet-5",
             config={"timeout": ModelFactory.TIMEOUT_STANDARD}
         )
 ```

--- a/docs/capabilities/llm.md
+++ b/docs/capabilities/llm.md
@@ -256,7 +256,7 @@ print(response.content)
 
 ```python
 model = AIFactory.create_language(
-    "anthropic", "claude-3-5-sonnet-20241022",
+    "anthropic", "claude-sonnet-5",
     config={"streaming": True, "temperature": 0.3}
 )
 

--- a/docs/capabilities/reranking.md
+++ b/docs/capabilities/reranking.md
@@ -162,7 +162,7 @@ reranked = reranker.rerank(query, candidates, top_k=5)
 top_docs = [r.document for r in reranked.results]
 context = "\n\n".join(top_docs)
 
-model = AIFactory.create_language("anthropic", "claude-3-5-sonnet-20241022")
+model = AIFactory.create_language("anthropic", "claude-sonnet-5")
 messages = [{
     "role": "user",
     "content": f"Context:\n{context}\n\nQuestion: {query}"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,7 +70,7 @@ ANTHROPIC_API_KEY=sk-ant-...
 ```
 
 ```python
-model = AIFactory.create_language("anthropic", "claude-3-5-sonnet-20241022", config={
+model = AIFactory.create_language("anthropic", "claude-sonnet-5", config={
     "api_key": "sk-ant-...",  # Or from env var
     "temperature": 0.7,
     "max_tokens": 1000,
@@ -674,7 +674,7 @@ JINA_API_KEY=...
 ELEVENLABS_API_KEY=...
 
 # Use best provider for each task
-llm = AIFactory.create_language("anthropic", "claude-3-5-sonnet-20241022")
+llm = AIFactory.create_language("anthropic", "claude-sonnet-5")
 embedder = AIFactory.create_embedding("jina", "jina-embeddings-v3")
 speaker = AIFactory.create_text_to_speech("elevenlabs", "eleven_multilingual_v2")
 ```

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -278,7 +278,7 @@ speaker = AIFactory.create_text_to_speech("openai", "tts-1")
 from esperanto.factory import AIFactory
 
 # Best-in-class for each capability
-llm = AIFactory.create_language("anthropic", "claude-3-5-sonnet-20241022")
+llm = AIFactory.create_language("anthropic", "claude-sonnet-5")
 embedder = AIFactory.create_embedding("jina", "jina-embeddings-v3")
 reranker = AIFactory.create_reranker("voyage", "rerank-2")
 speaker = AIFactory.create_text_to_speech("elevenlabs", "eleven_multilingual_v2")

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -46,7 +46,7 @@ ANTHROPIC_API_KEY="sk-ant-..."
 from esperanto.factory import AIFactory
 
 # Create Claude model
-model = AIFactory.create_language("anthropic", "claude-3-5-sonnet-20241022")
+model = AIFactory.create_language("anthropic", "claude-sonnet-5")
 
 # Chat completion
 messages = [{"role": "user", "content": "Explain quantum computing"}]
@@ -62,7 +62,7 @@ from esperanto.providers.llm.anthropic import AnthropicLanguageModel
 # Create model instance
 model = AnthropicLanguageModel(
     api_key="your-api-key",
-    model_name="claude-3-5-sonnet-20241022"
+    model_name="claude-sonnet-5"
 )
 
 # Use the model
@@ -79,11 +79,14 @@ print(response.choices[0].message.content)
 
 | Model | Context Window | Best For |
 |-------|----------------|----------|
-| **claude-3-5-sonnet-20241022** | 200K tokens | Latest, balanced performance and speed |
-| **claude-3-5-haiku-20241022** | 200K tokens | Fast responses, cost-effective |
-| **claude-3-opus-20240229** | 200K tokens | Complex tasks, highest capability |
-| **claude-3-sonnet-20240229** | 200K tokens | Balanced performance |
-| **claude-3-haiku-20240307** | 200K tokens | Speed and efficiency |
+| **claude-sonnet-5** | 200K tokens | Default. Balanced performance and speed |
+| **claude-opus-5** | 200K tokens | Complex tasks, highest capability |
+| **claude-sonnet-4-5-20250929** | 200K tokens | Pinned Sonnet, stable across releases |
+| **claude-haiku-4-5-20251001** | 200K tokens | Fast responses, cost-effective |
+
+The undated aliases (`claude-sonnet-5`, `claude-opus-5`) track Anthropic's
+current release of that tier; pin a dated id when you need the model to stay
+fixed.
 
 **Configuration:**
 
@@ -92,7 +95,7 @@ from esperanto.factory import AIFactory
 
 model = AIFactory.create_language(
     "anthropic",
-    "claude-3-5-sonnet-20241022",
+    "claude-sonnet-5",
     config={
         "temperature": 0.7,           # Randomness (0.0 - 1.0)
         "max_tokens": 1024,           # Maximum response length (required)
@@ -110,7 +113,7 @@ model = AIFactory.create_language(
 from esperanto.factory import AIFactory
 
 # Create Claude model
-model = AIFactory.create_language("anthropic", "claude-3-5-sonnet-20241022")
+model = AIFactory.create_language("anthropic", "claude-sonnet-5")
 
 # Simple chat
 messages = [
@@ -138,7 +141,7 @@ print(response.choices[0].message.content)
 
 ```python
 async def chat_async():
-    model = AIFactory.create_language("anthropic", "claude-3-5-sonnet-20241022")
+    model = AIFactory.create_language("anthropic", "claude-sonnet-5")
 
     messages = [{"role": "user", "content": "Explain quantum computing"}]
     response = await model.achat_complete(messages)
@@ -166,7 +169,7 @@ async for chunk in model.achat_complete(messages, stream=True):
 # Enable JSON output
 model = AIFactory.create_language(
     "anthropic",
-    "claude-3-5-sonnet-20241022",
+    "claude-sonnet-5",
     config={"structured": {"type": "json"}}
 )
 
@@ -216,14 +219,14 @@ print(response.choices[0].message.content)
 # More creative (higher temperature)
 creative_model = AIFactory.create_language(
     "anthropic",
-    "claude-3-5-sonnet-20241022",
+    "claude-sonnet-5",
     config={"temperature": 1.0, "max_tokens": 1024}
 )
 
 # More focused (lower temperature)
 focused_model = AIFactory.create_language(
     "anthropic",
-    "claude-3-5-sonnet-20241022",
+    "claude-sonnet-5",
     config={"temperature": 0.2, "max_tokens": 1024}
 )
 
@@ -241,7 +244,7 @@ Claude supports structured JSON output:
 ```python
 model = AIFactory.create_language(
     "anthropic",
-    "claude-3-5-sonnet-20241022",
+    "claude-sonnet-5",
     config={"structured": {"type": "json"}}
 )
 
@@ -267,7 +270,7 @@ class TravelPlan(BaseModel):
 
 model = AIFactory.create_language(
     "anthropic",
-    "claude-3-5-sonnet-20241022",
+    "claude-sonnet-5",
     config={
         "structured": {
             "type": "json_schema",
@@ -297,7 +300,7 @@ Claude prioritizes temperature over top_p when both are specified:
 # Temperature takes precedence
 model = AIFactory.create_language(
     "anthropic",
-    "claude-3-5-sonnet-20241022",
+    "claude-sonnet-5",
     config={
         "temperature": 0.7,  # This will be used
         "top_p": 0.9         # This will be ignored
@@ -312,7 +315,7 @@ Customize request timeouts:
 # Extended timeout for complex tasks
 model = AIFactory.create_language(
     "anthropic",
-    "claude-3-5-sonnet-20241022",
+    "claude-sonnet-5",
     config={
         "timeout": 120.0,    # 2 minutes
         "max_tokens": 4096
@@ -326,7 +329,7 @@ Convert to LangChain models:
 ```python
 from esperanto.factory import AIFactory
 
-model = AIFactory.create_language("anthropic", "claude-3-5-sonnet-20241022")
+model = AIFactory.create_language("anthropic", "claude-sonnet-5")
 langchain_model = model.to_langchain()
 
 # Use with LangChain
@@ -344,7 +347,7 @@ chain = ConversationChain(llm=langchain_model)
 - 200K token context window
 
 ```python
-model = AIFactory.create_language("anthropic", "claude-3-5-sonnet-20241022")
+model = AIFactory.create_language("anthropic", "claude-sonnet-5")
 ```
 
 ### Claude 3.5 Haiku
@@ -355,7 +358,7 @@ model = AIFactory.create_language("anthropic", "claude-3-5-sonnet-20241022")
 - Still maintains strong capabilities
 
 ```python
-model = AIFactory.create_language("anthropic", "claude-3-5-haiku-20241022")
+model = AIFactory.create_language("anthropic", "claude-haiku-4-5-20251001")
 ```
 
 ### Claude 3 Opus
@@ -366,7 +369,7 @@ model = AIFactory.create_language("anthropic", "claude-3-5-haiku-20241022")
 - Use when quality is paramount
 
 ```python
-model = AIFactory.create_language("anthropic", "claude-3-opus-20240229")
+model = AIFactory.create_language("anthropic", "claude-opus-5")
 ```
 
 ## Performance Characteristics

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -163,7 +163,7 @@ The beauty of Esperanto is that switching providers is as simple as changing two
 model = AIFactory.create_language("openai", "gpt-4")
 
 # Switch to Anthropic
-model = AIFactory.create_language("anthropic", "claude-3-5-sonnet-20241022")
+model = AIFactory.create_language("anthropic", "claude-sonnet-5")
 
 # Switch to Google
 model = AIFactory.create_language("google", "gemini-pro")
@@ -315,7 +315,7 @@ from esperanto.factory import AIFactory
 # Setup models
 embedder = AIFactory.create_embedding("openai", "text-embedding-3-small")
 reranker = AIFactory.create_reranker("jina", "jina-reranker-v2-base-multilingual")
-llm = AIFactory.create_language("anthropic", "claude-3-5-sonnet-20241022")
+llm = AIFactory.create_language("anthropic", "claude-sonnet-5")
 
 # Your knowledge base
 documents = [

--- a/src/esperanto/model_discovery.py
+++ b/src/esperanto/model_discovery.py
@@ -158,12 +158,11 @@ def get_anthropic_models(
 
     # Hardcoded list of known Anthropic models (they don't have a models API)
     models = [
-        Model(id="claude-3-5-sonnet-20241022", owned_by="anthropic", context_window=200000),
-        Model(id="claude-3-5-sonnet-20240620", owned_by="anthropic", context_window=200000),
-        Model(id="claude-3-5-haiku-20241022", owned_by="anthropic", context_window=200000),
-        Model(id="claude-3-opus-20240229", owned_by="anthropic", context_window=200000),
-        Model(id="claude-3-sonnet-20240229", owned_by="anthropic", context_window=200000),
-        Model(id="claude-3-haiku-20240307", owned_by="anthropic", context_window=200000),
+        Model(id="claude-opus-5", owned_by="anthropic", context_window=200000),
+        Model(id="claude-sonnet-5", owned_by="anthropic", context_window=200000),
+        Model(id="claude-opus-4-5-20251101", owned_by="anthropic", context_window=200000),
+        Model(id="claude-sonnet-4-5-20250929", owned_by="anthropic", context_window=200000),
+        Model(id="claude-haiku-4-5-20251001", owned_by="anthropic", context_window=200000),
     ]
 
     # Cache results

--- a/src/esperanto/providers/llm/anthropic.py
+++ b/src/esperanto/providers/llm/anthropic.py
@@ -174,22 +174,22 @@ class AnthropicLanguageModel(LanguageModel):
             # Fallback to known models if API call fails
             return [
                 Model(
-                    id="claude-3-7-sonnet-20250219",
+                    id="claude-sonnet-5",
                     owned_by="Anthropic",
                     context_window=200000,
                 ),
                 Model(
-                    id="claude-3-opus-20240229",
+                    id="claude-opus-5",
                     owned_by="Anthropic",
                     context_window=200000,
                 ),
                 Model(
-                    id="claude-3-sonnet-20240229",
+                    id="claude-sonnet-4-5-20250929",
                     owned_by="Anthropic",
                     context_window=200000,
                 ),
                 Model(
-                    id="claude-3-haiku-20240307",
+                    id="claude-haiku-4-5-20251001",
                     owned_by="Anthropic",
                     context_window=200000,
                 ),
@@ -551,7 +551,7 @@ class AnthropicLanguageModel(LanguageModel):
 
     def _get_default_model(self) -> str:
         """Get the default model name."""
-        return "claude-3-7-sonnet-20250219"
+        return "claude-sonnet-5"
 
     @property
     def provider(self) -> str:

--- a/tests/integration/test_chat_completion_real.py
+++ b/tests/integration/test_chat_completion_real.py
@@ -111,21 +111,21 @@ class TestAnthropicChat:
     """Real integration tests for Anthropic chat completion."""
 
     def test_sync_chat_complete(self):
-        model = AIFactory.create_language("anthropic", "claude-3-5-haiku-latest")
+        model = AIFactory.create_language("anthropic", "claude-haiku-4-5-20251001")
         response = model.chat_complete(messages=MESSAGES)
         assert isinstance(response, ChatCompletion)
         assert response.choices[0].message.content is not None
         assert len(response.choices[0].message.content) > 0
 
     async def test_async_chat_complete(self):
-        model = AIFactory.create_language("anthropic", "claude-3-5-haiku-latest")
+        model = AIFactory.create_language("anthropic", "claude-haiku-4-5-20251001")
         response = await model.achat_complete(messages=MESSAGES)
         assert isinstance(response, ChatCompletion)
         assert response.choices[0].message.content is not None
         assert len(response.choices[0].message.content) > 0
 
     def test_sync_streaming(self):
-        model = AIFactory.create_language("anthropic", "claude-3-5-haiku-latest")
+        model = AIFactory.create_language("anthropic", "claude-haiku-4-5-20251001")
         response = model.chat_complete(messages=MESSAGES, stream=True)
         total_content = ""
         for chunk in response:
@@ -135,7 +135,7 @@ class TestAnthropicChat:
         assert len(total_content) > 0
 
     async def test_async_streaming(self):
-        model = AIFactory.create_language("anthropic", "claude-3-5-haiku-latest")
+        model = AIFactory.create_language("anthropic", "claude-haiku-4-5-20251001")
         response = await model.achat_complete(messages=MESSAGES, stream=True)
         total_content = ""
         async for chunk in response:

--- a/tests/integration/test_structured_output_release.py
+++ b/tests/integration/test_structured_output_release.py
@@ -56,7 +56,7 @@ def test_openai_structured_output_real():
 )
 def test_anthropic_structured_output_real():
     model = AIFactory.create_language(
-        "anthropic", "claude-3-5-haiku-latest", config=STRUCTURED_CONFIG
+        "anthropic", "claude-haiku-4-5-20251001", config=STRUCTURED_CONFIG
     )
     response = model.chat_complete(PROMPT, max_tokens=100)
     _assert_capital(response)

--- a/tests/integration/test_tool_calling_real.py
+++ b/tests/integration/test_tool_calling_real.py
@@ -211,7 +211,7 @@ class TestAnthropicToolCalling:
 
     def test_basic_tool_call(self, weather_tools):
         """Test that Anthropic returns a tool call for a weather query."""
-        model = AIFactory.create_language("anthropic", "claude-3-5-haiku-latest")
+        model = AIFactory.create_language("anthropic", "claude-haiku-4-5-20251001")
 
         response = model.chat_complete(
             messages=TOOL_TRIGGER_MESSAGE,
@@ -240,7 +240,7 @@ class TestAnthropicToolCalling:
 
     def test_multi_turn_with_tool_result(self, weather_tools):
         """Test multi-turn conversation with tool result."""
-        model = AIFactory.create_language("anthropic", "claude-3-5-haiku-latest")
+        model = AIFactory.create_language("anthropic", "claude-haiku-4-5-20251001")
 
         # First call - should get tool call
         response1 = model.chat_complete(

--- a/tests/providers/llm/test_anthropic_provider.py
+++ b/tests/providers/llm/test_anthropic_provider.py
@@ -1253,3 +1253,34 @@ def test_anthropic_to_langchain_omits_default_base_url():
     with patch("langchain_anthropic.ChatAnthropic") as MockChat:
         model.to_langchain()
     assert "base_url" not in MockChat.call_args.kwargs
+
+
+# ---------------------------------------------------------------------------
+# Default model / model list
+#
+# Nothing pinned these, which is how the whole hardcoded set rotted into
+# withdrawn models without a single test going red.
+# ---------------------------------------------------------------------------
+
+
+def test_default_model_is_current():
+    """The default must be a model Anthropic still serves."""
+    model = AnthropicLanguageModel(api_key="test-key")
+    assert model._get_default_model() == "claude-sonnet-5"
+
+
+def test_fallback_model_list_has_no_withdrawn_models():
+    """The offline fallback list must not advertise retired models.
+
+    Anthropic has withdrawn the entire claude-3 family. Listing them makes
+    get_provider_models() recommend models that cannot be called.
+    """
+    model = AnthropicLanguageModel(api_key="test-key")
+    model.client = Mock()
+    model.client.get.side_effect = Exception("no network")
+
+    ids = [m.id for m in model._get_models()]
+
+    assert ids, "fallback list must not be empty"
+    assert not any(model_id.startswith("claude-3") for model_id in ids)
+    assert all(m.owned_by == "Anthropic" for m in model._get_models())

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -211,6 +211,9 @@ class TestAnthropicDiscovery:
         assert all(isinstance(m, Model) for m in models)
         assert all(m.owned_by == "anthropic" for m in models)
         assert any("claude" in m.id for m in models)
+        # Anthropic has withdrawn the entire claude-3 family — discovery must
+        # not recommend models that can no longer be called.
+        assert not any(m.id.startswith("claude-3") for m in models)
 
     def test_get_anthropic_models_caching(self):
         """Test that Anthropic models are cached."""


### PR DESCRIPTION
Found by the real-API release tests while preparing v2.26.0, once the account credit was topped up and the Anthropic paths became reachable. Same bug class as #272 (Google), on another first-class provider.

## Problem

Anthropic has withdrawn the entire `claude-3` family — and **every** Anthropic model hardcoded in this repo belonged to it. Checked one by one against the live API:

```
claude-3-7-sonnet-20250219     DEAD   <- the default
claude-3-opus-20240229         DEAD
claude-3-sonnet-20240229       DEAD
claude-3-haiku-20240307        DEAD
claude-3-5-sonnet-20241022     DEAD
claude-3-5-haiku-20241022      DEAD
```

Consequences:

```python
AIFactory.create_language("anthropic", None)   # -> hard failure
AIFactory.get_provider_models("anthropic")     # -> six uncallable models
```

`llm/anthropic.py:554` (default), `llm/anthropic.py:175-196` (fallback list), `model_discovery.py:161-166` (discovery list).

## Fix

Default → **`claude-sonnet-5`**, verified live (`create_language("anthropic", None)` now resolves to it and completes).

Lists now carry the current family: `claude-opus-5`, `claude-sonnet-5`, `claude-opus-4-5-20251101`, `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001`.

**On the undated alias.** `claude-sonnet-5` tracks Anthropic's current Sonnet 5 release rather than staying fixed, so the default's behavior can shift without Esperanto publishing anything. That's the maintainer's deliberate choice here; the dated ids sit alongside it in the list and the docs spell out how to pin.

## Why it rotted silently

Nothing pinned the default or the lists — no test went red as the models were withdrawn one by one. Three tests added:

- the default is `claude-sonnet-5`
- the provider's offline fallback list contains no `claude-3` id
- `get_anthropic_models()` contains no `claude-3` id

The last two are the durable ones: they'll fail the day the current family is withdrawn too, instead of quietly recommending ghosts.

## Also here

Docs (`docs/providers/anthropic.md`, `README.md`, `docs/quickstart.md`, `docs/configuration.md`, and others) stop recommending withdrawn models — 21 references swept. The real-API tests move off `claude-3-5-haiku-latest`, which also no longer exists.

OpenRouter's `anthropic/claude-3-*` ids are a different namespace on a different service and are left alone, as in #272.

## Validation

- Canonical validator: **1626 passed, 1 skipped, 1 xfailed**; `ruff` and `mypy` clean
- Real API: default resolves and completes; Anthropic chat **4/4**, tool calling **2/2**

⚠️ `test_anthropic_structured_output_real` still fails on this branch, for an unrelated reason already fixed in #273 — Anthropic also requires `additionalProperties: false` on the schema. It'll pass once both land.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

