### PR TITLE
build: add clean-room package validation

### DIFF
--- a/.maintainer/README.md
+++ b/.maintainer/README.md
@@ -19,10 +19,10 @@ Commands remain canonical in `AGENTS.md` and `Makefile`; contribution and
 architecture policy remain in `CONTRIBUTING.md` and `ARCHITECTURE.md`.
 Read the relevant module-level `AGENTS.md` when reviewing its implementation.
 
-Review, triage and Discussions are configured. The owner confirmed `make tag`
-as the release trigger. The package-install gate is deferred to
-[issue #279](https://github.com/lfnovo/esperanto/issues/279), so release configuration
-remains incomplete until that command exists.
+Review, triage, Discussions and release are configured. The owner confirmed
+`make tag` as the release trigger. `make package-check` is the canonical
+clean-room package gate implemented by
+[issue #279](https://github.com/lfnovo/esperanto/issues/279).
 A valid profile is not evidence that release checks have passed.
 Discussions is enabled, with its live category IDs in `profile.toml`.
 The application smoke skill does not apply to this library. Real-provider

--- a/.maintainer/decisions.md
+++ b/.maintainer/decisions.md
@@ -18,3 +18,14 @@ been made by this profile bootstrap.
   .github/workflows/publish.yml; verified GitHub settings, categories and labels;
   https://github.com/lfnovo/esperanto/issues/279.
 - This authorizes profile adoption and repository setup, not a release publication.
+
+## 2026-09-05 — Implement the package gate for 2.27.0
+
+- Decision: implement issue #279 now and make `make package-check` the mandatory
+  clean-room artifact gate for the 2.27.0 release.
+- Decision: the gate verifies fresh wheel and sdist builds, isolated bare
+  installs, a wheel rebuilt from the sdist, every declared optional extra and
+  SHA-256 artifact identities.
+- Evidence: explicit maintainer approval during the 2.27.0 release session and
+  local execution of `make package-check` on Python 3.13.11.
+- This decision configures the gate; it does not authorize merging or publishing.

--- a/.maintainer/profile.toml
+++ b/.maintainer/profile.toml
@@ -57,7 +57,7 @@ merge_own_prs = "ask-once-per-session"
 
 [artifacts.pypi]
 package = "esperanto"
-gate = "TODO implement canonical package-check gate in issue #279; see .maintainer/release/runbook.md"
+gate = "make package-check"
 surfaces = ["library"]
 extras = ["transformers", "validation"]
 identity = "sha256"

--- a/.maintainer/release/runbook.md
+++ b/.maintainer/release/runbook.md
@@ -16,20 +16,19 @@ use the narrower validator documented in AGENTS.md.
 Record the candidate SHA, interpreter, command, exit status and evidence. CI's
 extra mxbai-rerank install and its Python matrix are documented in test.yml.
 
-## Package gate — missing canonical command
+## Package gate
 
-TODO: define and validate a canonical build-and-clean-room-install command in
-AGENTS.md or Makefile, then replace artifacts.pypi.gate with its reference.
-The owner deferred implementation to [issue #279](https://github.com/lfnovo/esperanto/issues/279).
-The existing uv build step in publish.yml is build-only; it cannot satisfy this gate.
+Run `make package-check`. The command builds fresh wheel and sdist artifacts in
+a temporary directory, checks their metadata and packaged runtime files, and
+records SHA-256 identities. It installs the wheel outside the checkout with
+isolated Python, verifies a bare import and credential-free factory discovery,
+then builds a second wheel from the sdist and repeats the clean-room smoke. It
+also resolves the `transformers` and `validation` extras independently. The
+existing uv build step in publish.yml is build-only and cannot satisfy this gate.
 
-The gate must build wheel and sdist into a clean output location, check metadata
-against the candidate version, inspect packaged assets, install the wheel outside
-the checkout with isolated Python imports, import Esperanto and exercise a
-credential-free public API call. Confirm optional dependencies stay optional and
-that both transformers and validation extras resolve. Verify the sdist can build
-an installable wheel. Record SHA-256 identities and actual module origins.
-No package-gate pass or release GO is possible until this evidence exists.
+Capture the command output as release evidence. It includes the interpreter,
+artifact identities and actual module origins. A package-gate pass applies only
+to those exact locally built artifacts and candidate revision.
 
 ## Bucket C — maintainer-run integrations
 
@@ -68,8 +67,19 @@ Publish rebuilds the artifacts: distinguish tested local builds from index build
 If creating GitHub release notes, attach approved notes to the existing tag and
 verify the release page; publish.yml does not create a GitHub Release itself.
 
-TODO: document canonical index-install verification commands alongside the package
-gate. This verification completes publication; it cannot run before publication.
+Install the exact published version outside the checkout with:
+
+```bash
+check_dir="$(mktemp -d)"
+cd "$check_dir"
+uv run --isolated --no-project --with "esperanto==<version>" \
+  python -I -c 'import esperanto; print(esperanto.__file__)'
+```
+
+Repeat with `esperanto[transformers]==<version>` and
+`esperanto[validation]==<version>`, download the wheel and sdist from PyPI, and
+record their SHA-256 identities. This verification completes publication; it
+cannot run before publication.
 
 ## Cleanup
 

--- a/.maintainer/release/test-matrix.md
+++ b/.maintainer/release/test-matrix.md
@@ -10,7 +10,7 @@ Record passed, failed, not-run and not-applicable checks with revision and evide
 | Default mocked suite | commands.validator -> make test | pytest excludes release marker |
 | Lint | commands.ruff -> AGENTS.md | Same check as lint.yml |
 | Types | commands.mypy -> AGENTS.md | src/esperanto, as in lint.yml |
-| Packaging | artifacts.pypi.gate | Missing canonical clean-room gate; blocks release |
+| Packaging | artifacts.pypi.gate -> make package-check | Fresh wheel/sdist, metadata, packaged runtime files, clean-room imports, extras and SHA-256 identities |
 
 The setup target installs all extras. CI additionally installs mxbai-rerank.
 CI tests 3.10/3.11/3.12; package metadata also supports 3.13. Track actual coverage.
@@ -24,8 +24,6 @@ Do not claim a provider was exercised merely because a shared base test passed.
 
 ## Bucket B — investment candidates
 
-- Implement the package gate described in runbook.md, including wheel/sdist and extras
-  ([issue #279](https://github.com/lfnovo/esperanto/issues/279), deferred by the owner).
 - Add Python 3.13 CI coverage if the maintainer elects to cover the full declared range.
 - Reconcile the CI-specific mxbai-rerank setup with local validation documentation.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,6 +242,7 @@ All providers use utility mixins:
 - **Run all tests**: `uv run pytest -v`
 - **Run specific test**: `uv run pytest tests/providers/llm/test_openai.py -v`
 - **Run integration tests**: `uv run pytest tests/integration/ -v`
+- **Validate package artifacts**: `make package-check`
 - **Check types**: `uv run mypy src/esperanto`
 - **Fix lint issues**: `uv run ruff check . --fix`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,10 +247,13 @@ Run the release suite **before tagging a release** — it's the last gate that c
 3. Run `uv run pytest` (default, mocked) — must be green.
 4. Run `uv run ruff check .` and `uv run mypy src/esperanto` — must be green.
 5. **Run `uv run pytest -m release`** — must be green or have only known-tracked xfails.
-6. Bump version, commit, tag, push tag.
-7. Build + publish.
+6. Bump the version, regenerate `uv.lock`, and run `make package-check` against
+   the exact candidate — its clean-room wheel/sdist checks must be green.
+7. Commit the release cut, then repeat any gate invalidated by that commit.
+8. After the explicit release GO, run `make tag`; its tag push triggers the
+   publish workflow.
 
-If step 5 surfaces a real regression, the release waits.
+If a gate surfaces a real regression, the release waits.
 
 **6. Audio fixture**
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup ruff lint test
+.PHONY: setup ruff lint test package-check
 
 setup:
 	uv venv
@@ -13,6 +13,9 @@ ruff:
 test:
 	uv run pytest -v
 
+package-check:
+	uv run python scripts/package_check.py
+
 
 build-docs:
 	repomix . --include "**/*.py" --compress --style xml -o ai_docs/all_docs.txt
@@ -23,4 +26,3 @@ tag:
 	echo "Creating tag v$$version"; \
 	git tag "v$$version"; \
 	git push origin "v$$version"
-

--- a/scripts/package_check.py
+++ b/scripts/package_check.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Build and validate Esperanto distributions outside the source checkout."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import tarfile
+import tempfile
+import zipfile
+from email.parser import Parser
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = "esperanto"
+RUNTIME_FILES = {
+    path.relative_to(ROOT / "src").as_posix()
+    for path in (ROOT / "src" / PACKAGE).rglob("*.py")
+}
+RUNTIME_FILES.add(f"{PACKAGE}/py.typed")
+
+
+def run(command: list[str], *, cwd: Path) -> None:
+    print(f"+ {shlex.join(command)}", flush=True)
+    subprocess.run(command, cwd=cwd, check=True)
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def project_version() -> str:
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'^version = "([^"]+)"$', pyproject, re.MULTILINE)
+    if match is None:
+        raise RuntimeError("could not read project version from pyproject.toml")
+
+    version = match.group(1)
+    lock = (ROOT / "uv.lock").read_text(encoding="utf-8")
+    lock_match = re.search(
+        r'^name = "esperanto"\nversion = "([^"]+)"$', lock, re.MULTILINE
+    )
+    if lock_match is None or lock_match.group(1) != version:
+        locked = lock_match.group(1) if lock_match else "missing"
+        raise RuntimeError(
+            f"version files disagree: pyproject.toml={version}, uv.lock={locked}"
+        )
+    return version
+
+
+def one_file(directory: Path, pattern: str) -> Path:
+    matches = sorted(directory.glob(pattern))
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"expected exactly one {pattern} in {directory}, found {len(matches)}"
+        )
+    return matches[0].resolve()
+
+
+def wheel_metadata(wheel: Path) -> tuple[str, str]:
+    with zipfile.ZipFile(wheel) as archive:
+        metadata_names = [
+            name for name in archive.namelist() if name.endswith(".dist-info/METADATA")
+        ]
+        if len(metadata_names) != 1:
+            raise RuntimeError("wheel must contain exactly one METADATA file")
+        metadata = Parser().parsestr(archive.read(metadata_names[0]).decode("utf-8"))
+        return metadata.get("Name", ""), metadata.get("Version", "")
+
+
+def inspect_wheel(wheel: Path, version: str) -> None:
+    name, built_version = wheel_metadata(wheel)
+    if name != PACKAGE or built_version != version:
+        raise RuntimeError(
+            f"wheel metadata is {name} {built_version}, expected {PACKAGE} {version}"
+        )
+
+    with zipfile.ZipFile(wheel) as archive:
+        packaged = set(archive.namelist())
+    missing = sorted(RUNTIME_FILES - packaged)
+    if missing:
+        raise RuntimeError(f"wheel is missing runtime files: {', '.join(missing)}")
+
+
+def inspect_sdist(sdist: Path, version: str) -> None:
+    expected_prefix = f"{PACKAGE}-{version}/"
+    with tarfile.open(sdist, "r:gz") as archive:
+        names = archive.getnames()
+        if not all(
+            name == expected_prefix[:-1] or name.startswith(expected_prefix)
+            for name in names
+        ):
+            raise RuntimeError("sdist contains entries outside its versioned root")
+        packaged = {
+            name.removeprefix(expected_prefix)
+            for name in names
+            if name.startswith(expected_prefix)
+        }
+        metadata_names = [name for name in names if name.endswith("/PKG-INFO")]
+        if len(metadata_names) != 1:
+            raise RuntimeError("sdist must contain exactly one PKG-INFO file")
+        metadata_file = archive.extractfile(metadata_names[0])
+        if metadata_file is None:
+            raise RuntimeError("could not read sdist PKG-INFO")
+        metadata = metadata_file.read().decode("utf-8")
+
+    missing = sorted({f"src/{path}" for path in RUNTIME_FILES} - packaged)
+    if missing:
+        raise RuntimeError(f"sdist is missing runtime files: {', '.join(missing)}")
+    if f"Name: {PACKAGE}\n" not in metadata or f"Version: {version}\n" not in metadata:
+        raise RuntimeError("sdist metadata does not match project name and version")
+
+
+def smoke_wheel(wheel: Path, version: str, workdir: Path) -> None:
+    code = """
+import importlib.metadata
+import importlib.util
+import json
+import os
+from pathlib import Path
+
+import esperanto
+from esperanto import AIFactory
+
+origin = Path(esperanto.__file__).resolve()
+checkout = Path(os.environ["ESPERANTO_CHECKOUT_ROOT"]).resolve()
+if origin == checkout or checkout in origin.parents:
+    raise RuntimeError(f"import resolved inside checkout: {origin}")
+if importlib.metadata.version("esperanto") != os.environ["ESPERANTO_EXPECTED_VERSION"]:
+    raise RuntimeError("installed metadata version does not match candidate")
+if importlib.util.find_spec("transformers") is not None:
+    raise RuntimeError("bare wheel unexpectedly installed the transformers extra")
+if importlib.util.find_spec("jsonschema") is not None:
+    raise RuntimeError("bare wheel unexpectedly installed the validation extra")
+providers = AIFactory.get_available_providers()
+if not providers.get("language") or not providers.get("text_to_speech"):
+    raise RuntimeError("credential-free factory discovery returned incomplete surfaces")
+print(json.dumps({"module_origin": str(origin), "version": importlib.metadata.version("esperanto")}))
+"""
+    env = os.environ.copy()
+    env["ESPERANTO_CHECKOUT_ROOT"] = str(ROOT)
+    env["ESPERANTO_EXPECTED_VERSION"] = version
+    command = [
+        "uv",
+        "run",
+        "--isolated",
+        "--no-project",
+        "--with",
+        str(wheel),
+        "python",
+        "-I",
+        "-c",
+        code,
+    ]
+    print(f"+ {shlex.join(command)}", flush=True)
+    subprocess.run(command, cwd=workdir, env=env, check=True)
+
+
+def check_extra(
+    wheel: Path, extra: str, distributions: list[str], workdir: Path
+) -> None:
+    quoted = json.dumps(distributions)
+    code = (
+        "import importlib.metadata; "
+        f"names = {quoted}; "
+        "print({name: importlib.metadata.version(name) for name in names})"
+    )
+    run(
+        [
+            "uv",
+            "run",
+            "--isolated",
+            "--no-project",
+            "--with",
+            f"{PACKAGE}[{extra}] @ {wheel.as_uri()}",
+            "python",
+            "-I",
+            "-c",
+            code,
+        ],
+        cwd=workdir,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args()
+
+    version = project_version()
+    with tempfile.TemporaryDirectory(prefix="esperanto-package-check-") as temporary:
+        workspace = Path(temporary)
+        dist = workspace / "dist"
+        rebuilt = workspace / "rebuilt"
+        clean_room = workspace / "clean-room"
+        dist.mkdir()
+        rebuilt.mkdir()
+        clean_room.mkdir()
+
+        run(["uv", "build", "--out-dir", str(dist), str(ROOT)], cwd=workspace)
+        wheel = one_file(dist, "*.whl")
+        sdist = one_file(dist, "*.tar.gz")
+        inspect_wheel(wheel, version)
+        inspect_sdist(sdist, version)
+        smoke_wheel(wheel, version, clean_room)
+
+        run(
+            ["uv", "build", "--wheel", "--out-dir", str(rebuilt), str(sdist)],
+            cwd=workspace,
+        )
+        rebuilt_wheel = one_file(rebuilt, "*.whl")
+        inspect_wheel(rebuilt_wheel, version)
+        smoke_wheel(rebuilt_wheel, version, clean_room)
+
+        check_extra(
+            wheel,
+            "transformers",
+            ["transformers", "torch", "sentence-transformers"],
+            clean_room,
+        )
+        check_extra(wheel, "validation", ["jsonschema"], clean_room)
+
+        result = {
+            "package": PACKAGE,
+            "version": version,
+            "python": sys.version.split()[0],
+            "artifacts": {
+                wheel.name: sha256(wheel),
+                sdist.name: sha256(sdist),
+                f"sdist-rebuilt/{rebuilt_wheel.name}": sha256(rebuilt_wheel),
+            },
+        }
+        print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/package_check.py
+++ b/scripts/package_check.py
@@ -224,7 +224,16 @@ def main() -> int:
         check_extra(
             wheel,
             "transformers",
-            ["transformers", "torch", "sentence-transformers"],
+            [
+                "transformers",
+                "torch",
+                "tokenizers",
+                "sentence-transformers",
+                "scikit-learn",
+                "numpy",
+                "einops",
+                "accelerate",
+            ],
             clean_room,
         )
         check_extra(wheel, "validation", ["jsonschema"], clean_room)


### PR DESCRIPTION
## Summary

- add `make package-check` as the canonical PyPI artifact gate
- validate wheel/sdist metadata, runtime files, isolated bare installs, sdist rebuilds, and optional extras
- emit interpreter and SHA-256 artifact identities for release evidence
- mark the oss-maintainer release profile ready and document pre/post-publish checks

Closes #279.

## Validation

- `make package-check`
- `make test` — 1893 passed, 1 skipped, 1 xfailed
- `uv run ruff check .`
- `uv run mypy src/esperanto`
- oss-maintainer profile validator (`release`: ready)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

