### PR TITLE
fix: redact provider credentials from repr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `anthropic` provider at MiniMax's Anthropic-protocol API via `base_url`, with
   the regional (international / mainland China) URLs. (#278)
 
+### Fixed
+
+- **Provider credentials are redacted from object representations.** API keys
+  and configuration dictionaries no longer appear in dataclass `repr` output,
+  preventing failed requests and test tracebacks from leaking credentials.
+
 ## [2.26.0] - 2026-07-29
 
 ### Added

--- a/src/esperanto/providers/embedding/base.py
+++ b/src/esperanto/providers/embedding/base.py
@@ -23,12 +23,12 @@ class EmbeddingModel(HttpConnectionMixin, ABC):
     # breaks otherwise-correct user code (ARCHITECTURE.md "Hot-Swap-First Defaults").
     MAX_BATCH_SIZE: ClassVar[int] = 0
 
-    api_key: Optional[str] = None
+    api_key: Optional[str] = field(default=None, repr=False)
     base_url: Optional[str] = None
     model_name: Optional[str] = None
     organization: Optional[str] = None
-    config: Optional[Dict[str, Any]] = None
-    _config: Dict[str, Any] = field(default_factory=dict)
+    config: Optional[Dict[str, Any]] = field(default=None, repr=False)
+    _config: Dict[str, Any] = field(default_factory=dict, repr=False)
 
     def __post_init__(self):
         """Initialize configuration after dataclass initialization."""

--- a/src/esperanto/providers/embedding/openrouter.py
+++ b/src/esperanto/providers/embedding/openrouter.py
@@ -1,7 +1,7 @@
 """OpenRouter embedding model implementation."""
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import ClassVar, Dict, List, Optional
 
 from esperanto.common_types import Model
@@ -16,7 +16,7 @@ class OpenRouterEmbeddingModel(OpenAIEmbeddingModel):
     MAX_BATCH_SIZE: ClassVar[int] = 96
 
     base_url: Optional[str] = None
-    api_key: Optional[str] = None
+    api_key: Optional[str] = field(default=None, repr=False)
 
     def __post_init__(self):
         """Initialize OpenRouter-specific configuration."""

--- a/src/esperanto/providers/llm/base.py
+++ b/src/esperanto/providers/llm/base.py
@@ -13,7 +13,7 @@ from esperanto.utils.connect import HttpConnectionMixin
 class LanguageModel(HttpConnectionMixin, ABC):
     """Base class for all language models."""
 
-    api_key: Optional[str] = None
+    api_key: Optional[str] = field(default=None, repr=False)
     base_url: Optional[str] = None
     model_name: Optional[str] = None
     max_tokens: int = 850
@@ -22,12 +22,12 @@ class LanguageModel(HttpConnectionMixin, ABC):
     top_p: float = 0.9
     structured: Optional[Dict[str, Any]] = None
     organization: Optional[str] = None
-    config: Optional[Dict[str, Any]] = None
+    config: Optional[Dict[str, Any]] = field(default=None, repr=False)
     # Tool-related fields
     tools: Optional[List[Tool]] = None
     tool_choice: Optional[Union[str, Dict[str, Any]]] = None
     parallel_tool_calls: Optional[bool] = None
-    _config: Dict[str, Any] = field(default_factory=dict)
+    _config: Dict[str, Any] = field(default_factory=dict, repr=False)
 
     @property
     def models(self) -> List[Model]:

--- a/src/esperanto/providers/llm/openai_compatible.py
+++ b/src/esperanto/providers/llm/openai_compatible.py
@@ -1,6 +1,6 @@
 """OpenAI-compatible language model implementation."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -39,7 +39,7 @@ class OpenAICompatibleLanguageModel(ProfileAwareMixin, OpenAILanguageModel):
     """OpenAI-compatible language model implementation for custom endpoints."""
 
     base_url: Optional[str] = None
-    api_key: Optional[str] = None
+    api_key: Optional[str] = field(default=None, repr=False)
 
     def __post_init__(self):
         """Initialize OpenAI-compatible configuration."""

--- a/src/esperanto/providers/llm/openrouter.py
+++ b/src/esperanto/providers/llm/openrouter.py
@@ -1,7 +1,7 @@
 """OpenRouter language model implementation."""
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -39,7 +39,7 @@ class OpenRouterLanguageModel(OpenAILanguageModel):
     """OpenRouter language model implementation using OpenAI-compatible API."""
 
     base_url: Optional[str] = None  # Changed type hint
-    api_key: Optional[str] = None  # Changed type hint
+    api_key: Optional[str] = field(default=None, repr=False)
 
     def __post_init__(self):
         # Extract api_key and base_url from config dict first (before parent sets OpenAI defaults)

--- a/src/esperanto/providers/llm/perplexity.py
+++ b/src/esperanto/providers/llm/perplexity.py
@@ -48,7 +48,7 @@ class PerplexityLanguageModel(LanguageModel):
     """Perplexity AI language model implementation using httpx."""
 
     base_url: Optional[str] = None
-    api_key: Optional[str] = None
+    api_key: Optional[str] = field(default=None, repr=False)
     search_domain_filter: Optional[List[str]] = field(default=None)
     return_images: Optional[bool] = field(default=None)
     return_related_questions: Optional[bool] = field(default=None)

--- a/src/esperanto/providers/reranker/base.py
+++ b/src/esperanto/providers/reranker/base.py
@@ -14,11 +14,11 @@ from esperanto.utils.connect import HttpConnectionMixin
 class RerankerModel(HttpConnectionMixin, ABC):
     """Base class for all reranker providers."""
 
-    api_key: Optional[str] = None
+    api_key: Optional[str] = field(default=None, repr=False)
     base_url: Optional[str] = None
     model_name: Optional[str] = None
-    config: Optional[Dict[str, Any]] = None
-    _config: Dict[str, Any] = field(default_factory=dict)
+    config: Optional[Dict[str, Any]] = field(default=None, repr=False)
+    _config: Dict[str, Any] = field(default_factory=dict, repr=False)
 
     def __post_init__(self):
         """Initialize configuration after dataclass initialization."""

--- a/src/esperanto/providers/stt/base.py
+++ b/src/esperanto/providers/stt/base.py
@@ -147,9 +147,9 @@ class SpeechToTextModel(HttpConnectionMixin, ABC):
     """
 
     model_name: Optional[str] = None
-    api_key: Optional[str] = None
+    api_key: Optional[str] = field(default=None, repr=False)
     base_url: Optional[str] = None
-    config: Optional[Dict[str, Any]] = None
+    config: Optional[Dict[str, Any]] = field(default=None, repr=False)
     timeout: Optional[float] = None
     _config: Dict[str, Any] = field(init=False, repr=False)
 

--- a/src/esperanto/providers/tts/base.py
+++ b/src/esperanto/providers/tts/base.py
@@ -24,9 +24,9 @@ class TextToSpeechModel(HttpConnectionMixin, ABC):
     """
 
     model_name: Optional[str] = None
-    api_key: Optional[str] = None
+    api_key: Optional[str] = field(default=None, repr=False)
     base_url: Optional[str] = None
-    config: Optional[Dict[str, Any]] = None
+    config: Optional[Dict[str, Any]] = field(default=None, repr=False)
     timeout: Optional[float] = None
     _config: Dict[str, Any] = field(init=False, repr=False)
 

--- a/tests/providers/test_secret_redaction.py
+++ b/tests/providers/test_secret_redaction.py
@@ -1,0 +1,66 @@
+"""Regression tests for keeping credentials out of provider representations."""
+
+from dataclasses import fields
+
+import pytest
+
+from esperanto.providers.embedding.base import EmbeddingModel
+from esperanto.providers.embedding.openrouter import OpenRouterEmbeddingModel
+from esperanto.providers.llm.base import LanguageModel
+from esperanto.providers.llm.openai import OpenAILanguageModel
+from esperanto.providers.llm.openai_compatible import OpenAICompatibleLanguageModel
+from esperanto.providers.llm.openrouter import OpenRouterLanguageModel
+from esperanto.providers.llm.perplexity import PerplexityLanguageModel
+from esperanto.providers.reranker.base import RerankerModel
+from esperanto.providers.stt.base import SpeechToTextModel
+from esperanto.providers.tts.base import TextToSpeechModel
+
+
+@pytest.mark.parametrize(
+    "model_class",
+    [
+        LanguageModel,
+        EmbeddingModel,
+        RerankerModel,
+        SpeechToTextModel,
+        TextToSpeechModel,
+        OpenAICompatibleLanguageModel,
+        OpenRouterLanguageModel,
+        PerplexityLanguageModel,
+        OpenRouterEmbeddingModel,
+    ],
+)
+def test_api_keys_are_excluded_from_dataclass_repr(model_class):
+    api_key_field = next(field for field in fields(model_class) if field.name == "api_key")
+
+    assert api_key_field.repr is False
+
+
+@pytest.mark.parametrize(
+    "model_class",
+    [LanguageModel, EmbeddingModel, RerankerModel, SpeechToTextModel, TextToSpeechModel],
+)
+def test_config_is_excluded_from_dataclass_repr(model_class):
+    config_field = next(field for field in fields(model_class) if field.name == "config")
+
+    assert config_field.repr is False
+
+
+def test_provider_repr_does_not_contain_direct_or_configured_secrets():
+    direct_secret = "direct-secret-value"
+    configured_secret = "configured-secret-value"
+    model = OpenAILanguageModel(
+        api_key=direct_secret,
+        config={"api_key": configured_secret, "custom_header": configured_secret},
+    )
+
+    try:
+        representation = repr(model)
+    finally:
+        model.close()
+
+    assert direct_secret not in representation
+    assert configured_secret not in representation
+    assert "api_key=" not in representation
+    assert "config=" not in representation
+


### PR DESCRIPTION
## Summary

- exclude provider API keys from dataclass representations across every modality
- exclude config dictionaries and internal config state that may contain credentials
- cover base classes and provider subclasses that redeclare `api_key`
- add regression coverage and a changelog entry

## Why

A failed real-provider release test included the model dataclass representation in its traceback, exposing the configured API key.

## Validation

- `make test` — 1908 passed, 1 skipped, 192 deselected, 1 xfailed
- `uv run ruff check src/esperanto/providers tests/providers/test_secret_redaction.py`
- `uv run mypy src/esperanto`
- focused regression tests — 15 passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/esperanto/pull/285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

