### PR TITLE
chore: release v2.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.26.0] - 2026-07-29
+
 ### Added
 
 - **Automatic embedding batching across all providers.** `embed()` / `aembed()`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esperanto"
-version = "2.25.1"
+version = "2.26.0"
 description = "A light-weight, production-ready, unified interface for various AI model providers"
 authors = [
     { name = "LUIS NOVO", email = "lfnovo@gmail.com" }

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "esperanto"
-version = "2.25.1"
+version = "2.26.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Release cut for **v2.26.0**. Bumps `pyproject.toml`, dates the CHANGELOG section, opens a fresh `[Unreleased]`, and commits the refreshed `uv.lock`.

Minor, not patch: the release adds embedding auto-batching — a new feature with a new config key (`embed_batch_size`) — with no breaking change to the public API.

## What's in it

**Added**
- Automatic embedding batching across all providers, with native `:batchEmbedContents` / multi-instance `:predict` for Google and Vertex (#108, #203)

**Fixed**
- Schema-driven structured output on OpenAI and Anthropic (#273)
- Google/Vertex default model was withdrawn by Google (#272)
- Anthropic default model and lists were the withdrawn claude-3 family (#274)
- Non-Whisper OpenAI and Azure transcription models (#269, #263)
- `to_langchain()` custom base URL for Google (#248)

## Validation on the release commit

- Canonical validator: **1633 passed, 1 skipped, 1 xfailed**; `ruff` and `mypy` clean
- Real-API suite (`pytest -m release`) on unified main: **151 passed, 30 skipped, 4 failed** — the 4 are Ollama tests needing `qwen3:32b` pulled locally, an environment gap, not a regression (Ollama code is untouched this cycle)
- Build + clean-room install gate re-runs on this exact commit before the tag

## Known gap, stated plainly

Vertex could not be verified against the live API in this cycle — no Google Cloud project is configured in the release environment, so every Vertex LLM call errors on `VERTEX_PROJECT` before reaching Google. Its default model moved alongside Google's by inference (the withdrawal is model-side, not endpoint-side), not by observed pass. Same for the Azure non-Whisper deployment path, which skips without a `gpt-4o-*-transcribe` deployment to point at.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

