### PR TITLE
test(siliconflow): add real release coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,6 +162,7 @@ Each release-gated test class is `skipif`-gated on the env vars its provider nee
 | OpenRouter | `OPENROUTER_API_KEY` |
 | Perplexity | `PERPLEXITY_API_KEY` (note: tool-calling tests skip — Perplexity API doesn't support tools) |
 | MiniMax | `MINIMAX_API_KEY` |
+| SiliconFlow | `SILICONFLOW_API_KEY` |
 | DashScope (Qwen) | `DASHSCOPE_API_KEY` |
 | Jina | `JINA_API_KEY` |
 | Voyage | `VOYAGE_API_KEY` |

--- a/tests/integration/test_chat_completion_real.py
+++ b/tests/integration/test_chat_completion_real.py
@@ -752,6 +752,59 @@ class TestDashScopeChat:
 
 
 # =============================================================================
+# SiliconFlow Tests
+# =============================================================================
+
+
+@pytest.mark.release
+@pytest.mark.skipif(
+    not os.getenv("SILICONFLOW_API_KEY"),
+    reason="SILICONFLOW_API_KEY not configured",
+)
+class TestSiliconFlowChat:
+    """Real integration tests for SiliconFlow chat and model discovery."""
+
+    MODEL = "deepseek-ai/DeepSeek-V3.1-Terminus"
+
+    def test_sync_chat_complete(self):
+        model = AIFactory.create_language("siliconflow", self.MODEL)
+        response = model.chat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content
+
+    async def test_async_chat_complete(self):
+        model = AIFactory.create_language("siliconflow", self.MODEL)
+        response = await model.achat_complete(messages=MESSAGES)
+        assert isinstance(response, ChatCompletion)
+        assert response.choices[0].message.content
+
+    def test_sync_streaming(self):
+        model = AIFactory.create_language("siliconflow", self.MODEL)
+        response = model.chat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert total_content
+
+    async def test_async_streaming(self):
+        model = AIFactory.create_language("siliconflow", self.MODEL)
+        response = await model.achat_complete(messages=MESSAGES, stream=True)
+        total_content = ""
+        async for chunk in response:
+            assert isinstance(chunk, ChatCompletionChunk)
+            if chunk.choices[0].delta.content:
+                total_content += chunk.choices[0].delta.content
+        assert total_content
+
+    def test_model_discovery(self):
+        models = AIFactory.get_provider_models("siliconflow")
+        assert models
+        assert any(model.id == self.MODEL for model in models)
+
+
+# =============================================================================
 # MiniMax Tests
 # =============================================================================
 


### PR DESCRIPTION
## Summary

- add credential-gated real tests for SiliconFlow sync/async chat
- cover sync/async streaming and live model discovery
- document `SILICONFLOW_API_KEY` in the release credential reference

## Validation

- `env -u SILICONFLOW_API_KEY uv run pytest -m release tests/integration/test_chat_completion_real.py -k SiliconFlow -q --no-cov` — 5 skipped cleanly, no API calls
- `uv run ruff check tests/integration/test_chat_completion_real.py`
- `git diff --check`

Live execution remains a maintainer-authorized Bucket C release check because it uses paid credentials.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

